### PR TITLE
improve: consolidate ENV vars

### DIFF
--- a/api/_constants.ts
+++ b/api/_constants.ts
@@ -114,21 +114,15 @@ export const coinGeckoAssetPlatformLookup: Record<string, string> = {
   "0x4200000000000000000000000000000000000042": "optimistic-ethereum",
 };
 
-export const defaultRelayerAddressOverridePerToken: Record<
-  string,
-  { relayer: string; destinationChains: number[] }
-> = {
-  SNX: {
-    relayer: "0x19cDc2b23AF0cC791ca64dda5BFc094Cddda31Cd",
-    destinationChains: [1, 10],
-  },
-};
-
-export const defaultRelayerAddressOverridePerChain: Record<number, string> =
-  JSON.parse(process.env.RELAYER_ADDRESS_OVERRIDE_PER_CHAIN || "{}");
-
-export const defaultRelayerAddressOverride =
-  process.env.RELAYER_ADDRESS_OVERRIDE;
+export const defaultRelayerAddressOverride: {
+  defaultAddr?: string;
+  symbols: {
+    [symbol: string]: {
+      defaultAddr: string;
+      chains: { [chainId: string]: string };
+    };
+  };
+} = JSON.parse(process.env.RELAYER_ADDRESS_OVERRIDE || "{}");
 
 export const graphAPIKey = process.env.GRAPH_API_KEY;
 

--- a/api/_constants.ts
+++ b/api/_constants.ts
@@ -122,7 +122,7 @@ export const defaultRelayerAddressOverride: {
       chains?: { [chainId: string]: string };
     };
   };
-} = JSON.parse(process.env.RELAYER_ADDRESS_OVERRIDE || "{}");
+} = JSON.parse(process.env.RELAYER_ADDRESS_OVERRIDES || "{}");
 
 export const graphAPIKey = process.env.GRAPH_API_KEY;
 

--- a/api/_constants.ts
+++ b/api/_constants.ts
@@ -116,10 +116,10 @@ export const coinGeckoAssetPlatformLookup: Record<string, string> = {
 
 export const defaultRelayerAddressOverride: {
   defaultAddr?: string;
-  symbols: {
+  symbols?: {
     [symbol: string]: {
-      defaultAddr: string;
-      chains: { [chainId: string]: string };
+      defaultAddr?: string;
+      chains?: { [chainId: string]: string };
     };
   };
 } = JSON.parse(process.env.RELAYER_ADDRESS_OVERRIDE || "{}");

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -1450,7 +1450,9 @@ export function getDefaultRelayerAddress(
   destinationChainId: number,
   symbol?: string
 ) {
-  const symbolOverride = defaultRelayerAddressOverride?.symbols?.[symbol ?? ""];
+  const symbolOverride = symbol
+    ? defaultRelayerAddressOverride?.symbols?.[symbol]
+    : undefined;
   return (
     symbolOverride?.chains?.[destinationChainId] ?? // Specific Symbol/Chain override
     symbolOverride?.defaultAddr ?? // Specific Symbol override

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -39,8 +39,6 @@ import {
   SECONDS_PER_YEAR,
   TOKEN_SYMBOLS_MAP,
   defaultRelayerAddressOverride,
-  defaultRelayerAddressOverridePerToken,
-  defaultRelayerAddressOverridePerChain,
   disabledL1Tokens,
   graphAPIKey,
   maxRelayFeePct,
@@ -716,7 +714,7 @@ export const getSpokePool = (_chainId: number): SpokePool => {
 export const getSpokePoolAddress = (chainId: number): string => {
   switch (chainId) {
     default:
-      return sdk.utils.getDeployedAddress("SpokePool", chainId, true) as string;
+      return sdk.utils.getDeployedAddress("SpokePool", chainId) as string;
   }
 };
 
@@ -1452,19 +1450,13 @@ export function getDefaultRelayerAddress(
   destinationChainId: number,
   symbol?: string
 ) {
-  // All symbols are uppercase in this record.
-  const overrideForToken = symbol
-    ? defaultRelayerAddressOverridePerToken[symbol.toUpperCase()]
-    : undefined;
-  if (overrideForToken?.destinationChains.includes(destinationChainId)) {
-    return overrideForToken.relayer;
-  } else {
-    return (
-      defaultRelayerAddressOverridePerChain[destinationChainId] ||
-      defaultRelayerAddressOverride ||
-      sdk.constants.DEFAULT_SIMULATED_RELAYER_ADDRESS
-    );
-  }
+  const symbolOverride = defaultRelayerAddressOverride?.symbols[symbol ?? ""];
+  return (
+    symbolOverride?.chains[destinationChainId] ?? // Specific Symbol/Chain override
+    symbolOverride?.defaultAddr ?? // Specific Symbol override
+    defaultRelayerAddressOverride?.defaultAddr ?? // Default override
+    sdk.constants.DEFAULT_SIMULATED_RELAYER_ADDRESS // Default hardcoded value
+  );
 }
 
 /**

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -1450,9 +1450,9 @@ export function getDefaultRelayerAddress(
   destinationChainId: number,
   symbol?: string
 ) {
-  const symbolOverride = defaultRelayerAddressOverride?.symbols[symbol ?? ""];
+  const symbolOverride = defaultRelayerAddressOverride?.symbols?.[symbol ?? ""];
   return (
-    symbolOverride?.chains[destinationChainId] ?? // Specific Symbol/Chain override
+    symbolOverride?.chains?.[destinationChainId] ?? // Specific Symbol/Chain override
     symbolOverride?.defaultAddr ?? // Specific Symbol override
     defaultRelayerAddressOverride?.defaultAddr ?? // Default override
     sdk.constants.DEFAULT_SIMULATED_RELAYER_ADDRESS // Default hardcoded value


### PR DESCRIPTION
This consolidates the ENV vars related to relayer quoting override to a single ENV with the structure: 

```
{
  defaultAddr?: string;
  symbols?: {
    [symbol: string]: {
      defaultAddr?: string;
      chains?: { [chainId: string]: string };
    };
  };
}
```