### PR TITLE
improve(api): remove some unneeded scope

### DIFF
--- a/api/coingecko.ts
+++ b/api/coingecko.ts
@@ -11,8 +11,6 @@ import {
 } from "./_utils";
 import {
   SUPPORTED_CG_BASE_CURRENCIES,
-  CHAIN_IDs,
-  TOKEN_SYMBOLS_MAP,
   coinGeckoAssetPlatformLookup,
 } from "./_constants";
 
@@ -25,86 +23,6 @@ const {
   REDIRECTED_TOKEN_PRICE_LOOKUP_ADDRESSES,
   BALANCER_V2_TOKENS,
 } = process.env;
-
-// Helper function to fetch prices from coingecko. Can fetch either or both token and base currency.
-// Set hardcodedTokenPriceUsd to 0 to load the token price from coingecko, otherwise load only the base
-// currency.
-const getCoingeckoPrices = async (
-  coingeckoClient: coingecko.Coingecko,
-  tokenAddress: string,
-  baseCurrency: string,
-  hardcodedTokenPrices: {
-    [token: string]: number;
-  } = {},
-  balancerV2PoolTokens: string[] = []
-): Promise<number> => {
-  const baseCurrencyToken = Object.values(TOKEN_SYMBOLS_MAP).find(
-    ({ symbol }) => symbol === baseCurrency.toUpperCase()
-  );
-
-  if (!baseCurrencyToken) throw new InputError(`Base currency not supported`);
-
-  // Special case: token and base are the same. Coingecko class returns a single result in this case, so it must
-  // be handled separately.
-  const baseCurrentTokenAddress =
-    baseCurrencyToken.addresses[CHAIN_IDs.MAINNET];
-  if (tokenAddress.toLowerCase() === baseCurrentTokenAddress.toLowerCase())
-    return 1;
-
-  // If either token or base currency is in hardcoded list then use hardcoded USD price.
-  let basePriceUsdPromise: Promise<number> | number | undefined =
-    hardcodedTokenPrices[baseCurrentTokenAddress];
-  let tokenPriceUsdPromise: Promise<number> | number | undefined =
-    hardcodedTokenPrices[tokenAddress];
-
-  if (
-    basePriceUsdPromise === undefined &&
-    balancerV2PoolTokens.includes(
-      ethers.utils.getAddress(baseCurrentTokenAddress)
-    )
-  ) {
-    // Note this assumes mainnet token because all token addresses are assumed to be mainnet in this function.
-    basePriceUsdPromise = getBalancerV2TokenPrice(baseCurrentTokenAddress);
-  }
-
-  if (
-    tokenPriceUsdPromise === undefined &&
-    balancerV2PoolTokens.includes(ethers.utils.getAddress(tokenAddress))
-  ) {
-    // Note this assumes mainnet token because all token addresses are assumed to be mainnet in this function.
-    basePriceUsdPromise = getBalancerV2TokenPrice(tokenAddress);
-  }
-
-  // Fetch undefined base and token USD prices from coingecko client.
-  // Always use usd as the base currency for the purpose of conversion.
-  if (basePriceUsdPromise === undefined && tokenPriceUsdPromise === undefined) {
-    const groupedPromise = coingeckoClient.getContractPrices(
-      [baseCurrentTokenAddress, tokenAddress],
-      "usd"
-    );
-    basePriceUsdPromise = groupedPromise.then((prices) => prices[0].price);
-    tokenPriceUsdPromise = groupedPromise.then((prices) => prices[1].price);
-  } else if (basePriceUsdPromise === undefined) {
-    basePriceUsdPromise = coingeckoClient
-      .getContractPrices([baseCurrentTokenAddress, tokenAddress], "usd")
-      .then((prices) => prices[0].price);
-  } else if (tokenPriceUsdPromise === undefined) {
-    basePriceUsdPromise = coingeckoClient
-      .getContractPrices([baseCurrentTokenAddress, tokenAddress], "usd")
-      .then((prices) => prices[0].price);
-  }
-
-  // Extract from a promise.all.
-  const [basePriceUsd, tokenPriceUsd] = await Promise.all([
-    basePriceUsdPromise,
-    tokenPriceUsdPromise,
-  ]);
-
-  // Drop any decimals beyond the number of decimals for this token.
-  return Number(
-    (tokenPriceUsd / basePriceUsd).toFixed(baseCurrencyToken.decimals)
-  );
-};
 
 const CoingeckoQueryParamsSchema = object({
   l1Token: validAddress(),
@@ -128,13 +46,16 @@ const handler = async (
 
     let { l1Token, baseCurrency } = query;
 
-    // Start the symbol as lower case for CG.
-    // This isn't explicitly required, but there's nothing in their docs that guarantee that upper-case symbols will
-    // work.
-    if (!baseCurrency) baseCurrency = "eth";
-    else baseCurrency = baseCurrency.toLowerCase();
-
+    // Format the params for consistency
+    baseCurrency = (baseCurrency ?? "eth").toLowerCase();
     l1Token = ethers.utils.getAddress(l1Token);
+
+    // Confirm that the base Currency is supported by Coingecko
+    if (!SUPPORTED_CG_BASE_CURRENCIES.has(baseCurrency)) {
+      throw new InputError(
+        "Base currency supplied is not supported by this endpoint. See documentation."
+      );
+    }
 
     // Resolve the optional address lookup that maps one token's
     // contract address to another.
@@ -157,40 +78,28 @@ const handler = async (
     // We want to compute price and return to caller.
     let price: number;
 
-    const _fixedTokenPrices: {
-      [token: string]: number;
-    } = FIXED_TOKEN_PRICES !== undefined ? JSON.parse(FIXED_TOKEN_PRICES) : {};
-
     // Make sure all keys in `fixedTokenPrices` are in checksum format.
     const fixedTokenPrices = Object.fromEntries(
-      Object.entries(_fixedTokenPrices).map(([token, price]) => [
-        ethers.utils.getAddress(token),
-        price,
-      ])
+      Object.entries(JSON.parse(FIXED_TOKEN_PRICES ?? "{}")).map(
+        ([token, price]) => [ethers.utils.getAddress(token), Number(price)]
+      )
     );
 
-    const balancerV2PoolTokens =
-      BALANCER_V2_TOKENS !== undefined
-        ? JSON.parse(BALANCER_V2_TOKENS).map(ethers.utils.getAddress)
-        : [];
+    const balancerV2PoolTokens: string[] = JSON.parse(
+      BALANCER_V2_TOKENS ?? "[]"
+    ).map(ethers.utils.getAddress);
 
     const platformId = coinGeckoAssetPlatformLookup[l1Token] ?? "ethereum";
 
     // Caller wants to override price for token, possibly because the token is not supported yet on the Coingecko API,
     // so assume the caller set the USD price of the token. We now need to dynamically load the base currency.
-    if (
-      fixedTokenPrices[l1Token] !== undefined &&
-      !isNaN(fixedTokenPrices[l1Token])
-    ) {
+    if (!isNaN(fixedTokenPrices[l1Token])) {
       // If base is USD, return hardcoded token price in USD.
-      if (baseCurrency === "usd") price = fixedTokenPrices[l1Token];
-      else {
-        price = await getCoingeckoPrices(
-          coingeckoClient,
-          l1Token,
-          baseCurrency,
-          fixedTokenPrices,
-          balancerV2PoolTokens
+      if (baseCurrency === "usd") {
+        price = fixedTokenPrices[l1Token];
+      } else {
+        throw new InputError(
+          "This token has a fixed price in USD only. Switch to USD base currency."
         );
       }
     } else if (
@@ -198,35 +107,19 @@ const handler = async (
     ) {
       if (baseCurrency === "usd") {
         price = await getBalancerV2TokenPrice(l1Token);
-      } else if (SUPPORTED_CG_BASE_CURRENCIES.has(baseCurrency)) {
-        throw new Error(
-          "Only CG base currency allowed for BalancerV2 tokens is usd"
-        );
       } else {
-        price = await getCoingeckoPrices(
-          coingeckoClient,
-          l1Token,
-          baseCurrency,
-          fixedTokenPrices,
-          balancerV2PoolTokens
+        throw new InputError(
+          "Only CG base currency allowed for BalancerV2 tokens is usd"
         );
       }
     }
     // Fetch price dynamically from Coingecko API
-    else if (SUPPORTED_CG_BASE_CURRENCIES.has(baseCurrency)) {
+    else {
       // This base matches a supported base currency for CG.
       [, price] = await coingeckoClient.getCurrentPriceByContract(
         l1Token,
         baseCurrency,
         platformId
-      );
-    } else {
-      price = await getCoingeckoPrices(
-        coingeckoClient,
-        l1Token,
-        baseCurrency,
-        fixedTokenPrices,
-        balancerV2PoolTokens
       );
     }
 

--- a/api/coingecko.ts
+++ b/api/coingecko.ts
@@ -53,7 +53,9 @@ const handler = async (
     // Confirm that the base Currency is supported by Coingecko
     if (!SUPPORTED_CG_BASE_CURRENCIES.has(baseCurrency)) {
       throw new InputError(
-        "Base currency supplied is not supported by this endpoint. See documentation."
+        `Base currency supplied is not supported by this endpoint. Supported currencies: [${Array.from(
+          SUPPORTED_CG_BASE_CURRENCIES
+        ).join(", ")}].`
       );
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -24738,7 +24738,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -24772,15 +24772,6 @@ string-width@^3.0.0, string-width@^3.1.0:
     emoji-regex "^7.0.1"
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
-
-string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.0, string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -24883,7 +24874,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -24910,13 +24901,6 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.0.1"
@@ -27717,7 +27701,7 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -27747,15 +27731,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -24738,7 +24738,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -24772,6 +24772,15 @@ string-width@^3.0.0, string-width@^3.1.0:
     emoji-regex "^7.0.1"
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
+
+string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^5.0.0, string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -24874,7 +24883,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -24901,6 +24910,13 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.0.1"
@@ -27701,7 +27717,7 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -27731,6 +27747,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
We previously allowed a case where we could quote a price with a non-standard base currency. I.e. `acx/wbtc` was possible.

This is out of scope of existing work and no longer needed. Removing will improve readability, clean up legacy code, and make additional changes to this API endpoint more convenient.