### PR TITLE
feat: decrease /limits cache time

### DIFF
--- a/api/limits.ts
+++ b/api/limits.ts
@@ -267,7 +267,7 @@ const handler = async (
       message: "Response data",
       responseJson,
     });
-    // Respond with a 200 status code and 15 seconds of cache cache with
+    // Respond with a 200 status code and 15 seconds of cache with
     // 45 seconds of stale-while-revalidate.
     sendResponse(response, responseJson, 200, 15, 45);
   } catch (error: unknown) {

--- a/api/limits.ts
+++ b/api/limits.ts
@@ -267,9 +267,9 @@ const handler = async (
       message: "Response data",
       responseJson,
     });
-    // Respond with a 200 status code and 4 minutes of cache cache with
-    // a minute of stale-while-revalidate.
-    sendResponse(response, responseJson, 200, 240, 60);
+    // Respond with a 200 status code and 15 seconds of cache cache with
+    // 45 seconds of stale-while-revalidate.
+    sendResponse(response, responseJson, 200, 15, 45);
   } catch (error: unknown) {
     return handleErrorCondition("limits", response, logger, error);
   }


### PR DESCRIPTION
Closes ACX-2294

The env vars for the limits multipliers are also adjusted. We still need to set up some schedulers to keep the cache fresh for major routes so that performance is not impacted too much as suggested by @mrice32 