### PR TITLE
feat: bump packages + testnet fixes

### DIFF
--- a/api/_constants.ts
+++ b/api/_constants.ts
@@ -112,6 +112,9 @@ export const defaultRelayerAddressOverridePerToken: Record<
   },
 };
 
+export const defaultRelayerAddressOverridePerChain: Record<number, string> =
+  JSON.parse(process.env.RELAYER_ADDRESS_OVERRIDE_PER_CHAIN || "{}");
+
 export const defaultRelayerAddressOverride =
   process.env.RELAYER_ADDRESS_OVERRIDE;
 

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -695,10 +695,6 @@ export const getSpokePool = (_chainId: number): SpokePool => {
 
 export const getSpokePoolAddress = (chainId: number): string => {
   switch (chainId) {
-    case CHAIN_IDs.MODE_SEPOLIA:
-      return "0xbd886FC0725Cc459b55BbFEb3E4278610331f83b";
-    case CHAIN_IDs.MODE:
-      return "0x3baD7AD0728f9917d1Bf08af5782dCbD516cDd96s";
     default:
       return sdk.utils.getDeployedAddress("SpokePool", chainId);
   }

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -40,6 +40,7 @@ import {
   TOKEN_SYMBOLS_MAP,
   defaultRelayerAddressOverride,
   defaultRelayerAddressOverridePerToken,
+  defaultRelayerAddressOverridePerChain,
   disabledL1Tokens,
   graphAPIKey,
   maxRelayFeePct,
@@ -516,7 +517,7 @@ export const getRelayerFeeCalculator = (
     destinationChainId,
     getProvider(destinationChainId),
     undefined,
-    overrides.spokePoolAddress,
+    overrides.spokePoolAddress || getSpokePoolAddress(destinationChainId),
     overrides.relayerAddress,
     REACT_APP_COINGECKO_PRO_API_KEY,
     getLogger(),
@@ -1443,6 +1444,7 @@ export function getDefaultRelayerAddress(
     return overrideForToken.relayer;
   } else {
     return (
+      defaultRelayerAddressOverridePerChain[destinationChainId] ||
       defaultRelayerAddressOverride ||
       sdk.constants.DEFAULT_SIMULATED_RELAYER_ADDRESS
     );

--- a/api/limits.ts
+++ b/api/limits.ts
@@ -163,9 +163,9 @@ const handler = async (
       ),
       Promise.all(
         fullRelayers.map((relayer) =>
-          destinationChainId === 1
+          destinationChainId === HUB_POOL_CHAIN_ID
             ? ethers.BigNumber.from("0")
-            : getCachedTokenBalance("1", relayer, l1Token.address)
+            : getCachedTokenBalance(HUB_POOL_CHAIN_ID, relayer, l1Token.address)
         )
       ),
     ]);

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "license": "AGPL-3.0-only",
   "dependencies": {
-    "@across-protocol/constants": "^3.1.3",
-    "@across-protocol/contracts": "^3.0.1",
-    "@across-protocol/sdk": "^3.1.6",
+    "@across-protocol/constants": "^3.1.5",
+    "@across-protocol/contracts": "^3.0.4",
+    "@across-protocol/sdk": "^3.1.10",
     "@amplitude/analytics-browser": "^2.3.5",
     "@balancer-labs/sdk": "1.1.6-beta.16",
     "@emotion/react": "^11.4.1",

--- a/src/utils/typechain.ts
+++ b/src/utils/typechain.ts
@@ -5,7 +5,7 @@
  */
 export { AcrossMerkleDistributor__factory } from "@across-protocol/contracts/dist/typechain/factories/contracts/merkle-distributor/AcrossMerkleDistributor__factory";
 export { HubPool__factory } from "@across-protocol/contracts/dist/typechain/factories/contracts/HubPool__factory";
-export { SpokePool__factory } from "@across-protocol/contracts/dist/typechain/factories/contracts/SpokePool.sol/SpokePool__factory";
+export { SpokePool__factory } from "@across-protocol/contracts/dist/typechain/factories/contracts/SpokePool__factory";
 export { SpokePoolVerifier__factory } from "@across-protocol/contracts/dist/typechain/factories/contracts/SpokePoolVerifier__factory";
 export { ERC20__factory } from "@across-protocol/contracts/dist/typechain/factories/@openzeppelin/contracts/token/ERC20/ERC20__factory";
 export { AcceleratingDistributor__factory } from "@across-protocol/across-token/dist/typechain/factories/AcceleratingDistributor__factory";
@@ -18,7 +18,7 @@ export type { HubPool } from "@across-protocol/contracts/dist/typechain/contract
 export type {
   SpokePool,
   FilledV3RelayEvent,
-} from "@across-protocol/contracts/dist/typechain/contracts/SpokePool.sol/SpokePool";
+} from "@across-protocol/contracts/dist/typechain/contracts/SpokePool";
 export type { SpokePoolVerifier } from "@across-protocol/contracts/dist/typechain/contracts/SpokePoolVerifier";
 export type {
   UniversalSwapAndBridge,

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,15 +16,15 @@
     "@uma/common" "^2.17.0"
     hardhat "^2.9.3"
 
-"@across-protocol/constants@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@across-protocol/constants/-/constants-3.0.1.tgz#8fb2760a3c64801c9324bcbf76084fae9dfabb52"
-  integrity sha512-cCrhLEpYfiFeDrXscUgdRTnOW5Sn2W9mmdrxxl1dXLC+tYMb1c2rgQVBQNxrdW7LGiDqCR4a5m5jYgWPXonzQg==
-
 "@across-protocol/constants@^3.1.3":
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/@across-protocol/constants/-/constants-3.1.3.tgz#534764a4137bd5181ab4214543d0cbbf44a90c63"
   integrity sha512-4pUjJrRor9gFPAsskbva6bDK780tzXYMWtqCtBa1jOUc+X3PxC6U6lF7ZoyX+lqU/KcfAWDLg8YEsz+KLm3NrQ==
+
+"@across-protocol/constants@^3.1.5":
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/@across-protocol/constants/-/constants-3.1.5.tgz#58cdd06816518b5cf1d92d94a4bc175ab0bc9d0c"
+  integrity sha512-3bqBNdYhVnpNwd9zwxmDWewM0ixRxTiL0SCHmOWlmDEx9xqPFHx5t+GLJWOa18wIoPP5KWv/TyI+fdwi3Tg5Bw==
 
 "@across-protocol/contracts@^0.1.4":
   version "0.1.4"
@@ -35,12 +35,12 @@
     "@openzeppelin/contracts" "4.1.0"
     "@uma/core" "^2.18.0"
 
-"@across-protocol/contracts@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@across-protocol/contracts/-/contracts-3.0.1.tgz#05944932ee5f64895c940041c2770824964fb00f"
-  integrity sha512-8OGsYRRzewrsb3OKhM2KBQAILXpQ6OWNmiuKqnX9el7x2K+sLdWVjBklPybI8mgngbJ/vALstulkQtQXOqkZ1Q==
+"@across-protocol/contracts@^3.0.4":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@across-protocol/contracts/-/contracts-3.0.4.tgz#249e5294ebbc3ee7076702eeaf01e054835e3624"
+  integrity sha512-NhpNE3iwMNNOeHCA2IVcXYZAdmRqI9OAWrRF/gwCJ0yzKL46fodKlZEVjBwGMbTWE4QLqiPTnI0cVwARoFdybg==
   dependencies:
-    "@across-protocol/constants" "^3.0.1"
+    "@across-protocol/constants" "^3.1.3"
     "@defi-wonderland/smock" "^2.3.4"
     "@eth-optimism/contracts" "^0.5.40"
     "@ethersproject/abstract-provider" "5.7.0"
@@ -55,14 +55,14 @@
     axios "^1.6.2"
     zksync-web3 "^0.14.3"
 
-"@across-protocol/sdk@^3.1.6":
-  version "3.1.6"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-3.1.6.tgz#b547ee35e6764e52997c9145ecb328afea7e043c"
-  integrity sha512-Pg/2foxB7ORFGfZJluVPOCoKXKOl4pPZhyT+MlSes13wp5Z1hKc+DVLfCRmUeEM4eP1RttQ9lZG8wDgdhIJxUQ==
+"@across-protocol/sdk@^3.1.10":
+  version "3.1.10"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-3.1.10.tgz#2fd129b00c2cac9ad2dfc8895abdc4be42c788d1"
+  integrity sha512-VtnnxlxnRO43+yt3r+aorCqZ8JScTMr/fD9MlHRMgnGCrpAjfTnAN4XrhFD8gM/vjzyQAY2LOj+6/AhXAI1Kyg==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
-    "@across-protocol/constants" "^3.1.3"
-    "@across-protocol/contracts" "^3.0.1"
+    "@across-protocol/constants" "^3.1.5"
+    "@across-protocol/contracts" "^3.0.4"
     "@eth-optimism/sdk" "^3.3.1"
     "@pinata/sdk" "^2.1.0"
     "@types/mocha" "^10.0.1"
@@ -24743,7 +24743,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -24777,6 +24777,15 @@ string-width@^3.0.0, string-width@^3.1.0:
     emoji-regex "^7.0.1"
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
+
+string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^5.0.0, string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -24879,7 +24888,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -24906,6 +24915,13 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.0.1"
@@ -27706,7 +27722,7 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -27736,6 +27752,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Bumps to latest @across-protocol deps and fixes some bugs discovered while adding support for Lisk and Blast.