### PR TITLE
Revert "fix(exclusivity): Reintroduce origin chain constraint (#1188)"

### DIFF
--- a/api/_exclusivity/index.ts
+++ b/api/_exclusivity/index.ts
@@ -45,11 +45,6 @@ export async function selectExclusiveRelayer(
     return { exclusiveRelayer, exclusivityPeriod };
   }
 
-  // @todo: remove this when all other SpokePools are redeployed to support `depositExclusive`.
-  if (![690, 1135, 81457, 534352, 7777777].includes(originChainId)) {
-    return { exclusiveRelayer, exclusivityPeriod };
-  }
-
   const exclusivityPeriodSec = getExclusivityPeriod(estimatedFillTimeSec);
   const relayers = await getEligibleRelayers(
     originChainId,


### PR DESCRIPTION
All SpokePools have been upgraded now.

This reverts commit 9c5cc82f0f5ff378596212f6bce18e5f0a9fadaa.