### PR TITLE
improve: Isolate host time from deposit fillDeadline

### DIFF
--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -1577,7 +1577,7 @@ export function getBaseRewardsApr(
  * @returns An array of the decoded results in the same order that they were passed in.
  */
 export async function callViaMulticall3(
-  provider: ethers.providers.Provider,
+  provider: ethers.providers.JsonRpcProvider,
   calls: {
     contract: ethers.Contract;
     functionName: string;

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -1577,7 +1577,7 @@ export function getBaseRewardsApr(
  * @returns An array of the decoded results in the same order that they were passed in.
  */
 export async function callViaMulticall3(
-  provider: ethers.providers.JsonRpcProvider,
+  provider: ethers.providers.Provider,
   calls: {
     contract: ethers.Contract;
     functionName: string;

--- a/src/utils/bridge.ts
+++ b/src/utils/bridge.ts
@@ -1,6 +1,4 @@
 import { ethers, BigNumber } from "ethers";
-
-import { callViaMulticall3 } from "../../api/_utils";
 import {
   ChainId,
   fixedPointAdjustment,
@@ -427,19 +425,12 @@ export async function getSpokePoolAndVerifier({
 
 async function getFillDeadline(spokePool: SpokePool): Promise<number> {
   const calls = [
-    {
-      contract: spokePool,
-      functionName: "getCurrentTime",
-    },
-    {
-      contract: spokePool,
-      functionName: "fillDeadlineBuffer",
-    },
+    spokePool.interface.encodeFunctionData("getCurrentTime"),
+    spokePool.interface.encodeFunctionData("fillDeadlineBuffer"),
   ];
-  const [currentTime, fillDeadlineBuffer] = await callViaMulticall3(
-    spokePool.provider,
-    calls
-  );
+
+  const [currentTime, fillDeadlineBuffer] =
+    await spokePool.callStatic.multicall(calls);
   return Number(currentTime) + Number(fillDeadlineBuffer);
 }
 

--- a/src/utils/bridge.ts
+++ b/src/utils/bridge.ts
@@ -7,7 +7,7 @@ import {
 } from "./constants";
 import { DOMAIN_CALLDATA_DELIMITER, tagAddress, tagHex } from "./format";
 import { getProvider } from "./providers";
-import { getConfig, getCurrentTime, isContractDeployedToAddress } from "utils";
+import { getConfig, isContractDeployedToAddress } from "utils";
 import getApiEndpoint from "./serverless-api";
 import { BridgeLimitInterface } from "./serverless-api/types";
 import { DepositNetworkMismatchProperties } from "ampli";

--- a/src/utils/bridge.ts
+++ b/src/utils/bridge.ts
@@ -1,4 +1,5 @@
 import { ethers, BigNumber } from "ethers";
+
 import { callViaMulticall3 } from "../../api/_utils";
 import {
   ChainId,


### PR DESCRIPTION
If the host time is out of sync with the origin chain time then it may be possible to set fillDeadline such that it would revert on simulation. Per existing implementation, this could occur if the RPC time was > 60 seconds behind the host time, or if the host time was > 60 seconds ahead. Using the time of the chain and the fillDeadlineBuffer offset should protect against this possibility.