### PR TITLE
fix: reduce max concurrency

### DIFF
--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -734,7 +734,7 @@ function getProviderFromConfigJson(_chainId: string) {
     1, // quorum can be 1 in the context of the API
     3, // retries
     0.1, // delay
-    100, // max. concurrency
+    10, // max. concurrency
     "RPC_PROVIDER", // cache namespace
     0 // disable RPC calls logging
   );


### PR DESCRIPTION
I have seen higher volatility between execution times since the last commit. Trying to figure out if the max concurrency is the issue