### PR TITLE
get token details for any address in any chainId

### DIFF
--- a/api/_errors.ts
+++ b/api/_errors.ts
@@ -74,6 +74,15 @@ export class AcrossApiError extends Error {
   }
 }
 
+export class TokenNotFoundError extends AcrossApiError {
+  constructor(args: { address: string; chainId: number; opts?: ErrorOptions }) {
+    super({
+      message: `Unable to find tokenDetails for address: ${args.address}, on chain with id: ${args.chainId}`,
+      status: HttpErrorToStatusCode.NOT_FOUND,
+    });
+  }
+}
+
 export class UnauthorizedError extends AcrossApiError {
   constructor(args?: { message: string }, opts?: ErrorOptions) {
     super(

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -2003,7 +2003,7 @@ const TTL_TOKEN_INFO = 30 * 24 * 60 * 60; // 30 days
 
 function tokenInfoCache(params: TokenOptions) {
   return makeCacheGetterAndSetter(
-    buildInternalCacheKey("tokenInfo", ...Object.values(params)),
+    buildInternalCacheKey("tokenInfo", params.address, params.chainId),
     TTL_TOKEN_INFO,
     () => getTokenInfo(params),
     (tokenDetails) => tokenDetails

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -65,7 +65,6 @@ import {
   InvalidParamError,
   RouteNotEnabledError,
 } from "./_errors";
-import { ZERO_ADDRESS } from "@across-protocol/sdk/dist/esm/constants";
 
 export { InputError, handleErrorCondition } from "./_errors";
 
@@ -2014,45 +2013,12 @@ export async function getCachedTokenInfo(params: TokenOptions) {
   return tokenInfoCache(params).get();
 }
 
-async function getNativeTokenInfo(
-  chainId: number
-): Promise<Pick<TokenInfo, "decimals" | "symbol"> | undefined> {
-  const res = await fetch("https://chainid.network/chains.json");
-  const data = (await res.json()) as Array<{
-    chainId: number;
-    nativeCurrency: {
-      name: string;
-      symbol: string;
-      decimals: number;
-    };
-  }>;
-
-  return data.find((chain) => chain.chainId === chainId)?.nativeCurrency;
-}
-
 // find decimals and symbol for any token address on any chain.
-// assumes zero address for native tokens
 export async function getTokenInfo({
   chainId,
   address,
 }: TokenOptions): Promise<Omit<TokenInfo, "addresses" | "name">> {
   try {
-    // NATIVE
-    if (address === ZERO_ADDRESS) {
-      const nativeTokenInfo = await getNativeTokenInfo(chainId);
-
-      if (!nativeTokenInfo) {
-        throw new Error(
-          `No native token found for chain ${chainId} on https://chainid.network`
-        );
-      }
-
-      return {
-        ...nativeTokenInfo,
-        address,
-      };
-    }
-
     // ERC20 resolved statically
     const token = Object.values(TOKEN_SYMBOLS_MAP).find((token) =>
       Boolean(

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -2090,7 +2090,7 @@ export async function getTokenInfo({
     throw new Error(
       `Unable to find tokenDetails for address: ${address}, on chain with id: ${chainId}`,
       {
-        cause: err instanceof Error && err.cause,
+        cause: err instanceof Error && err,
       }
     );
   }

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -2022,6 +2022,20 @@ export async function getTokenInfo({
   Pick<TokenInfo, "address" | "name" | "symbol" | "decimals">
 > {
   try {
+    if (!ethers.utils.isAddress(address)) {
+      throw new InvalidParamError({
+        param: "address",
+        message: '"Address" must be a valid ethereum address',
+      });
+    }
+
+    if (!Number.isSafeInteger(chainId) || chainId < 0) {
+      throw new InvalidParamError({
+        param: "chainId",
+        message: '"chainId" must be a positive integer',
+      });
+    }
+
     // ERC20 resolved statically
     const token = Object.values(TOKEN_SYMBOLS_MAP).find((token) =>
       Boolean(
@@ -2076,6 +2090,9 @@ export async function getTokenInfo({
     throw new TokenNotFoundError({
       chainId,
       address,
+      opts: {
+        cause: error,
+      },
     });
   }
 }


### PR DESCRIPTION
closes ACX-3284

While calculating swap routes using uniswap's sdk, we need to find the token symbol and decimals for any token address on any chain,
Since there is no on-chain way of getting the token symbol for a native token, we need to use an external api. we can use that exposed by chainlist.org and cache any values for a pretty long ttl.

