### PR TITLE
fix casing of zksync logo served from /chains

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "generate:routes": "tsx scripts/generate-routes.ts",
     "generate:routes:e2e": "tsx scripts/generate-e2e-test-routes.ts",
     "generate:routes:mainnet": "yarn generate:routes 1",
+    "generate:routes:testnet": "yarn generate:routes 11155111",
     "generate:chain-config": "tsx scripts/generate-chain-config.ts",
     "generate:ui-assets": "tsx scripts/generate-ui-assets.ts"
   },

--- a/scripts/generate-routes.ts
+++ b/scripts/generate-routes.ts
@@ -3,7 +3,7 @@ import { utils as sdkUtils } from "@across-protocol/sdk";
 import { utils } from "ethers";
 import { writeFileSync } from "fs";
 import * as prettier from "prettier";
-
+import path from "path";
 import * as chainConfigs from "./chain-configs";
 
 function getDeployedAddress(contractName: string, chainId: number): string {
@@ -413,7 +413,7 @@ async function generateRoutes(hubPoolChainId = 1) {
       name: chainConfig.name,
       publicRpcUrl: chainConfig.publicRpcUrl,
       explorerUrl: chainConfig.blockExplorer,
-      logoUrl: `${assetsBaseUrl}/scripts/chain-configs/${chainKey.toLowerCase()}/assets/logo.svg`,
+      logoUrl: `${assetsBaseUrl}${path.resolve("/scripts/chain-configs/", chainKey.toLowerCase().replace("_", "-"), chainConfig.logoPath)}`,
       spokePool: chainConfig.spokePool.address,
       spokePoolBlock: chainConfig.spokePool.blockNumber,
       inputTokens: routeFileContent.routes

--- a/src/components/AmountInput/AmountInput.tsx
+++ b/src/components/AmountInput/AmountInput.tsx
@@ -66,6 +66,7 @@ export function AmountInput({
         ) : null}
         <Input
           type="number"
+          inputMode="numeric"
           valid={isAmountValid}
           placeholder="Enter amount"
           value={amountInput}

--- a/src/components/AmountInput/AmountInput.tsx
+++ b/src/components/AmountInput/AmountInput.tsx
@@ -66,7 +66,7 @@ export function AmountInput({
         ) : null}
         <Input
           type="number"
-          inputMode="numeric"
+          inputMode="decimal"
           valid={isAmountValid}
           placeholder="Enter amount"
           value={amountInput}

--- a/src/components/AmountInput/AmountInput.tsx
+++ b/src/components/AmountInput/AmountInput.tsx
@@ -66,7 +66,6 @@ export function AmountInput({
         ) : null}
         <Input
           type="number"
-          inputMode="decimal"
           valid={isAmountValid}
           placeholder="Enter amount"
           value={amountInput}

--- a/src/data/chains_1.json
+++ b/src/data/chains_1.json
@@ -672,7 +672,7 @@
     "name": "zkSync",
     "publicRpcUrl": "https://mainnet.era.zksync.io",
     "explorerUrl": "https://era.zksync.network",
-    "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/scripts/chain-configs/zk_sync/assets/logo.svg",
+    "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/scripts/chain-configs/zk-sync/assets/logo.svg",
     "spokePool": "0xE0B015E54d54fc84a6cB9B666099c46adE9335FF",
     "spokePoolBlock": 10352565,
     "inputTokens": [
@@ -1384,7 +1384,7 @@
     "name": "World Chain",
     "publicRpcUrl": "https://worldchain-mainnet.g.alchemy.com/public",
     "explorerUrl": "https://worldchain-mainnet-explorer.alchemy.com",
-    "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/scripts/chain-configs/world_chain/assets/logo.svg",
+    "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/scripts/chain-configs/world-chain/assets/logo.svg",
     "spokePool": "0x09aea4b2242abC8bb4BB78D537A67a245A7bEC64",
     "spokePoolBlock": 4524742,
     "inputTokens": [

--- a/src/data/chains_11155111.json
+++ b/src/data/chains_11155111.json
@@ -4,7 +4,7 @@
     "name": "Sepolia",
     "publicRpcUrl": "https://gateway.tenderly.co/public/sepolia",
     "explorerUrl": "https://sepolia.etherscan.io",
-    "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/scripts/chain-configs/sepolia/assets/logo.svg",
+    "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/scripts/chain-configs/mainnet/assets/logo.svg",
     "spokePool": "0x5ef6C01E11889d86803e0B23e3cB3F9E9d97B662",
     "spokePoolBlock": 5288470,
     "inputTokens": [
@@ -59,7 +59,7 @@
     "name": "Base Sepolia",
     "publicRpcUrl": "https://sepolia.base.org",
     "explorerUrl": "https://sepolia.basescan.org",
-    "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/scripts/chain-configs/base_sepolia/assets/logo.svg",
+    "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/scripts/chain-configs/base/assets/logo.svg",
     "spokePool": "0x82B564983aE7274c86695917BBf8C99ECb6F0F8F",
     "spokePoolBlock": 6082004,
     "inputTokens": [
@@ -121,7 +121,7 @@
     "name": "Arbitrum Sepolia",
     "publicRpcUrl": "https://sepolia-rollup.arbitrum.io/rpc",
     "explorerUrl": "https://sepolia.arbiscan.io",
-    "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/scripts/chain-configs/arbitrum_sepolia/assets/logo.svg",
+    "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/scripts/chain-configs/arbitrum/assets/logo.svg",
     "spokePool": "0x7E63A5f1a8F0B4d0934B2f2327DAED3F6bb2ee75",
     "spokePoolBlock": 12411026,
     "inputTokens": [
@@ -176,7 +176,7 @@
     "name": "Optimism Sepolia",
     "publicRpcUrl": "https://sepolia.optimism.io",
     "explorerUrl": "https://sepolia-optimism.etherscan.io",
-    "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/scripts/chain-configs/optimism_sepolia/assets/logo.svg",
+    "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/scripts/chain-configs/optimism/assets/logo.svg",
     "spokePool": "0x4e8E101924eDE233C13e2D8622DC8aED2872d505",
     "spokePoolBlock": 7762656,
     "inputTokens": [],
@@ -187,7 +187,7 @@
     "name": "Mode Sepolia",
     "publicRpcUrl": "https://sepolia.mode.network",
     "explorerUrl": "https://sepolia.explorer.mode.network",
-    "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/scripts/chain-configs/mode_sepolia/assets/logo.svg",
+    "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/scripts/chain-configs/mode/assets/logo.svg",
     "spokePool": "0xbd886FC0725Cc459b55BbFEb3E4278610331f83b",
     "spokePoolBlock": 13999465,
     "inputTokens": [
@@ -228,7 +228,7 @@
     "name": "Polygon Amoy",
     "publicRpcUrl": "https://rpc-amoy.polygon.technology",
     "explorerUrl": "https://amoy.polygonscan.com",
-    "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/scripts/chain-configs/polygon_amoy/assets/logo.svg",
+    "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/scripts/chain-configs/polygon/assets/logo.svg",
     "spokePool": "0xd08baaE74D6d2eAb1F3320B2E1a53eeb391ce8e5",
     "spokePoolBlock": 7529960,
     "inputTokens": [
@@ -262,7 +262,7 @@
     "name": "Blast Sepolia",
     "publicRpcUrl": "https://sepolia.blast.io",
     "explorerUrl": "https://sepolia.blastscan.io",
-    "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/scripts/chain-configs/blast_sepolia/assets/logo.svg",
+    "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/scripts/chain-configs/blast/assets/logo.svg",
     "spokePool": "0x5545092553Cf5Bf786e87a87192E902D50D8f022",
     "spokePoolBlock": 7634204,
     "inputTokens": [
@@ -303,7 +303,7 @@
     "name": "Lisk Sepolia",
     "publicRpcUrl": "https://rpc.sepolia-api.lisk.com",
     "explorerUrl": "https://sepolia-blockscout.lisk.com",
-    "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/scripts/chain-configs/lisk_sepolia/assets/logo.svg",
+    "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/scripts/chain-configs/lisk/assets/logo.svg",
     "spokePool": "0xeF684C38F94F48775959ECf2012D7E864ffb9dd4",
     "spokePoolBlock": 7267988,
     "inputTokens": [


### PR DESCRIPTION
closes ACX-2707

- find the relative path of the logo in `chainConfig` and resolves it. testnet chains do not have duplicate assets so this will direct base-sepolia to base/assets/logo.svg. 
- directories for multi word names use dashes (-) as separator, while we export the chainConfig map keys with underscores. when resolving the path we need to replace underscores with dashes. this fixes the zksync logo resolution