### PR TITLE
feat: improve ethers error parsing in API

### DIFF
--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -1050,7 +1050,7 @@ export function applyMapFilter<InputType, MapType>(
 export function resolveEthersError(err: unknown): string {
   // prettier-ignore
   return sdk.typeguards.isEthersError(err)
-    ? `${err.reason}: ${err.code}`
+    ? `${err.reason}: ${err.code} - ${err.error}`
     : sdk.typeguards.isError(err)
       ? err.message
       : "unknown error";

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -729,7 +729,7 @@ function getProviderFromConfigJson(_chainId: string) {
   }
 
   return new sdk.providers.RetryProvider(
-    urls.map((url) => [url, chainId]),
+    urls.map((url) => [{ url, errorPassThrough: true }, chainId]),
     chainId,
     1, // quorum can be 1 in the context of the API
     3, // retries


### PR DESCRIPTION
The API is throwing a lot of the following errors that can be reproduced locally
```
InputError: Relayer fill simulation failed - processing response error: SERVER_ERROR
    at getRelayerFeeDetails (/vercel/path0/api/_utils.ts:632:11)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Promise.all (index 0)
    at handler (/vercel/path0/api/limits.ts:132:9)
    at async Server.<anonymous> (/opt/rust/nodejs.js:1:10566)
    at async Server.<anonymous> (/opt/rust/nodejs.js:8:4242)
END RequestId: a7503f75-c737-4371-8c1b-2fb7f27a55bb
REPORT RequestId: a7503f75-c737-4371-8c1b-2fb7f27a55bb	Duration: 6585.34 ms	Billed Duration: 6586 ms	Memory Size: 1024 MB	Max Memory Used: 377 MB
```

Hope to get more insight with this change