### PR TITLE
fix: lisk endpoint

### DIFF
--- a/src/constants/chains/index.ts
+++ b/src/constants/chains/index.ts
@@ -19,6 +19,7 @@ const orderedEnabledChainIds = [
   CHAIN_IDs.LINEA,
   CHAIN_IDs.MODE,
   CHAIN_IDs.BLAST,
+  CHAIN_IDs.LISK,
   // testnet
   CHAIN_IDs.SEPOLIA,
   CHAIN_IDs.BASE_SEPOLIA,
@@ -27,6 +28,7 @@ const orderedEnabledChainIds = [
   CHAIN_IDs.MODE_SEPOLIA,
   CHAIN_IDs.POLYGON_AMOY,
   CHAIN_IDs.BLAST_SEPOLIA,
+  CHAIN_IDs.LISK_SEPOLIA,
 ];
 
 export const chainInfoList: ChainInfoList = orderedEnabledChainIds.map(


### PR DESCRIPTION
Lisk routes are reading as unknown because `LISK` isn't in the `getChainInfo` lookup