### PR TITLE
fix: update UI message when maxDeposit is 0

### DIFF
--- a/src/views/Bridge/components/BridgeForm.tsx
+++ b/src/views/Bridge/components/BridgeForm.tsx
@@ -72,6 +72,8 @@ export type BridgeFormProps = {
 const validationErrorTextMap = {
   [AmountInputError.INSUFFICIENT_BALANCE]:
     "Insufficient balance to process this transfer.",
+  [AmountInputError.PAUSED_DEPOSITS]:
+    "[INPUT_TOKEN] deposits are temporarily paused.",
   [AmountInputError.INSUFFICIENT_LIQUIDITY]:
     "Input amount exceeds limits set to maintain optimal service for all users. Decrease amount to [MAX_DEPOSIT] or lower.",
   [AmountInputError.INVALID]: "Only positive numbers are allowed as an input.",
@@ -174,13 +176,15 @@ const BridgeForm = ({
       </RowWrapper>
       {parsedAmountInput && validationError && (
         <InputErrorText
-          errorText={validationErrorTextMap[validationError].replace(
-            "[MAX_DEPOSIT]",
-            `${formatUnitsWithMaxFractions(
-              limits?.maxDeposit || 0,
-              getToken(selectedRoute.fromTokenSymbol).decimals
-            )} ${selectedRoute.fromTokenSymbol}`
-          )}
+          errorText={validationErrorTextMap[validationError]
+            .replace("[INPUT_TOKEN]", selectedRoute.fromTokenSymbol)
+            .replace(
+              "[MAX_DEPOSIT]",
+              `${formatUnitsWithMaxFractions(
+                limits?.maxDeposit || 0,
+                getToken(selectedRoute.fromTokenSymbol).decimals
+              )} ${selectedRoute.fromTokenSymbol}`
+            )}
         />
       )}
       <RowWrapper>

--- a/src/views/Bridge/components/EstimatedTable.tsx
+++ b/src/views/Bridge/components/EstimatedTable.tsx
@@ -117,7 +117,8 @@ const EstimatedTable = ({
     rewardToken?.displaySymbol || rewardToken?.symbol.toUpperCase();
   const baseToken = swapToken || inputToken;
   const doesAmountExceedMaxDeposit =
-    validationError === AmountInputError.INSUFFICIENT_LIQUIDITY;
+    validationError === AmountInputError.INSUFFICIENT_LIQUIDITY ||
+    validationError === AmountInputError.PAUSED_DEPOSITS;
 
   const { bridgeFee, outputAmount, swapFee } = doesAmountExceedMaxDeposit
     ? {

--- a/src/views/Bridge/components/FeesCollapsible.tsx
+++ b/src/views/Bridge/components/FeesCollapsible.tsx
@@ -54,7 +54,8 @@ export function FeesCollapsible(props: Props) {
   );
 
   const doesAmountExceedMaxDeposit =
-    props.validationError === AmountInputError.INSUFFICIENT_LIQUIDITY;
+    props.validationError === AmountInputError.INSUFFICIENT_LIQUIDITY ||
+    props.validationError === AmountInputError.PAUSED_DEPOSITS;
 
   const estimatedTime =
     props.quotedLimits && outputAmount && !doesAmountExceedMaxDeposit

--- a/src/views/Bridge/utils.ts
+++ b/src/views/Bridge/utils.ts
@@ -31,6 +31,7 @@ type RouteFilter = Partial<{
 
 export enum AmountInputError {
   INVALID = "invalid",
+  PAUSED_DEPOSITS = "pausedDeposits",
   INSUFFICIENT_LIQUIDITY = "insufficientLiquidity",
   INSUFFICIENT_BALANCE = "insufficientBalance",
   AMOUNT_TOO_LOW = "amountTooLow",
@@ -112,6 +113,12 @@ export function validateBridgeAmount(
   if (!parsedAmountInput || !amountToBridgeAfterSwap) {
     return {
       error: AmountInputError.INVALID,
+    };
+  }
+
+  if (maxDeposit && maxDeposit.eq(0)) {
+    return {
+      error: AmountInputError.PAUSED_DEPOSITS,
     };
   }
 

--- a/src/views/Bridge/utils.ts
+++ b/src/views/Bridge/utils.ts
@@ -116,7 +116,7 @@ export function validateBridgeAmount(
     };
   }
 
-  if (maxDeposit && maxDeposit.eq(0)) {
+  if (maxDeposit && BigNumber.from(0).eq(maxDeposit)) {
     return {
       error: AmountInputError.PAUSED_DEPOSITS,
     };


### PR DESCRIPTION
We were displaying the message "Input amount exceeds limits set to maintain optimal service for all users. Decrease amount to 0 LSK or lower." when maxDeposit was 0.