### PR TITLE
Fixing timing estimations for Lisk

### DIFF
--- a/api/_timings.ts
+++ b/api/_timings.ts
@@ -69,11 +69,15 @@ export function resolveTiming(
     return override;
   }
 
+  const DEFAULT_FILL_TIME_SECS = 10;
   const sourceData = timingsLookup[sourceChainId] ?? timingsLookup["0"];
-  const destinationData = sourceData[destinationChainId] ?? sourceData["0"];
-  const symbolData = destinationData[symbol] ?? destinationData["OTHER"]; // implicitly sorted
-  return (
-    symbolData.find((cutoff) => usdAmount.lt(cutoff.amountUsd))?.timingInSecs ??
-    10
-  );
+  if (sourceData) {
+    const destinationData = sourceData[destinationChainId] ?? sourceData["0"];
+    const symbolData = destinationData[symbol] ?? destinationData["OTHER"]; // implicitly sorted
+    return (
+      symbolData?.find((cutoff) => usdAmount.lt(cutoff.amountUsd))
+        ?.timingInSecs ?? DEFAULT_FILL_TIME_SECS
+    );
+  }
+  return DEFAULT_FILL_TIME_SECS;
 }


### PR DESCRIPTION
/suggested-fees was breaking as there is no timing estimation for routes involving Lisk.
This is a temporarily fix, will check with @james-a-morris how this should be solved next week.