### PR TITLE
feat: Relayer exclusivity plumbing

### DIFF
--- a/src/utils/bridge.ts
+++ b/src/utils/bridge.ts
@@ -30,6 +30,8 @@ export type BridgeFees = {
   quoteBlock: ethers.BigNumber;
   limits: BridgeLimitInterface;
   estimatedFillTimeSec: number;
+  exclusiveRelayer: string;
+  exclusivityDeadline: number;
 };
 
 type GetBridgeFeesArgs = {
@@ -73,6 +75,8 @@ export async function getBridgeFees({
     lpFee,
     limits,
     estimatedFillTimeSec,
+    exclusiveRelayer,
+    exclusivityDeadline,
   } = await getApiEndpoint().suggestedFees(
     amount,
     getConfig().getTokenInfoBySymbol(fromChainId, inputTokenSymbol).address,
@@ -97,6 +101,8 @@ export async function getBridgeFees({
     quoteLatency,
     limits,
     estimatedFillTimeSec,
+    exclusiveRelayer,
+    exclusivityDeadline,
   };
 }
 

--- a/src/utils/serverless-api/mocked/suggested-fees.mocked.ts
+++ b/src/utils/serverless-api/mocked/suggested-fees.mocked.ts
@@ -49,5 +49,7 @@ export async function suggestedFeesMockedApiCall(
       maxDepositInstant: parseUnits("0.5", decimals),
       maxDepositShortDelay: parseUnits("0.5", decimals),
     },
+    exclusiveRelayer: ethers.constants.AddressZero,
+    exclusivityDeadline: 0,
   };
 }

--- a/src/utils/serverless-api/prod/suggested-fees.prod.ts
+++ b/src/utils/serverless-api/prod/suggested-fees.prod.ts
@@ -56,6 +56,8 @@ export async function suggestedFeesApiCall(
   );
 
   const estimatedFillTimeSec = result["estimatedFillTimeSec"];
+  const exclusiveRelayer = result["exclusiveRelayer"];
+  const exclusivityDeadline = result["exclusivityDeadline"];
 
   return {
     totalRelayFee: {
@@ -84,5 +86,7 @@ export async function suggestedFeesApiCall(
       minDeposit,
     },
     estimatedFillTimeSec,
+    exclusiveRelayer,
+    exclusivityDeadline,
   };
 }

--- a/src/utils/serverless-api/types.ts
+++ b/src/utils/serverless-api/types.ts
@@ -56,6 +56,8 @@ export type SuggestedApiFeeReturnType = {
   quoteBlock: ethers.BigNumber;
   limits: BridgeLimitInterface;
   estimatedFillTimeSec: number;
+  exclusiveRelayer: string;
+  exclusivityDeadline: number;
 };
 
 export type SuggestedApiFeeType = (

--- a/src/views/Bridge/hooks/useBridgeAction.ts
+++ b/src/views/Bridge/hooks/useBridgeAction.ts
@@ -271,6 +271,8 @@ type DepositArgs = {
   tokenAddress: string;
   isNative: boolean;
   toAddress: string;
+  exclusiveRelayer: string;
+  exclusivityDeadline: number;
   integratorId: string;
 };
 function getDepositArgs(
@@ -303,6 +305,8 @@ function getDepositArgs(
     tokenAddress: selectedRoute.fromTokenAddress,
     isNative: selectedRoute.isNative,
     toAddress: recipient,
+    exclusiveRelayer: quotedFees.exclusiveRelayer,
+    exclusivityDeadline: quotedFees.exclusivityDeadline,
     integratorId,
   };
 }

--- a/src/views/Bridge/hooks/useTransferQuote.ts
+++ b/src/views/Bridge/hooks/useTransferQuote.ts
@@ -100,6 +100,8 @@ export function useTransferQuote(
           amountToBridgeAfterSwap: undefined,
           initialAmount: undefined,
           recipient: undefined,
+          exclusiveRelayer: undefined,
+          exclusivityDeadline: undefined,
         };
       }
 
@@ -140,6 +142,8 @@ export function useTransferQuote(
         amountToBridgeAfterSwap,
         initialAmount: amount,
         recipient: toAddress,
+        exclusiveRelayer: feesQuery.fees.exclusiveRelayer,
+        exclusivityDeadline: feesQuery.fees.exclusivityDeadline,
       };
     },
   });


### PR DESCRIPTION
This commit attempts to add the code plumbing necessary for the exclusiveRelayer and exclusivityDeadline fields to be set based on the suggested-fees API response.