### PR TITLE
improve: swap deposit exclusive with depositV3

### DIFF
--- a/api/_exclusivity/index.ts
+++ b/api/_exclusivity/index.ts
@@ -1,13 +1,14 @@
 import { ethers } from "ethers";
 import * as sdk from "@across-protocol/sdk";
-import { getCachedTokenBalances } from "../_utils";
+import { getCachedTokenBalances, getCachedLatestBlock } from "../_utils";
 import { getExclusivityPeriod, getRelayerConfig, getStrategy } from "./config";
 import { ExclusiveRelayer } from "./types";
 
 type BigNumber = ethers.BigNumber;
 const { parseUnits } = ethers.utils;
-const { ZERO_ADDRESS } = sdk.constants;
+const { ZERO_ADDRESS, CHAIN_IDs } = sdk.constants;
 const { fixedPointAdjustment: fixedPoint } = sdk.utils;
+const REORG_CHAINS = [CHAIN_IDs.MAINNET, CHAIN_IDs.POLYGON, CHAIN_IDs.SCROLL];
 
 /**
  * Select a specific relayer exclusivity strategy to apply.
@@ -45,7 +46,7 @@ export async function selectExclusiveRelayer(
     return { exclusiveRelayer, exclusivityPeriod };
   }
 
-  const exclusivityPeriodSec = getExclusivityPeriod(estimatedFillTimeSec);
+  let exclusivityPeriodSec = getExclusivityPeriod(estimatedFillTimeSec);
   const relayers = await getEligibleRelayers(
     originChainId,
     destinationChainId,
@@ -57,6 +58,12 @@ export async function selectExclusiveRelayer(
   );
 
   if (relayers.length > 0) {
+    // Only get the latest block if we are doing an exclusive relay and on a chain which re-orgs.
+    if (REORG_CHAINS.includes(originChainId)) {
+      const currentBlock = await getCachedLatestBlock(originChainId);
+      exclusivityPeriodSec += currentBlock.timestamp;
+    }
+
     exclusiveRelayer = selectorFn(relayers);
     exclusivityPeriod =
       exclusiveRelayer === ZERO_ADDRESS ? 0 : exclusivityPeriodSec;

--- a/src/utils/bridge.ts
+++ b/src/utils/bridge.ts
@@ -237,10 +237,6 @@ export async function sendDepositV3Tx(
   );
   fillDeadline ??= await getFillDeadline(spokePool);
 
-  const useExclusiveRelayer =
-    exclusiveRelayer !== ethers.constants.AddressZero &&
-    exclusivityDeadline > 0;
-
   const depositArgs = [
     await signer.getAddress(),
     recipient,
@@ -257,9 +253,7 @@ export async function sendDepositV3Tx(
     { value },
   ] as const;
 
-  const tx = useExclusiveRelayer
-    ? await spokePool.populateTransaction.depositExclusive(...depositArgs)
-    : await spokePool.populateTransaction.depositV3(...depositArgs);
+  const tx = await spokePool.populateTransaction.depositV3(...depositArgs);
 
   return _tagRefAndSignTx(
     tx,

--- a/src/utils/serverless-api/prod/suggested-fees.prod.ts
+++ b/src/utils/serverless-api/prod/suggested-fees.prod.ts
@@ -28,7 +28,7 @@ export async function suggestedFeesApiCall(
       recipient: recipientAddress,
       amount: amount.toString(),
       skipAmountLimit: true,
-      depositMethod: "depositExclusive",
+      depositMethod: "depositV3",
     },
   });
   const result = response.data;


### PR DESCRIPTION
Once the spoke pools are upgraded with the most recent audit changes, we will want to stop using deposit exclusive and start using depositV3. This also means we need to pass in the exclusivity parameter as either an offset or a timestamp, depending on whether the origin chain re-orgs.