### PR TITLE
fix(exclusivity): Require depositMethod=depositExclusive for exclusivity

### DIFF
--- a/api/suggested-fees.ts
+++ b/api/suggested-fees.ts
@@ -257,18 +257,20 @@ const handler = async (
           amountInUsd
         );
 
-    const { exclusiveRelayer, exclusivityPeriod } =
-      await selectExclusiveRelayer(
-        computedOriginChainId,
-        destinationChainId,
-        outputToken,
-        amount.sub(totalRelayFee),
-        amountInUsd,
-        BigNumber.from(relayerFeeDetails.capitalFeePercent),
-        estimatedFillTimeSec
-      );
-    const exclusivityDeadline =
-      depositMethod === "depositExclusive" ? exclusivityPeriod : 0;
+    let exclusiveRelayer = sdk.constants.ZERO_ADDRESS;
+    let exclusivityDeadline = 0;
+    if (depositMethod === "depositExclusive") {
+      ({ exclusiveRelayer, exclusivityPeriod: exclusivityDeadline } =
+        await selectExclusiveRelayer(
+          computedOriginChainId,
+          destinationChainId,
+          outputToken,
+          amount.sub(totalRelayFee),
+          amountInUsd,
+          BigNumber.from(relayerFeeDetails.capitalFeePercent),
+          estimatedFillTimeSec
+        ));
+    }
 
     const responseJson = {
       estimatedFillTimeSec,


### PR DESCRIPTION
This exisiting logic can return an exclusive relayer with exclusivityDeadline 0, which is a no-go for depositV3().