### PR TITLE
chore: remove redundant relayer fees from nested limits field

### DIFF
--- a/api/suggested-fees.ts
+++ b/api/suggested-fees.ts
@@ -305,7 +305,13 @@ const handler = async (
         pct: lpFeePct.toString(),
         total: lpFeeTotal.toString(),
       },
-      limits,
+      limits: {
+        minDeposit,
+        maxDeposit,
+        maxDepositInstant,
+        maxDepositShortDelay: limits.maxDepositShortDelay,
+        recommendedDepositInstant: limits.recommendedDepositInstant,
+      },
     };
 
     logger.debug({


### PR DESCRIPTION
We don't need to expose the relayer fee details in the `suggested-fees.limits` field due to redundancy