### PR TITLE
perf: api speed improvements

### DIFF
--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -613,10 +613,10 @@ export const getRelayerFeeDetails = async (
     originChainId: number;
     destinationChainId: number;
     recipientAddress: string;
+    message?: string;
+    relayerAddress?: string;
   },
   tokenPrice?: number,
-  message?: string,
-  relayerAddress?: string,
   gasPrice?: sdk.utils.BigNumberish,
   gasUnits?: sdk.utils.BigNumberish
 ): Promise<sdk.relayFeeCalculator.RelayerFeeDetails> => {
@@ -627,6 +627,8 @@ export const getRelayerFeeDetails = async (
     originChainId,
     destinationChainId,
     recipientAddress,
+    message,
+    relayerAddress,
   } = deposit;
   const relayFeeCalculator = getRelayerFeeCalculator(destinationChainId, {
     relayerAddress,
@@ -646,7 +648,7 @@ export const getRelayerFeeDetails = async (
       sdk.utils.isMessageEmpty(message),
       relayerAddress,
       tokenPrice,
-      gasPrice, // FIXME: We need properly cache the gas price before this can be used reliably
+      gasPrice,
       gasUnits
     );
   } catch (err: unknown) {

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -1871,8 +1871,7 @@ export function getCachedFillGasUsage(
     );
     const { nativeGasCost } = await relayerFeeCalculatorQueries.getGasCosts(
       buildDepositForSimulation(deposit),
-      overrides?.relayerAddress,
-      await getCachedGasPrice(deposit.destinationChainId)
+      overrides?.relayerAddress
     );
     return nativeGasCost;
   };

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -728,15 +728,13 @@ function getProviderFromConfigJson(_chainId: string) {
     return undefined;
   }
 
-  return new sdk.providers.RetryProvider(
+  return new sdk.providers.SpeedProvider(
     urls.map((url) => [{ url, errorPassThrough: true }, chainId]),
     chainId,
-    1, // quorum can be 1 in the context of the API
-    3, // retries
-    0.5, // delay
-    5, // max. concurrency
+    3, // max. concurrency used in `SpeedProvider`
+    5, // max. concurrency used in `RateLimitedProvider`
     "RPC_PROVIDER", // cache namespace
-    0 // disable RPC calls logging
+    1 // disable RPC calls logging
   );
 }
 

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -1000,19 +1000,8 @@ export const getCachedTokenBalance = async (
   account: string,
   token: string
 ): Promise<BigNumber> => {
-  // Make the request to the vercel API.
-  const response = await axios.get<{ balance: string }>(
-    `${resolveVercelEndpoint()}/api/account-balance`,
-    {
-      params: {
-        chainId,
-        account,
-        token,
-      },
-    }
-  );
-  // Return the balance
-  return BigNumber.from(response.data.balance);
+  const balance = await getCachedLatestBalance(Number(chainId), token, account);
+  return balance;
 };
 
 /**
@@ -1845,8 +1834,8 @@ export function getCachedLatestBalance(
   address: string
 ) {
   const ttlPerChain = {
-    default: 5,
-    [CHAIN_IDs.MAINNET]: 12,
+    default: 30,
+    [CHAIN_IDs.MAINNET]: 30,
   };
 
   return getCachedValue(

--- a/api/limits.ts
+++ b/api/limits.ts
@@ -30,7 +30,6 @@ import {
   validAddress,
   validateChainAndTokenParams,
   getCachedLatestBlock,
-  getCachedGasPrice,
   getCachedFillGasUsage,
 } from "./_utils";
 
@@ -126,7 +125,7 @@ const handler = async (
       relayerAddress,
     };
 
-    const [tokenPriceNative, _tokenPriceUsd, latestBlock, gasPrice, gasUnits] =
+    const [tokenPriceNative, _tokenPriceUsd, latestBlock, gasUnits] =
       await Promise.all([
         getCachedTokenPrice(
           l1Token.address,
@@ -134,7 +133,6 @@ const handler = async (
         ),
         getCachedTokenPrice(l1Token.address, "usd"),
         getCachedLatestBlock(HUB_POOL_CHAIN_ID),
-        getCachedGasPrice(destinationChainId),
         getCachedFillGasUsage(depositArgs, {
           relayerAddress,
         }),
@@ -148,7 +146,7 @@ const handler = async (
       transferRestrictedBalances,
       fullRelayerMainnetBalances,
     ] = await Promise.all([
-      getRelayerFeeDetails(depositArgs, tokenPriceNative, gasPrice, gasUnits),
+      getRelayerFeeDetails(depositArgs, tokenPriceNative, undefined, gasUnits),
       callViaMulticall3(provider, multiCalls, {
         blockTag: latestBlock.number,
       }),

--- a/api/limits.ts
+++ b/api/limits.ts
@@ -112,6 +112,10 @@ const handler = async (
       },
     ];
 
+    const relayerAddress = getDefaultRelayerAddress(
+      destinationChainId,
+      l1Token.symbol
+    );
     const depositArgs = {
       amount: ethers.BigNumber.from("10").pow(l1Token.decimals),
       inputToken: inputToken.address,
@@ -119,11 +123,8 @@ const handler = async (
       recipientAddress: DEFAULT_SIMULATED_RECIPIENT_ADDRESS,
       originChainId: computedOriginChainId,
       destinationChainId,
+      relayerAddress,
     };
-    const relayerAddress = getDefaultRelayerAddress(
-      destinationChainId,
-      l1Token.symbol
-    );
 
     const [tokenPriceNative, _tokenPriceUsd, latestBlock, gasPrice, gasUnits] =
       await Promise.all([
@@ -147,14 +148,7 @@ const handler = async (
       transferRestrictedBalances,
       fullRelayerMainnetBalances,
     ] = await Promise.all([
-      getRelayerFeeDetails(
-        depositArgs,
-        tokenPriceNative,
-        undefined,
-        getDefaultRelayerAddress(destinationChainId, l1Token.symbol),
-        gasPrice,
-        gasUnits
-      ),
+      getRelayerFeeDetails(depositArgs, tokenPriceNative, gasPrice, gasUnits),
       callViaMulticall3(provider, multiCalls, {
         blockTag: latestBlock.number,
       }),

--- a/api/suggested-fees.ts
+++ b/api/suggested-fees.ts
@@ -28,7 +28,6 @@ import {
   validateChainAndTokenParams,
   getCachedLimits,
   getCachedLatestBlock,
-  getCachedGasPrice,
   getCachedFillGasUsage,
 } from "./_utils";
 import { selectExclusiveRelayer } from "./_exclusivity";
@@ -222,7 +221,6 @@ const handler = async (
       tokenPrice,
       tokenPriceUsd,
       limits,
-      gasPrice,
       gasUnits,
     ] = await Promise.all([
       callViaMulticall3(provider, multiCalls, { blockTag: quoteBlockNumber }),
@@ -234,7 +232,6 @@ const handler = async (
         computedOriginChainId,
         destinationChainId
       ),
-      getCachedGasPrice(destinationChainId),
       // Only use cached fill gas usage if message is empty
       sdk.utils.isMessageEmpty(message)
         ? undefined
@@ -272,7 +269,7 @@ const handler = async (
     const relayerFeeDetails = await getRelayerFeeDetails(
       depositArgs,
       tokenPrice,
-      gasPrice,
+      undefined,
       gasUnits
     );
 

--- a/api/suggested-fees.ts
+++ b/api/suggested-fees.ts
@@ -29,6 +29,7 @@ import {
   getCachedLimits,
   getCachedLatestBlock,
   getCachedGasPrice,
+  getCachedFillGasUsage,
 } from "./_utils";
 import { selectExclusiveRelayer } from "./_exclusivity";
 import { resolveTiming, resolveRebalanceTiming } from "./_timings";
@@ -205,6 +206,15 @@ const handler = async (
       },
     ];
 
+    const depositArgs = {
+      amount,
+      inputToken: inputToken.address,
+      outputToken: outputToken.address,
+      recipientAddress: recipient,
+      originChainId: computedOriginChainId,
+      destinationChainId,
+    };
+
     const [
       [currentUt, nextUt, _quoteTimestamp, rawL1TokenConfig],
       tokenPrice,
@@ -222,6 +232,7 @@ const handler = async (
         destinationChainId
       ),
       getCachedGasPrice(destinationChainId),
+      getCachedFillGasUsage(depositArgs, { relayerAddress: relayer }),
     ]);
     const quoteTimestamp = parseInt(_quoteTimestamp.toString());
 
@@ -253,12 +264,7 @@ const handler = async (
     );
     const lpFeeTotal = amount.mul(lpFeePct).div(ethers.constants.WeiPerEther);
     const relayerFeeDetails = await getRelayerFeeDetails(
-      inputToken.address,
-      outputToken.address,
-      amount,
-      computedOriginChainId,
-      destinationChainId,
-      recipient,
+      depositArgs,
       tokenPrice,
       message,
       relayer,

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@across-protocol/constants": "^3.1.15",
     "@across-protocol/contracts": "^3.0.10",
     "@across-protocol/contracts-v3.0.6": "npm:@across-protocol/contracts@3.0.6",
-    "@across-protocol/sdk": "^3.1.25",
+    "@across-protocol/sdk": "^3.1.32",
     "@amplitude/analytics-browser": "^2.3.5",
     "@balancer-labs/sdk": "1.1.6-beta.16",
     "@emotion/react": "^11.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -80,10 +80,10 @@
     axios "^1.6.2"
     zksync-web3 "^0.14.3"
 
-"@across-protocol/sdk@^3.1.25":
-  version "3.1.25"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-3.1.25.tgz#e1273b1fe5d64eef867d748ded2f8b0dc93261dd"
-  integrity sha512-s+JhA0DSD3NXrut/L5IbmanfzHhy0lTlGcq5TgjtPLcZJ5GvWMqnNdVzUNbijb+lZAVW5gea0AgkFU0Z+6gdEg==
+"@across-protocol/sdk@^3.1.32":
+  version "3.1.32"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-3.1.32.tgz#04248d6f722bf2706c9d2b9cd0bf228510a07ff6"
+  integrity sha512-BXv1dJPvZw3Ozsm1LPlFQD1OSdDYPZQH7czmSPCOEtrHoVl1eScKHxdu53hbD09//YhoVFF+i2W4auLXCJ8Stg==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/constants" "^3.1.14"


### PR DESCRIPTION
Closes ACX-2429 and ACX-2610

This PR introduces more potential speed improvements:
1. Usage of [SpeedProvider](https://github.com/across-protocol/frontend/compare/more-speed-improvements?expand=1#diff-428e8c9eb80e1971d1eb1d20244ebe4791f3f5d6c6c664cb694759f503874251R793-R800) 
2. Caching of fill gas units
3. ~Re-introduction of using cached gas price with tweaked params~ EDIT: Will be postponed to separate PR
4. Usage of cached token balances from redis instead of self call