### PR TITLE
fix: temp ignore cached gas price

### DIFF
--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -624,8 +624,8 @@ export const getRelayerFeeDetails = async (
       amount,
       sdk.utils.isMessageEmpty(message),
       relayerAddress,
-      tokenPrice,
-      gasPrice
+      tokenPrice
+      // gasPrice // FIXME
     );
   } catch (err: unknown) {
     const reason = resolveEthersError(err);


### PR DESCRIPTION
Since the introduction of cached values, we have been seeing a lot API errors like
```
InputError: Relayer fill simulation failed - processing response error: SERVER_ERROR - Error: failed with 50044019 gas: max fee per gas less than block base fee: address 0x07aE8551Be970cB1cCa11Dd7a11F47Ae82e70E67, maxFeePerGas: 14025000, baseFee: 19815000
    at getRelayerFeeDetails (/vercel/path0/api/_utils.ts:632:11)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at handler (/vercel/path0/api/suggested-fees.ts:255:31)
    at async Server.<anonymous> (/opt/rust/nodejs.js:1:10566)
    at async Server.<anonymous> (/opt/rust/nodejs.js:8:4242)
END RequestId: 60797827-296d-4bde-af4a-8862b3692f0e
REPORT RequestId: 60797827-296d-4bde-af4a-8862b3692f0e	Duration: 7303.97 ms	Billed Duration: 7304 ms	Memory Size: 1024 MB	Max Memory Used: 365 MB
```
Most probably due to stale gas prices. Ways to circumvent these:
- decrease TTL
- apply multiplier to cached gas price

This PR only removes the usage of cached gas prices for now, so that we can get off the rollback deployment.