### PR TITLE
perf: cron job for caching relayer balances

### DIFF
--- a/api/_cache.ts
+++ b/api/_cache.ts
@@ -87,8 +87,10 @@ export function makeCacheGetterAndSetter<T>(
     get: async () => {
       return getCachedValue(key, ttl, fetcher, parser);
     },
-    set: async () => {
-      const value = await fetcher();
+    set: async (value?: T) => {
+      if (!value) {
+        value = await fetcher();
+      }
       await redisCache.set(key, value, ttl);
     },
   };

--- a/api/_cache.ts
+++ b/api/_cache.ts
@@ -66,7 +66,7 @@ export async function getCachedValue<T>(
   ttl: number,
   fetcher: () => Promise<T>,
   parser?: (value: T) => T
-) {
+): Promise<T> {
   const cachedValue = await redisCache.get<T>(key);
   if (cachedValue) {
     return parser ? parser(cachedValue) : cachedValue;
@@ -75,4 +75,21 @@ export async function getCachedValue<T>(
   const value = await fetcher();
   await redisCache.set(key, value, ttl);
   return value;
+}
+
+export function makeCacheGetterAndSetter<T>(
+  key: string,
+  ttl: number,
+  fetcher: () => Promise<T>,
+  parser?: (value: T) => T
+) {
+  return {
+    get: async () => {
+      return getCachedValue(key, ttl, fetcher, parser);
+    },
+    set: async () => {
+      const value = await fetcher();
+      await redisCache.set(key, value, ttl);
+    },
+  };
 }

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -1089,11 +1089,11 @@ export const getCachedTokenBalance = async (
   account: string,
   token: string
 ): Promise<BigNumber> => {
-  const balance = await latestBalanceCache(
-    Number(chainId),
-    token,
-    account
-  ).get();
+  const balance = await latestBalanceCache({
+    chainId: Number(chainId),
+    tokenAddress: token,
+    address: account,
+  }).get();
   return balance;
 };
 
@@ -1904,11 +1904,12 @@ export function getCachedLatestBlock(chainId: number) {
   );
 }
 
-export function latestBalanceCache(
-  chainId: number,
-  tokenAddress: string,
-  address: string
-) {
+export function latestBalanceCache(params: {
+  chainId: number;
+  tokenAddress: string;
+  address: string;
+}) {
+  const { chainId, tokenAddress, address } = params;
   const ttlPerChain = {
     default: 60,
     [CHAIN_IDs.MAINNET]: 60,

--- a/api/account-balance.ts
+++ b/api/account-balance.ts
@@ -31,11 +31,11 @@ const handler = async (
 
     let { token, account, chainId } = query;
 
-    const balance = await latestBalanceCache(
-      Number(chainId),
-      token,
-      account
-    ).get();
+    const balance = await latestBalanceCache({
+      chainId: Number(chainId),
+      tokenAddress: token,
+      address: account,
+    }).get();
     const result = {
       balance: balance.toString(),
       account: account,

--- a/api/account-balance.ts
+++ b/api/account-balance.ts
@@ -2,7 +2,7 @@ import { VercelResponse } from "@vercel/node";
 import { assert, Infer, type, string } from "superstruct";
 import { TypedVercelRequest } from "./_types";
 import {
-  getCachedLatestBalance,
+  latestBalanceCache,
   getLogger,
   handleErrorCondition,
   validAddress,
@@ -31,11 +31,11 @@ const handler = async (
 
     let { token, account, chainId } = query;
 
-    const balance = await getCachedLatestBalance(
+    const balance = await latestBalanceCache(
       Number(chainId),
       token,
       account
-    );
+    ).get();
     const result = {
       balance: balance.toString(),
       account: account,

--- a/api/cron-cache-balances.ts
+++ b/api/cron-cache-balances.ts
@@ -12,7 +12,7 @@ import {
 import mainnetChains from "../src/data/chains_1.json";
 
 const handler = async (
-  _: TypedVercelRequest<Record<string, never>>,
+  request: TypedVercelRequest<Record<string, never>>,
   response: VercelResponse
 ) => {
   const logger = getLogger();
@@ -21,6 +21,14 @@ const handler = async (
     message: "Starting cron job...",
   });
   try {
+    const authHeader = (request.headers as any)?.get("authorization");
+    if (
+      !process.env.CRON_SECRET ||
+      authHeader !== `Bearer ${process.env.CRON_SECRET}`
+    ) {
+      return response.status(401).json({ success: false });
+    }
+
     const {
       REACT_APP_FULL_RELAYERS, // These are relayers running a full auto-rebalancing strategy.
       REACT_APP_TRANSFER_RESTRICTED_RELAYERS, // These are relayers whose funds stay put.

--- a/api/cron-cache-balances.ts
+++ b/api/cron-cache-balances.ts
@@ -1,0 +1,69 @@
+import { VercelResponse } from "@vercel/node";
+import { ethers } from "ethers";
+import { TypedVercelRequest } from "./_types";
+
+import {
+  HUB_POOL_CHAIN_ID,
+  getLogger,
+  handleErrorCondition,
+  latestBalanceCache,
+} from "./_utils";
+
+import mainnetChains from "../src/data/chains_1.json";
+
+const handler = async (
+  _: TypedVercelRequest<Record<string, never>>,
+  response: VercelResponse
+) => {
+  const logger = getLogger();
+  logger.debug({
+    at: "CronCacheBalances",
+    message: "Starting cron job...",
+  });
+  try {
+    const {
+      REACT_APP_FULL_RELAYERS, // These are relayers running a full auto-rebalancing strategy.
+      REACT_APP_TRANSFER_RESTRICTED_RELAYERS, // These are relayers whose funds stay put.
+    } = process.env;
+
+    const fullRelayers = !REACT_APP_FULL_RELAYERS
+      ? []
+      : (JSON.parse(REACT_APP_FULL_RELAYERS) as string[]).map((relayer) => {
+          return ethers.utils.getAddress(relayer);
+        });
+    const transferRestrictedRelayers = !REACT_APP_TRANSFER_RESTRICTED_RELAYERS
+      ? []
+      : (JSON.parse(REACT_APP_TRANSFER_RESTRICTED_RELAYERS) as string[]).map(
+          (relayer) => {
+            return ethers.utils.getAddress(relayer);
+          }
+        );
+
+    // Skip cron job on testnet
+    if (HUB_POOL_CHAIN_ID !== 1) {
+      return;
+    }
+
+    for (const chain of mainnetChains) {
+      for (const token of chain.inputTokens) {
+        const setTokenBalance = async (relayer: string) => {
+          await latestBalanceCache(chain.chainId, relayer, token.address).set();
+        };
+        await Promise.all([
+          Promise.all(fullRelayers.map(setTokenBalance)),
+          Promise.all(transferRestrictedRelayers.map(setTokenBalance)),
+        ]);
+      }
+    }
+
+    logger.debug({
+      at: "CronCacheBalances",
+      message: "Finished",
+    });
+    response.status(200);
+  } catch (error: unknown) {
+    return handleErrorCondition("cron-cache-balances", response, logger, error);
+  }
+};
+
+export default handler;

--- a/api/cron-cache-balances.ts
+++ b/api/cron-cache-balances.ts
@@ -4,7 +4,7 @@ import { TypedVercelRequest } from "./_types";
 
 import {
   HUB_POOL_CHAIN_ID,
-  getCachedTokenBalances,
+  getBatchBalanceViaMulticall3,
   getLogger,
   handleErrorCondition,
   latestBalanceCache,
@@ -55,7 +55,7 @@ const handler = async (
 
     const allRelayers = [...fullRelayers, ...transferRestrictedRelayers];
     for (const chain of mainnetChains) {
-      const batchResult = await getCachedTokenBalances(
+      const batchResult = await getBatchBalanceViaMulticall3(
         chain.chainId,
         allRelayers,
         [

--- a/api/cron-cache-balances.ts
+++ b/api/cron-cache-balances.ts
@@ -21,7 +21,7 @@ const handler = async (
     message: "Starting cron job...",
   });
   try {
-    const authHeader = (request.headers as any)?.get("authorization");
+    const authHeader = request.headers?.["authorization"];
     if (
       !process.env.CRON_SECRET ||
       authHeader !== `Bearer ${process.env.CRON_SECRET}`

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,11 @@
 {
   "devCommand": "yarn dev",
+  "crons": [
+    {
+      "path": "/api/cron-cache-balances",
+      "schedule": "* * * * *"
+    }
+  ],
   "rewrites": [
     {
       "source": "/api/deposit/status",


### PR DESCRIPTION
This PR introduces a cron-scheduled handler that aims to keep relayer balances for all tokens on all chains fresh. Theoretically, this should further even out worst-case latencies for /limits and /suggested-fees.

Closes ACX-2661

We could use a similar approach for fairly constant and static values as well, such as `gasPrice`, `fillGasExpenditure`, `latestBlock`, etc. One issue is that Vercel only supports a min. interval of minutes. So for TTL values that are in seconds, we would need to create another external trigger