### PR TITLE
chore: remove snx fill time override

### DIFF
--- a/api/_timings.ts
+++ b/api/_timings.ts
@@ -11,18 +11,7 @@ const fillTimeOverrides: {
       [symbol: string]: number;
     };
   };
-} = {
-  "1": {
-    "10": {
-      SNX: 9_000,
-    },
-  },
-  "10": {
-    "1": {
-      SNX: 9_000,
-    },
-  },
-};
+} = {};
 
 const timingsLookup = timings
   .map((timing) => ({


### PR DESCRIPTION
SNX relayer has been online again for a while. We can remove overrides