### PR TITLE
feat(API): Align limits and suggested-fees relayerFeeDetails computations

### DIFF
--- a/api/_cache.ts
+++ b/api/_cache.ts
@@ -1,8 +1,21 @@
 import { kv } from "@vercel/kv";
 import { interfaces } from "@across-protocol/sdk";
 
+const {
+  KV_REST_API_READ_ONLY_TOKEN,
+  KV_REST_API_TOKEN,
+  KV_REST_API_URL,
+  KV_URL,
+} = process.env;
+const isRedisCacheEnabled =
+  KV_REST_API_URL && KV_REST_API_TOKEN && KV_REST_API_READ_ONLY_TOKEN && KV_URL;
+
 export class RedisCache implements interfaces.CachingMechanismInterface {
   async get<T>(key: string): Promise<T | null> {
+    if (!isRedisCacheEnabled) {
+      return null;
+    }
+
     const value = await kv.get(key);
     if (value === null || value === undefined) {
       return null;
@@ -11,6 +24,10 @@ export class RedisCache implements interfaces.CachingMechanismInterface {
   }
 
   async set<T>(key: string, value: T, ttl = 10): Promise<string | undefined> {
+    if (!isRedisCacheEnabled) {
+      return;
+    }
+
     try {
       if (typeof value === "string") {
         try {

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -712,9 +712,9 @@ export const getCachedLimits = async (
   outputToken: string,
   originChainId: number,
   destinationChainId: number,
-  amount: string,
-  recipient: string,
-  relayer: string,
+  amount?: string,
+  recipient?: string,
+  relayer?: string,
   message?: string
 ): Promise<{
   minDeposit: string;

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -284,6 +284,52 @@ export const validateChainAndTokenParams = (
   };
 };
 
+export const validateDepositMessage = async (
+  recipient: string,
+  destinationChainId: number,
+  relayer: string,
+  outputTokenAddress: string,
+  amountInput: string,
+  message: string
+) => {
+  if (!sdk.utils.isMessageEmpty(message)) {
+    if (!ethers.utils.isHexString(message)) {
+      throw new InputError("Message must be a hex string");
+    }
+    if (message.length % 2 !== 0) {
+      // Our message encoding is a hex string, so we need to check that the length is even.
+      throw new InputError("Message must be an even hex string");
+    }
+    const isRecipientAContract = await sdk.utils.isContractDeployedToAddress(
+      recipient,
+      getProvider(destinationChainId)
+    );
+    if (!isRecipientAContract) {
+      throw new InputError(
+        "Recipient must be a contract when a message is provided"
+      );
+    } else {
+      // If we're in this case, it's likely that we're going to have to simulate the execution of
+      // a complex message handling from the specified relayer to the specified recipient by calling
+      // the arbitrary function call `handleAcrossMessage` at the recipient. So that we can discern
+      // the difference between an OUT_OF_FUNDS error in either the transfer or through the execution
+      // of the `handleAcrossMessage` we will check that the balance of the relayer is sufficient to
+      // support this deposit.
+      const balanceOfToken = await getCachedTokenBalance(
+        destinationChainId,
+        relayer,
+        outputTokenAddress
+      );
+      if (balanceOfToken.lt(amountInput)) {
+        throw new InputError(
+          `Relayer Address (${relayer}) doesn't have enough funds to support this deposit;` +
+            ` for help, please reach out to https://discord.across.to`
+        );
+      }
+    }
+  }
+};
+
 /**
  * Utility function to resolve route details based on given `inputTokenAddress` and `destinationChainId`.
  * The optional parameter `originChainId` can be omitted if the `inputTokenAddress` is unique across all
@@ -665,13 +711,25 @@ export const getCachedLimits = async (
   inputToken: string,
   outputToken: string,
   originChainId: number,
-  destinationChainId: number
+  destinationChainId: number,
+  amount: string,
+  recipient: string,
+  relayer: string,
+  message?: string
 ): Promise<{
   minDeposit: string;
   maxDeposit: string;
   maxDepositInstant: string;
   maxDepositShortDelay: string;
   recommendedDepositInstant: string;
+  relayerFeeDetails: {
+    relayFeeTotal: string;
+    relayFeePercent: string;
+    capitalFeePercent: string;
+    capitalFeeTotal: string;
+    gasFeePercent: string;
+    gasFeeTotal: string;
+  };
 }> => {
   return (
     await axios(`${resolveVercelEndpoint()}/api/limits`, {
@@ -680,6 +738,10 @@ export const getCachedLimits = async (
         outputToken,
         originChainId,
         destinationChainId,
+        amount,
+        message,
+        recipient,
+        relayer,
       },
     })
   ).data;

--- a/api/limits.ts
+++ b/api/limits.ts
@@ -96,7 +96,7 @@ const handler = async (
     // to compute limits.
     let { amount: amountInput, recipient, relayer, message } = query;
     recipient ??= DEFAULT_SIMULATED_RECIPIENT_ADDRESS;
-    relayer ??= getDefaultRelayerAddress(destinationChainId, inputToken.symbol);
+    relayer ??= getDefaultRelayerAddress(destinationChainId, l1Token.symbol);
     if (sdk.utils.isDefined(message)) {
       if (!sdk.utils.isDefined(amountInput)) {
         throw new InputError("amount must be defined when message is defined");

--- a/api/limits.ts
+++ b/api/limits.ts
@@ -200,6 +200,11 @@ const handler = async (
         )
       ),
     ]);
+    logger.debug({
+      at: "Limits",
+      message: "Relayer fee details from SDK",
+      relayerFeeDetails,
+    });
 
     let { liquidReserves } = multicallOutput[1];
     const [liteChainIdsEncoded] = multicallOutput[2];
@@ -341,7 +346,6 @@ const handler = async (
       maxDepositInstant: bufferedMaxDepositInstant.toString(),
       maxDepositShortDelay: bufferedMaxDepositShortDelay.toString(),
       recommendedDepositInstant: bufferedRecommendedDepositInstant.toString(),
-      relayerFeeDetails,
     };
     logger.debug({
       at: "Limits",

--- a/api/suggested-fees.ts
+++ b/api/suggested-fees.ts
@@ -89,7 +89,8 @@ const handler = async (
 
     relayer ??= getDefaultRelayerAddress(destinationChainId, inputToken.symbol);
     recipient ??= DEFAULT_SIMULATED_RECIPIENT_ADDRESS;
-    if (sdk.utils.isDefined(message)) {
+    const depositWithMessage = sdk.utils.isDefined(message);
+    if (depositWithMessage) {
       validateDepositMessage(
         recipient,
         destinationChainId,
@@ -150,9 +151,6 @@ const handler = async (
       ENABLED_ROUTES.acrossConfigStoreAddress,
       provider
     );
-    const baseCurrency = sdk.utils
-      .getNativeTokenSymbol(destinationChainId)
-      .toLowerCase();
 
     // Aggregate multiple calls into a single multicall to decrease
     // opportunities for RPC calls to be delayed.
@@ -190,10 +188,12 @@ const handler = async (
         outputToken.address,
         computedOriginChainId,
         destinationChainId,
-        amountInput,
-        recipient,
-        relayer,
-        message
+        // Only pass in the following parameters if message is defined, otherwise leave them undefined so we are more
+        // likely to hit the /limits cache using the above parameters that are not specific to this deposit.
+        depositWithMessage ? amountInput : undefined,
+        depositWithMessage ? recipient : undefined,
+        depositWithMessage ? relayer : undefined,
+        depositWithMessage ? message : undefined
       ),
     ]);
     const { maxDeposit, maxDepositInstant, minDeposit, relayerFeeDetails } =

--- a/api/suggested-fees.ts
+++ b/api/suggested-fees.ts
@@ -265,10 +265,14 @@ const handler = async (
       gasPrice
     );
 
-    const skipAmountLimitEnabled = skipAmountLimit === "true";
+    const isAmountTooLow =
+      relayerFeeDetails.isAmountTooLow ||
+      BigNumber.from(amountInput).lt(limits.minDeposit);
 
-    if (!skipAmountLimitEnabled && relayerFeeDetails.isAmountTooLow)
+    const skipAmountLimitEnabled = skipAmountLimit === "true";
+    if (!skipAmountLimitEnabled && isAmountTooLow) {
       throw new InputError("Sent amount is too low relative to fees");
+    }
 
     // Across V3's new `deposit` function requires now a total fee that includes the LP fee
     const totalRelayFee = BigNumber.from(relayerFeeDetails.relayFeeTotal).add(
@@ -312,7 +316,7 @@ const handler = async (
       timestamp: isNaN(parsedTimestamp)
         ? quoteTimestamp.toString()
         : parsedTimestamp.toString(),
-      isAmountTooLow: relayerFeeDetails.isAmountTooLow,
+      isAmountTooLow,
       quoteBlock: quoteBlockNumber.toString(),
       exclusiveRelayer,
       exclusivityDeadline,

--- a/api/suggested-fees.ts
+++ b/api/suggested-fees.ts
@@ -188,9 +188,10 @@ const handler = async (
         outputToken.address,
         computedOriginChainId,
         destinationChainId,
+        // Always pass amount since we get relayerFeeDetails (including gross fee amounts) from limits.
+        amountInput,
         // Only pass in the following parameters if message is defined, otherwise leave them undefined so we are more
         // likely to hit the /limits cache using the above parameters that are not specific to this deposit.
-        depositWithMessage ? amountInput : undefined,
         depositWithMessage ? recipient : undefined,
         depositWithMessage ? relayer : undefined,
         depositWithMessage ? message : undefined


### PR DESCRIPTION
Add the following optional parameters to `/limits` to make it possible to compute the exact same limits in suggested fees:

- message
- recipient
- relayer
- amount

This way the `/suggested-fees` endpoint can query `/limits` using those parameters so it doesn't need to recompute `relayerFeeDetails()` which might return very different values.

I believe this also removes the need for `relayerFeeDetails` to compute the `isAmountTooLow` boolean anymore.