### PR TITLE
improve(rewards): cap estimation at 25bips of input

### DIFF
--- a/src/components/DepositsTable/DepositsTable.tsx
+++ b/src/components/DepositsTable/DepositsTable.tsx
@@ -1,6 +1,11 @@
 import styled from "@emotion/styled";
 
-import { HeadRow, headerCells, ColumnKey } from "./HeadRow";
+import {
+  HeadRow,
+  headerCells,
+  ColumnKey,
+  ColumnTooltipRecord,
+} from "./HeadRow";
 import { DataRow } from "./DataRow";
 import { Deposit } from "hooks/useDeposits";
 
@@ -9,6 +14,7 @@ export type DepositsTableProps = {
   onClickSpeedUp?: (deposit: Deposit) => void;
   deposits: Deposit[];
   filterKey?: string;
+  tooltips?: ColumnTooltipRecord;
 };
 
 export function DepositsTable({
@@ -16,11 +22,12 @@ export function DepositsTable({
   deposits,
   onClickSpeedUp,
   filterKey = "",
+  tooltips,
 }: DepositsTableProps) {
   return (
     <Wrapper>
       <StyledTable>
-        <HeadRow disabledColumns={disabledColumns} />
+        <HeadRow disabledColumns={disabledColumns} columnTooltips={tooltips} />
         <tbody>
           {deposits.map((deposit) => (
             <DataRow

--- a/src/components/DepositsTable/HeadRow.tsx
+++ b/src/components/DepositsTable/HeadRow.tsx
@@ -1,9 +1,14 @@
 import styled from "@emotion/styled";
+import { ReactComponent as II } from "assets/icons/info.svg";
 import { Text } from "components/Text";
+import { Tooltip } from "components/Tooltip";
 import { COLORS } from "utils";
 
 export type HeaderCells = typeof headerCells;
 export type ColumnKey = keyof HeaderCells;
+export type ColumnTooltipRecord = Partial<
+  Record<ColumnKey, { title: string; content: string }>
+>;
 
 export const headerCells = {
   asset: {
@@ -58,8 +63,10 @@ export const headerCells = {
 
 export function HeadRow({
   disabledColumns = [],
+  columnTooltips,
 }: {
   disabledColumns?: ColumnKey[];
+  columnTooltips?: ColumnTooltipRecord;
 }) {
   return (
     <StyledHead>
@@ -68,6 +75,20 @@ export function HeadRow({
           disabledColumns.includes(key as ColumnKey) ? null : (
             <StyledCell key={key} width={value.width}>
               <Text color="grey-400">{value.label}</Text>
+              {columnTooltips?.[key as ColumnKey] && (
+                <StylizedTooltip
+                  tooltipId={key}
+                  title={columnTooltips[key as ColumnKey]?.title}
+                  body={
+                    <BodyText size="md">
+                      {columnTooltips[key as ColumnKey]?.content ?? ""}
+                    </BodyText>
+                  }
+                  placement="bottom-start"
+                >
+                  <InfoIcon />
+                </StylizedTooltip>
+              )}
             </StyledCell>
           )
         )}
@@ -93,4 +114,24 @@ const StyledRow = styled.tr`
 const StyledCell = styled.th<{ width: number }>`
   display: flex;
   width: ${({ width }) => width}px;
+  gap: 4px;
+  flex-direction: row;
+  align-items: center;
+  padding-right: 4px;
+`;
+
+const InfoIcon = styled(II)`
+  height: 14px;
+  width: 14px;
+  margin-bottom: -3px;
+`;
+
+const StylizedTooltip = styled(Tooltip)`
+  width: fit-content;
+  height: fit-content;
+  text-align: left;
+`;
+
+const BodyText = styled(Text)`
+  text-align: left;
 `;

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -8,6 +8,11 @@ export function max(a: BigNumberish, b: BigNumberish) {
   return BigNumber.from(b);
 }
 
+export function min(a: BigNumberish, b: BigNumberish) {
+  if (BigNumber.from(a).lte(b)) return BigNumber.from(a);
+  return BigNumber.from(b);
+}
+
 /**
  * Finds the amount of tokens that will be received after fees are deducted
  * @param amount Amount of tokens to be received (gross amount before fees)

--- a/src/views/Bridge/components/EstimatedTable.tsx
+++ b/src/views/Bridge/components/EstimatedTable.tsx
@@ -36,7 +36,6 @@ const PriceFee = ({
   baseCurrencyFee,
   token,
   highlightTokenFee = false,
-  rewardPercentageOfFees,
   hideSymbolOnEmpty = true,
   tokenIconFirstOnMobile = false,
   hideTokenIcon,
@@ -46,7 +45,6 @@ const PriceFee = ({
   baseCurrencyFee?: BigNumber;
   token: TokenInfo;
   highlightTokenFee?: boolean;
-  rewardPercentageOfFees?: BigNumber;
   hideSymbolOnEmpty?: boolean;
   tokenIconFirstOnMobile?: boolean;
   hideTokenIcon?: boolean;
@@ -62,16 +60,9 @@ const PriceFee = ({
       ) : (
         <>
           {baseCurrencyFee && tokenFee && (
-            <>
-              {rewardPercentageOfFees && (
-                <PercentageText size="md" color="grey-400">
-                  ({formatWeiPct(rewardPercentageOfFees)}% of fees)
-                </PercentageText>
-              )}
-              <Text size="md" color="grey-400">
-                {`$${formatUSD(baseCurrencyFee)}`}
-              </Text>
-            </>
+            <Text size="md" color="grey-400">
+              {`$${formatUSD(baseCurrencyFee)}`}
+            </Text>
           )}
           {tokenFee ? (
             <Text size="md" color={highlightTokenFee ? "primary" : "light-200"}>
@@ -345,7 +336,7 @@ const EstimatedTable = ({
           showLoadingSkeleton={showLoadingSkeleton}
         />
       </Row>
-      {rewardDisplaySymbol && rewardToken && (
+      {rewardDisplaySymbol && rewardToken && rewardPercentage && (
         <Row>
           <ToolTipWrapper>
             <Text size="md" color="grey-400">
@@ -353,7 +344,14 @@ const EstimatedTable = ({
             </Text>
             <Tooltip
               title={`${rewardDisplaySymbol} Rebate Reward`}
-              body={`Estimate of ${rewardDisplaySymbol} earned from this transfer. Final reward is calculated based on prior day ${rewardDisplaySymbol} price.`}
+              body={
+                <>
+                  Up to {formatWeiPct(rewardPercentage)}% of bridge fee earned
+                  in {rewardDisplaySymbol}. Rebate is capped to a bridge fee of
+                  25 bps (0.25%). Final reward is calculated based on prior day{" "}
+                  {rewardDisplaySymbol} price.
+                </>
+              }
               placement="bottom-start"
             >
               <InfoIconWrapper>
@@ -366,7 +364,6 @@ const EstimatedTable = ({
               token={rewardToken}
               tokenFee={reward}
               baseCurrencyFee={referralRewardAsBaseCurrency}
-              rewardPercentageOfFees={rewardPercentage}
               hideSymbolOnEmpty={!isDefined(netFeeAsBaseCurrency)}
               showLoadingSkeleton={isQuoteLoading}
             />
@@ -602,12 +599,6 @@ const TransparentWrapper = styled.div<{ isTransparent: boolean }>`
   margin: 0;
 
   opacity: ${({ isTransparent }) => (isTransparent ? 0.5 : 1)};
-`;
-
-const PercentageText = styled(Text)`
-  @media ${QUERIESV2.xs.andDown} {
-    display: none;
-  }
 `;
 
 const SwapSlippageSettings = styled.div`

--- a/src/views/Bridge/components/FeesCollapsible.tsx
+++ b/src/views/Bridge/components/FeesCollapsible.tsx
@@ -46,6 +46,7 @@ export function FeesCollapsible(props: Props) {
     baseToken,
     props.toChainId,
     props.isSwap,
+    props.parsedAmount,
     props.gasFee,
     bridgeFee,
     swapFee

--- a/src/views/Bridge/hooks/useEstimatedRewards.ts
+++ b/src/views/Bridge/hooks/useEstimatedRewards.ts
@@ -3,15 +3,16 @@ import { useTokenConversion } from "hooks/useTokenConversion";
 import { useMemo } from "react";
 import {
   TokenInfo,
+  chainIdToRewardsProgramName,
   fixedPointAdjustment,
   formatUnitsWithMaxFractions,
   getToken,
   isDefined,
+  min,
   parseUnits,
   parseUnitsWithExtendedDecimals,
-  rewardPrograms,
-  chainIdToRewardsProgramName,
   rewardProgramTypes,
+  rewardPrograms,
 } from "utils";
 
 export type EstimatedRewards = ReturnType<typeof useEstimatedRewards>;
@@ -20,6 +21,7 @@ export function useEstimatedRewards(
   token: TokenInfo,
   destinationChainId: number,
   isSwap: boolean,
+  inputAmount?: BigNumber,
   gasFee?: BigNumber,
   bridgeFee?: BigNumber,
   swapFee?: BigNumber
@@ -47,12 +49,16 @@ export function useEstimatedRewards(
       availableRewardPercentage === undefined ||
       rewardToken === undefined ||
       bridgeFee === undefined ||
-      gasFee === undefined
+      gasFee === undefined ||
+      inputAmount === undefined
     ) {
       return undefined;
     }
     const totalFeeInL1 = bridgeFee.add(gasFee);
-    const totalRewardInL1 = totalFeeInL1
+    const maximalFee = parseUnits("0.0025", token.decimals); // 25 bips parsed to the input amount decimals
+    const cappedFee = min(totalFeeInL1, maximalFee);
+
+    const totalRewardInL1 = cappedFee
       .mul(availableRewardPercentage)
       .div(fixedPointAdjustment);
 
@@ -78,6 +84,8 @@ export function useEstimatedRewards(
     convertRewardToBaseCurrency,
     gasFee,
     rewardToken,
+    inputAmount,
+    token.decimals,
   ]);
 
   const hasDepositReward = depositReward?.rewardAsL1.gt(0) ?? false;
@@ -92,10 +100,12 @@ export function useEstimatedRewards(
     const gasFeeInUSD = convertL1ToBaseCurrency(gasFee);
     const bridgeFeeInUSD = convertL1ToBaseCurrency(bridgeFee);
     const swapFeeInUSD = convertL1ToBaseCurrency(swapFee);
+    const inputAmountInUSD = convertL1ToBaseCurrency(inputAmount);
 
     if (
       !isDefined(gasFeeInUSD) ||
       !isDefined(bridgeFeeInUSD) ||
+      !isDefined(inputAmountInUSD) ||
       (isSwap && !isDefined(swapFeeInUSD))
     ) {
       return {
@@ -107,11 +117,14 @@ export function useEstimatedRewards(
       };
     }
 
+    const numericInputAmount = formatNumericUsd(inputAmountInUSD);
     const numericGasFee = formatNumericUsd(gasFeeInUSD);
     const numericBridgeFee = formatNumericUsd(bridgeFeeInUSD);
     const numericReward = availableRewardPercentage
-      ? (numericBridgeFee + numericGasFee) *
-        Number(formatUnitsWithMaxFractions(availableRewardPercentage, 18))
+      ? Math.min(
+          numericInputAmount * 0.0025, // Cap reward at 25 basis points
+          numericBridgeFee + numericGasFee
+        ) * Number(formatUnitsWithMaxFractions(availableRewardPercentage, 18))
       : undefined;
     const numericSwapFee = swapFeeInUSD ? formatNumericUsd(swapFeeInUSD) : 0;
 
@@ -132,6 +145,7 @@ export function useEstimatedRewards(
     gasFee,
     swapFee,
     isSwap,
+    inputAmount,
   ]);
 
   return {

--- a/src/views/DepositStatus/components/DepositStatusLowerCard.tsx
+++ b/src/views/DepositStatus/components/DepositStatusLowerCard.tsx
@@ -78,10 +78,12 @@ export function DepositStatusLowerCard({
           }
         : undefined,
     }) || {};
+
   const estimatedRewards = useEstimatedRewards(
     baseToken,
     toChainId,
     isSwap,
+    depositArgs?.initialAmount,
     gasFee,
     bridgeFee,
     swapFee


### PR DESCRIPTION
Rewards are now capped to `min(25bps, bridge_fee) * 95%`. UI has had updates to reference this information.