### PR TITLE
fix: don't claim rewards for windows not live

### DIFF
--- a/src/hooks/useUnclaimedProofs.ts
+++ b/src/hooks/useUnclaimedProofs.ts
@@ -2,7 +2,11 @@ import { useQuery } from "react-query";
 import { BigNumber } from "ethers";
 
 import { useConnection } from "hooks";
-import { fetchIsClaimed, fetchAirdropProofs } from "utils/merkle-distributor";
+import {
+  fetchIsClaimed,
+  fetchAirdropProofs,
+  fetchNextCreatedIndex,
+} from "utils/merkle-distributor";
 import {
   getUnclaimedProofsQueryKey,
   rewardProgramTypes,
@@ -50,8 +54,12 @@ async function fetchUnclaimedProofs(
   account?: string
 ) {
   const allProofs = await fetchAirdropProofs(rewardsType, account);
+  const nextCreatedIndex = await fetchNextCreatedIndex(rewardsType);
+  const publishedProofs = allProofs.filter(
+    (proof) => proof.windowIndex < nextCreatedIndex.toNumber()
+  );
   const isClaimedResults = await fetchIsClaimedForIndices(
-    allProofs,
+    publishedProofs,
     rewardsType
   );
 

--- a/src/utils/merkle-distributor.ts
+++ b/src/utils/merkle-distributor.ts
@@ -49,6 +49,11 @@ export async function fetchIsClaimed(
   return merkleDistributor.isClaimed(windowIndex, accountIndex);
 }
 
+export async function fetchNextCreatedIndex(rewardsType: rewardProgramTypes) {
+  const merkleDistributor = config.getMerkleDistributor(rewardsType);
+  return merkleDistributor.nextCreatedIndex();
+}
+
 export async function fetchAirdropProof(account?: string) {
   if (!account) {
     return undefined;


### PR DESCRIPTION
Currently the `Claim` button is enabled because of proofs that corresponds to windows that were not created yet. 

This PR will allow to claim rewards only for the proofs that are associated with windows that were created in the MerkleDistributor contract