### PR TITLE
chore: cache balance for 1 minute

### DIFF
--- a/api/account-balance.ts
+++ b/api/account-balance.ts
@@ -48,7 +48,7 @@ const handler = async (
     // Set the caching headers that will be used by the CDN.
     response.setHeader(
       "Cache-Control",
-      "s-maxage=150, stale-while-revalidate=150"
+      "s-maxage=60, stale-while-revalidate=60"
     );
     // Return the response
     response.status(200).json(result);


### PR DESCRIPTION
## motivation

high demand for weth bridges are causing relayers' balances to be wiped out quicker than usual, therefore we need to decrease the time we cache balances for