### PR TITLE
hotfix(coingecko): account for derived currencies with strict scope

### DIFF
--- a/api/_constants.ts
+++ b/api/_constants.ts
@@ -160,7 +160,7 @@ export const BLOCK_TAG_LAG = -1;
 // we've decided to keep this list small for now.
 export const SUPPORTED_CG_BASE_CURRENCIES = new Set(["eth", "usd"]);
 // Note: this is a small set of currencies that the API will derive from the base currencies by using USD as an intermediary.
-export const SUPPORTED_CG_DERRIVED_CURRENCIES = new Set(["matic"]);
+export const SUPPORTED_CG_DERIVED_CURRENCIES = new Set(["matic"]);
 
 // 1:1 because we don't need to handle underlying tokens on FE
 export const EXTERNAL_POOL_TOKEN_EXCHANGE_RATE = utils.fixedPointAdjustment;

--- a/api/_constants.ts
+++ b/api/_constants.ts
@@ -159,6 +159,8 @@ export const BLOCK_TAG_LAG = -1;
 // Note: this is a small subset of all the supported base currencies, but since we don't expect to use the others,
 // we've decided to keep this list small for now.
 export const SUPPORTED_CG_BASE_CURRENCIES = new Set(["eth", "usd"]);
+// Note: this is a small set of currencies that the API will derive from the base currencies by using USD as an intermediary.
+export const SUPPORTED_CG_DERRIVED_CURRENCIES = new Set(["matic"]);
 
 // 1:1 because we don't need to handle underlying tokens on FE
 export const EXTERNAL_POOL_TOKEN_EXCHANGE_RATE = utils.fixedPointAdjustment;

--- a/api/coingecko.ts
+++ b/api/coingecko.ts
@@ -135,6 +135,7 @@ const handler = async (
     // If the base currency is a derived currency, we just need to grab
     // the price of the quote currency in USD and perform the conversion.
     let quotePrice = 1.0;
+    let quotePrecision = 18;
     if (isDerivedCurrency) {
       const token =
         TOKEN_SYMBOLS_MAP[
@@ -144,8 +145,9 @@ const handler = async (
         token.addresses[CHAIN_IDs.MAINNET],
         "usd"
       );
+      quotePrecision = token.decimals;
     }
-    price = price / quotePrice;
+    price = Number((price / quotePrice).toFixed(quotePrecision));
 
     // Two different explanations for how `stale-while-revalidate` works:
 

--- a/api/coingecko.ts
+++ b/api/coingecko.ts
@@ -13,7 +13,7 @@ import {
 import {
   CHAIN_IDs,
   SUPPORTED_CG_BASE_CURRENCIES,
-  SUPPORTED_CG_DERRIVED_CURRENCIES,
+  SUPPORTED_CG_DERIVED_CURRENCIES,
   TOKEN_SYMBOLS_MAP,
   coinGeckoAssetPlatformLookup,
 } from "./_constants";
@@ -55,18 +55,14 @@ const handler = async (
     l1Token = ethers.utils.getAddress(l1Token);
 
     // Confirm that the base Currency is supported by Coingecko
-    if (
-      !SUPPORTED_CG_BASE_CURRENCIES.has(baseCurrency) &&
-      !SUPPORTED_CG_DERRIVED_CURRENCIES.has(baseCurrency)
-    ) {
+    const isDerivedCurrency = SUPPORTED_CG_DERIVED_CURRENCIES.has(baseCurrency);
+    if (!SUPPORTED_CG_BASE_CURRENCIES.has(baseCurrency) && !isDerivedCurrency) {
       throw new InputError(
         `Base currency supplied is not supported by this endpoint. Supported currencies: [${Array.from(
           SUPPORTED_CG_BASE_CURRENCIES
         ).join(", ")}].`
       );
     }
-    const isDerivedCurrency =
-      SUPPORTED_CG_DERRIVED_CURRENCIES.has(baseCurrency);
 
     // Resolve the optional address lookup that maps one token's
     // contract address to another.


### PR DESCRIPTION
Missed reference to matic in suggested-fees. This enabled a _select_ number of derived tokens.