### PR TITLE
fix: handle empty addresses query param

### DIFF
--- a/api/_exclusivity/index.ts
+++ b/api/_exclusivity/index.ts
@@ -89,6 +89,10 @@ async function getEligibleRelayers(
   // Source all relayers that have opted in for this destination chain.
   const relayers = getRelayerConfig(originChainId);
 
+  if (relayers.length === 0) {
+    return [];
+  }
+
   // @todo: Balances are returned as strings; consider mapping them automagically to BNs.
   const { balances } = await getCachedTokenBalances(
     destinationChainId,

--- a/api/batch-account-balance.ts
+++ b/api/batch-account-balance.ts
@@ -5,6 +5,7 @@ import {
   getBatchBalanceViaMulticall3,
   getLogger,
   handleErrorCondition,
+  InputError,
   validAddress,
 } from "./_utils";
 
@@ -74,14 +75,26 @@ const handler = async (
     // Validate the query parameters
     assert(query, BatchAccountBalanceQueryParamsSchema);
 
-    const { chainId, addresses, tokenAddresses } = query;
+    const {
+      chainId,
+      addresses: _addresses,
+      tokenAddresses: _tokenAddresses,
+    } = query;
 
     const chainIdAsInt = Number(chainId);
+    const addresses = paramToArray(_addresses);
+    const tokenAddresses = paramToArray(_tokenAddresses);
+
+    if (addresses.length === 0 || tokenAddresses.length === 0) {
+      throw new InputError(
+        "Params 'addresses' and 'tokenAddresses' must not be empty"
+      );
+    }
 
     const result = await getBatchBalanceViaMulticall3(
       chainIdAsInt,
-      paramToArray(addresses),
-      paramToArray(tokenAddresses)
+      addresses,
+      tokenAddresses
     );
 
     const data: BatchAccountBalanceResponse = {


### PR DESCRIPTION
Fixes ACX-2700

I noticed a few 500 response codes in our monitoring tool when calling /suggested-fees. It seems that these happen when exclusivity is set but there is no relayer opted in for a specific origin chain