### PR TITLE
fix: more robust undefined checking

### DIFF
--- a/api/_timings.ts
+++ b/api/_timings.ts
@@ -70,10 +70,10 @@ export function resolveTiming(
   }
 
   const sourceData = timingsLookup[sourceChainId] ?? timingsLookup["0"];
-  const destinationData = sourceData[destinationChainId] ?? sourceData["0"];
-  const symbolData = destinationData[symbol] ?? destinationData["OTHER"]; // implicitly sorted
+  const destinationData = sourceData?.[destinationChainId] ?? sourceData?.["0"];
+  const symbolData = destinationData?.[symbol] ?? destinationData?.["OTHER"]; // implicitly sorted
   return (
-    symbolData.find((cutoff) => usdAmount.lt(cutoff.amountUsd))?.timingInSecs ??
-    10
+    symbolData?.find((cutoff) => usdAmount.lt(cutoff.amountUsd))
+      ?.timingInSecs ?? 10
   );
 }


### PR DESCRIPTION
We can assume there's a possibility our descending routes fail. This new logic eventually lands us at 10 seconds if we have no specific definitions