### PR TITLE
serve logos for bridged usdc

### DIFF
--- a/scripts/generate-routes.ts
+++ b/scripts/generate-routes.ts
@@ -6,6 +6,17 @@ import * as prettier from "prettier";
 import path from "path";
 import * as chainConfigs from "./chain-configs";
 
+function getTokenSymbolForLogo(tokenSymbol: string): string {
+  switch (tokenSymbol) {
+    case "USDC.e":
+    case "USDbC":
+    case "USDzC":
+      return "USDC";
+    default:
+      return tokenSymbol;
+  }
+}
+
 function getDeployedAddress(contractName: string, chainId: number): string {
   return sdkUtils.getDeployedAddress(contractName, chainId, true) as string;
 }
@@ -400,7 +411,7 @@ async function generateRoutes(hubPoolChainId = 1) {
         symbol: tokenSymbol,
         name: tokenInfo.name,
         decimals: tokenInfo.decimals,
-        logoUrl: `${assetsBaseUrl}/src/assets/token-logos/${tokenSymbol.toLowerCase()}.svg`,
+        logoUrl: `${assetsBaseUrl}/src/assets/token-logos/${getTokenSymbolForLogo(tokenSymbol).toLowerCase()}.svg`,
       };
     };
     return {

--- a/src/data/chains_1.json
+++ b/src/data/chains_1.json
@@ -294,7 +294,7 @@
         "symbol": "USDC.e",
         "name": "USD Coin (bridged)",
         "decimals": 6,
-        "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/src/assets/token-logos/usdc.e.svg"
+        "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/src/assets/token-logos/usdc.svg"
       },
       {
         "address": "0x68f180fcCe6836688e9084f035309E29Bf0A2095",
@@ -454,7 +454,7 @@
         "symbol": "USDC.e",
         "name": "USD Coin (bridged)",
         "decimals": 6,
-        "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/src/assets/token-logos/usdc.e.svg"
+        "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/src/assets/token-logos/usdc.svg"
       },
       {
         "address": "0x1BFD67037B42Cf73acF2047067bd4F2C47D9BfD6",
@@ -614,7 +614,7 @@
         "symbol": "USDC.e",
         "name": "USD Coin (bridged)",
         "decimals": 6,
-        "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/src/assets/token-logos/usdc.e.svg"
+        "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/src/assets/token-logos/usdc.svg"
       },
       {
         "address": "0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f",
@@ -695,7 +695,7 @@
         "symbol": "USDC.e",
         "name": "USD Coin (bridged)",
         "decimals": 6,
-        "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/src/assets/token-logos/usdc.e.svg"
+        "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/src/assets/token-logos/usdc.svg"
       },
       {
         "address": "0xBBeB516fb02a01611cBBE0453Fe3c580D7281011",
@@ -739,7 +739,7 @@
         "symbol": "USDC.e",
         "name": "USD Coin (bridged)",
         "decimals": 6,
-        "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/src/assets/token-logos/usdc.e.svg"
+        "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/src/assets/token-logos/usdc.svg"
       },
       {
         "address": "0xBBeB516fb02a01611cBBE0453Fe3c580D7281011",
@@ -843,7 +843,7 @@
         "symbol": "USDbC",
         "name": "USD Coin (bridged)",
         "decimals": 6,
-        "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/src/assets/token-logos/usdbc.svg"
+        "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/src/assets/token-logos/usdc.svg"
       },
       {
         "address": "0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb",
@@ -896,7 +896,7 @@
         "symbol": "USDC.e",
         "name": "USD Coin (bridged)",
         "decimals": 6,
-        "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/src/assets/token-logos/usdc.e.svg"
+        "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/src/assets/token-logos/usdc.svg"
       },
       {
         "address": "0xA219439258ca9da29E9Cc4cE5596924745e12B93",
@@ -940,7 +940,7 @@
         "symbol": "USDC.e",
         "name": "USD Coin (bridged)",
         "decimals": 6,
-        "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/src/assets/token-logos/usdc.e.svg"
+        "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/src/assets/token-logos/usdc.svg"
       },
       {
         "address": "0x3aAB2285ddcDdaD8edf438C1bAB47e1a9D05a9b4",
@@ -993,7 +993,7 @@
         "symbol": "USDC.e",
         "name": "USD Coin (bridged)",
         "decimals": 6,
-        "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/src/assets/token-logos/usdc.e.svg"
+        "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/src/assets/token-logos/usdc.svg"
       },
       {
         "address": "0xf0F161fDA2712DB8b566946122a5af183995e2eD",
@@ -1030,7 +1030,7 @@
         "symbol": "USDC.e",
         "name": "USD Coin (bridged)",
         "decimals": 6,
-        "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/src/assets/token-logos/usdc.e.svg"
+        "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/src/assets/token-logos/usdc.svg"
       },
       {
         "address": "0xcDd475325D6F564d27247D1DddBb0DAc6fA0a5CF",
@@ -1352,7 +1352,7 @@
         "symbol": "USDzC",
         "name": "USD Coin (bridged)",
         "decimals": 6,
-        "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/src/assets/token-logos/usdzc.svg"
+        "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/src/assets/token-logos/usdc.svg"
       }
     ],
     "outputTokens": [
@@ -1375,7 +1375,7 @@
         "symbol": "USDzC",
         "name": "USD Coin (bridged)",
         "decimals": 6,
-        "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/src/assets/token-logos/usdzc.svg"
+        "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/src/assets/token-logos/usdc.svg"
       }
     ]
   },
@@ -1414,7 +1414,7 @@
         "symbol": "USDC.e",
         "name": "USD Coin (bridged)",
         "decimals": 6,
-        "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/src/assets/token-logos/usdc.e.svg"
+        "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/src/assets/token-logos/usdc.svg"
       }
     ],
     "outputTokens": [
@@ -1437,7 +1437,7 @@
         "symbol": "USDC.e",
         "name": "USD Coin (bridged)",
         "decimals": 6,
-        "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/src/assets/token-logos/usdc.e.svg"
+        "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/src/assets/token-logos/usdc.svg"
       },
       {
         "address": "0x03C7054BCB39f7b2e5B2c7AcB37583e32D70Cfa3",

--- a/src/data/chains_11155111.json
+++ b/src/data/chains_11155111.json
@@ -112,7 +112,7 @@
         "symbol": "USDbC",
         "name": "USD Coin (bridged)",
         "decimals": 6,
-        "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/src/assets/token-logos/usdbc.svg"
+        "logoUrl": "https://raw.githubusercontent.com/across-protocol/frontend/master/src/assets/token-logos/usdc.svg"
       }
     ]
   },


### PR DESCRIPTION
Some integrators using our /chains endpoint noticed tokenLogos don't resolve for USDC.e for example.
