### PR TITLE
fix: display correct max deposit limits value

### DIFF
--- a/src/views/Bridge/hooks/useBridge.ts
+++ b/src/views/Bridge/hooks/useBridge.ts
@@ -125,7 +125,7 @@ export function useBridge() {
     selectedRoute,
     toAccount,
     walletAccount: account,
-    limits: quotedLimits || limitsQuery.limits,
+    limits: transferQuote ? quotedLimits : limitsQuery.limits,
     fees: quotedFees,
     swapQuote: quotedSwap,
     balance,


### PR DESCRIPTION
Fixes ACX-2425

We displayed the previously quoted max. deposit limits if a user swapped chains for example. This PR fixed that issue by only displaying the quoted limits if a transfer quote could be retrieved