### PR TITLE
allow filtering by chainId or list of chainIds

### DIFF
--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -2008,6 +2008,7 @@ export function buildSearchParams(
   const searchParams = new URLSearchParams();
   for (const key in params) {
     const value = params[key];
+    if (!value) continue;
     if (Array.isArray(value)) {
       value.forEach((val) => searchParams.append(key, String(val)));
     } else {
@@ -2015,4 +2016,11 @@ export function buildSearchParams(
     }
   }
   return searchParams.toString();
+}
+
+export function paramToArray<T extends undefined | string | string[]>(
+  param: T
+): string[] | undefined {
+  if (!param) return;
+  return Array.isArray(param) ? param : [param];
 }

--- a/api/batch-account-balance.ts
+++ b/api/batch-account-balance.ts
@@ -5,6 +5,7 @@ import {
   getBatchBalanceViaMulticall3,
   getLogger,
   handleErrorCondition,
+  paramToArray,
   validAddress,
 } from "./_utils";
 import { InvalidParamError } from "./_errors";
@@ -24,10 +25,6 @@ export type BatchAccountBalanceResponse = Awaited<
 > & {
   chainId: number;
 };
-
-function paramToArray(param: string | string[]): string[] {
-  return Array.isArray(param) ? param : [param];
-}
 
 /**
  * ## Description
@@ -85,7 +82,7 @@ const handler = async (
     const addresses = paramToArray(_addresses);
     const tokenAddresses = paramToArray(_tokenAddresses);
 
-    if (addresses.length === 0 || tokenAddresses.length === 0) {
+    if (!addresses || !tokenAddresses) {
       throw new InvalidParamError({
         message: "Params 'addresses' and 'tokenAddresses' must not be empty",
       });


### PR DESCRIPTION
closes ACX-2842

- allows consumer to filter /chains response by list of chainIds. this means the sdk can easily retrieve and cache chain specific data (spokePool address etc.)