### PR TITLE
[WIP] feat: native token wrapping/unwrapping with message handler

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -820,3 +820,8 @@ export const vercelApiBaseUrl =
   process.env.REACT_APP_VERCEL_API_BASE_URL_OVERRIDE || "";
 
 export const bnUint32Max = utils.bnUint32Max;
+
+export const WETH_ABI = [
+  "function deposit()",
+  "function withdraw(uint256 wad)",
+];


### PR DESCRIPTION
In order to facilitate the various input/output combinations of wrapped and unwrapped native tokens, the message handler contract [here](https://github.com/across-protocol/contracts-v3/pull/489) will be used. Its design is still up in the air and will need to pass audit, so this logic will also not be finalized until then.