### PR TITLE
feat: use rpc provider configs from remote

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@
 src/data/fill-times-preset.json
 src/data/exclusive-relayer-configs.json
 src/data/exclusive-relayer-weights.json
+src/data/rpc-providers.json
 
 # IDE
 .idea

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -18,6 +18,7 @@ import { StructError, define } from "superstruct";
 
 import enabledMainnetRoutesAsJson from "../src/data/routes_1_0xc186fA914353c44b2E33eBE05f21846F1048bEda.json";
 import enabledSepoliaRoutesAsJson from "../src/data/routes_11155111_0x14224e63716afAcE30C9a417E0542281869f7d9e.json";
+import rpcProvidersJson from "../src/data/rpc-providers.json";
 
 import {
   MINIMAL_BALANCER_V2_POOL_ABI,
@@ -47,6 +48,7 @@ import {
 import { PoolStateOfUser, PoolStateResult } from "./_types";
 
 type LoggingUtility = sdk.relayFeeCalculator.Logger;
+type RpcProviderName = keyof typeof rpcProvidersJson.providers.urls;
 
 const {
   REACT_APP_HUBPOOL_CHAINID,
@@ -683,7 +685,7 @@ export const providerCache: Record<string, StaticJsonRpcProvider> = {};
 
 /**
  * Generates a relevant provider for the given input chainId
- * @param _chainId A valid chain identifier where an AcrossV2 contract is deployed
+ * @param _chainId A valid chain identifier where Across is deployed
  * @returns A provider object to query the requested blockchain
  */
 export const getProvider = (
@@ -691,8 +693,15 @@ export const getProvider = (
 ): providers.StaticJsonRpcProvider => {
   const chainId = _chainId.toString();
   if (!providerCache[chainId]) {
+    // Resolves provider from urls set in rpc-providers.json.
+    const providerFromConfigJson = getProviderFromConfigJson(chainId);
+    // Resolves provider from urls set via environment variables.
+    // Note that this is legacy and should be removed in the future.
     const override = overrideProvider(chainId);
-    if (override) {
+
+    if (providerFromConfigJson) {
+      providerCache[chainId] = providerFromConfigJson;
+    } else if (override) {
       providerCache[chainId] = override;
     } else {
       providerCache[chainId] = infuraProvider(_chainId);
@@ -700,6 +709,36 @@ export const getProvider = (
   }
   return providerCache[chainId];
 };
+
+/**
+ * Resolves a provider from the `rpc-providers.json` configuration file.
+ */
+function getProviderFromConfigJson(chainId: string) {
+  const { providers } = rpcProvidersJson;
+  const enabledProviders: RpcProviderName[] =
+    (providers.enabled as Record<string, RpcProviderName[]>)[chainId] ||
+    providers.enabled.default;
+
+  let providerUrl: string | undefined;
+  for (const provider of enabledProviders) {
+    providerUrl = (providers.urls[provider] as Record<string, string>)?.[
+      chainId
+    ];
+    if (providerUrl) {
+      console.log(`Using provider ${provider} for chainId ${chainId}`);
+      break;
+    }
+  }
+
+  if (!providerUrl) {
+    console.error(
+      `No provider URL found for chainId ${chainId} in rpc-providers.json`
+    );
+    return undefined;
+  }
+
+  return new ethers.providers.StaticJsonRpcProvider(providerUrl);
+}
 
 /**
  * Generates a relevant SpokePool given the input chain ID

--- a/scripts/pre-build.ts
+++ b/scripts/pre-build.ts
@@ -3,6 +3,7 @@ import { writeFileSync } from "fs";
 import dotenv from "dotenv";
 
 import {
+  fetchRpcProviderConfigs,
   fetchExclusiveRelayerConfigs,
   fetchFillTimes,
   fetchExclusiveRelayersDynamicWeights,
@@ -10,6 +11,7 @@ import {
   getRemoteConfigCommitHash,
   getBqReaderRemoteBaseUrl,
   remoteConfigTypes,
+  getAcrossConfigsRemoteBaseUrl,
 } from "./remote-configs/utils";
 
 dotenv.config({
@@ -17,6 +19,15 @@ dotenv.config({
 });
 
 const remoteConfigs = {
+  [remoteConfigTypes.RPC_PROVIDERS]: {
+    fetchFn: () =>
+      fetchRpcProviderConfigs(
+        getAcrossConfigsRemoteBaseUrl(),
+        "packages/quotes-api-config/config.json",
+        getRemoteConfigCommitHash(remoteConfigTypes.RPC_PROVIDERS)
+      ),
+    localFilePath: "src/data/rpc-providers.json",
+  },
   [remoteConfigTypes.FILL_TIMES]: {
     fetchFn: () =>
       fetchFillTimes(

--- a/scripts/pre-build.ts
+++ b/scripts/pre-build.ts
@@ -12,6 +12,7 @@ import {
   getBqReaderRemoteBaseUrl,
   remoteConfigTypes,
   getAcrossConfigsRemoteBaseUrl,
+  getRelayerConfigsRemoteBaseUrl,
 } from "./remote-configs/utils";
 
 dotenv.config({
@@ -40,7 +41,7 @@ const remoteConfigs = {
   [remoteConfigTypes.EXCLUSIVE_RELAYERS]: {
     fetchFn: () =>
       fetchExclusiveRelayerConfigs(
-        "https://raw.githubusercontent.com/across-protocol/exclusive-relayer-configs",
+        getRelayerConfigsRemoteBaseUrl(),
         "build/exclusive-relayer-configs.json",
         getRemoteConfigCommitHash(remoteConfigTypes.EXCLUSIVE_RELAYERS)
       ),

--- a/scripts/remote-configs/utils.ts
+++ b/scripts/remote-configs/utils.ts
@@ -13,16 +13,28 @@ import {
 import fillTimesFallbackData from "../../src/data/examples/fill-times.json";
 import dynamicWeightsFallbackData from "../../src/data/examples/dynamic-weights.json";
 import fixedWeightsFallbackData from "../../src/data/examples/fixed-weights.json";
+import rpcProvidersFallbackData from "../../src/data/examples/rpc-providers.json";
 
 export const remoteConfigTypes = {
   FILL_TIMES: "FILL_TIMES",
   EXCLUSIVE_RELAYERS: "EXCLUSIVE_RELAYERS",
   EXCLUSIVE_RELAYERS_DYNAMIC_WEIGHTS: "EXCLUSIVE_RELAYERS_DYNAMIC_WEIGHTS",
   EXCLUSIVE_RELAYERS_FIXED_WEIGHTS: "EXCLUSIVE_RELAYER_WEIGHTS",
+  RPC_PROVIDERS: "RPC_PROVIDERS",
 } as const;
 
 export type RemoteConfig =
   (typeof remoteConfigTypes)[keyof typeof remoteConfigTypes];
+
+export const fetchRpcProviderConfigs = makeFetchRemoteConfig(
+  type({
+    providers: type({
+      enabled: record(string(), array(string())),
+      urls: record(string(), record(string(), string())),
+    }),
+  }),
+  rpcProvidersFallbackData
+);
 
 export const fetchFillTimes = makeFetchRemoteConfig(
   array(
@@ -122,4 +134,8 @@ export function getRemoteConfigCommitHash(config: RemoteConfig) {
 
 export function getBqReaderRemoteBaseUrl() {
   return `https://raw.githubusercontent.com/UMAprotocol/across-bq-reader`;
+}
+
+export function getAcrossConfigsRemoteBaseUrl() {
+  return `https://raw.githubusercontent.com/UMAprotocol/across-configs`;
 }

--- a/scripts/remote-configs/utils.ts
+++ b/scripts/remote-configs/utils.ts
@@ -128,14 +128,37 @@ async function fetchRemoteConfigAndValidate<T>(
   return data as Infer<typeof schema>;
 }
 
+export function getRemoteConfigBaseUrl(
+  envSuffix: string,
+  defaultBaseUrl: string
+) {
+  return (
+    process.env[`REMOTE_CONFIG_BASE_URL_${envSuffix.toUpperCase()}`] ??
+    defaultBaseUrl
+  );
+}
+
 export function getRemoteConfigCommitHash(config: RemoteConfig) {
   return process.env[`REMOTE_CONFIG_COMMIT_HASH_${config}`] ?? "master";
 }
 
+export function getRelayerConfigsRemoteBaseUrl() {
+  return getRemoteConfigBaseUrl(
+    "RELAYER_CONFIGS",
+    "https://raw.githubusercontent.com/across-protocol/exclusive-relayer-configs"
+  );
+}
+
 export function getBqReaderRemoteBaseUrl() {
-  return `https://raw.githubusercontent.com/UMAprotocol/across-bq-reader`;
+  return getRemoteConfigBaseUrl(
+    "BQ_READER",
+    "https://raw.githubusercontent.com/UMAprotocol/across-bq-reader"
+  );
 }
 
 export function getAcrossConfigsRemoteBaseUrl() {
-  return `https://raw.githubusercontent.com/UMAprotocol/across-configs`;
+  return getRemoteConfigBaseUrl(
+    "ACROSS_CONFIGS",
+    "https://raw.githubusercontent.com/UMAprotocol/across-configs"
+  );
 }

--- a/src/data/examples/rpc-providers.json
+++ b/src/data/examples/rpc-providers.json
@@ -7,7 +7,7 @@
       "public": {
         "1": "https://mainnet.gateway.tenderly.co",
         "10": "https://mainnet.optimism.io",
-        "137": "https://rpc.ankr.com/polygon",
+        "137": "https://polygon-mainnet.g.alchemy.com/v2/demo",
         "324": "https://mainnet.era.zksync.io",
         "690": "https://rpc.redstonechain.com",
         "8453": "https://mainnet.base.org",

--- a/src/data/examples/rpc-providers.json
+++ b/src/data/examples/rpc-providers.json
@@ -1,0 +1,23 @@
+{
+  "providers": {
+    "enabled": {
+      "default": ["public"]
+    },
+    "urls": {
+      "public": {
+        "1": "https://mainnet.gateway.tenderly.co",
+        "10": "https://mainnet.optimism.io",
+        "137": "https://rpc.ankr.com/polygon",
+        "324": "https://mainnet.era.zksync.io",
+        "690": "https://rpc.redstonechain.com",
+        "8453": "https://mainnet.base.org",
+        "34443": "https://mainnet.mode.network",
+        "42161": "https://arb1.arbitrum.io/rpc",
+        "59144": "https://rpc.linea.build",
+        "81457": "https://rpc.blast.io",
+        "534352": "https://rpc.scroll.io",
+        "7777777": "https://rpc.zora.energy"
+      }
+    }
+  }
+}


### PR DESCRIPTION
~Requires #1175~

Closes ACX-2586

Uses configs set in here https://github.com/UMAprotocol/across-configs/blob/master/packages/quotes-api-config/config.json. This allows for a workflow similar to the `fill-times.json` and bot configs.