### PR TITLE
fix: resolve speedup requests on expired deposits

### DIFF
--- a/src/components/DepositsTable/cells/ActionsCell.tsx
+++ b/src/components/DepositsTable/cells/ActionsCell.tsx
@@ -8,7 +8,7 @@ import { Tooltip } from "components/Tooltip";
 import { Deposit } from "hooks/useDeposits";
 import { COLORS } from "utils";
 
-import { useIsProfitableAndDelayed } from "../hooks/useIsProfitableAndDelayed";
+import { useDepositStatus } from "../hooks/useDepositStatus";
 
 type Props = {
   deposit: Deposit;
@@ -16,7 +16,7 @@ type Props = {
 };
 
 export function ActionsCell({ deposit, onClickSpeedUp }: Props) {
-  const { isDelayed, isProfitable } = useIsProfitableAndDelayed(deposit);
+  const { isDelayed, isProfitable, isExpired } = useDepositStatus(deposit);
 
   const slowRelayInfo =
     isDelayed && isProfitable ? (
@@ -43,7 +43,10 @@ export function ActionsCell({ deposit, onClickSpeedUp }: Props) {
   }, [deposit, onClickSpeedUp]);
 
   const speedUp =
-    !isDelayed && !isProfitable && deposit.status === "pending" ? (
+    !isExpired &&
+    !isDelayed &&
+    !isProfitable &&
+    deposit.status === "pending" ? (
       <ZapIconPersistent onClick={handleClickSpeedUp} />
     ) : null;
 

--- a/src/components/DepositsTable/hooks/useDepositStatus.ts
+++ b/src/components/DepositsTable/hooks/useDepositStatus.ts
@@ -10,7 +10,7 @@ import {
 } from "utils";
 import { useBridgeLimits } from "hooks";
 
-export function useIsProfitableAndDelayed(deposit: Deposit) {
+export function useDepositStatus(deposit: Deposit) {
   const { limits } = useBridgeLimits(
     // disable query for filled deposits
     deposit.status === "pending" ? deposit?.token?.symbol : undefined,
@@ -37,8 +37,13 @@ export function useIsProfitableAndDelayed(deposit: Deposit) {
       ? BigNumber.from(deposit.amount).gt(limits?.maxDepositInstant)
       : false;
 
+  const isExpired = deposit.fillDeadline
+    ? DateTime.fromISO(deposit.fillDeadline).diffNow().as("seconds") < 0
+    : false;
+
   return {
     isProfitable,
     isDelayed,
+    isExpired,
   };
 }


### PR DESCRIPTION
Expired deposits no longer display a infinite loader next to the `Expired` status + are ineligible for the speedup modal.