### PR TITLE
feat: use trading api + support universal router

### DIFF
--- a/api/_dexes/cross-swap.ts
+++ b/api/_dexes/cross-swap.ts
@@ -14,7 +14,7 @@ import {
   getUniswapCrossSwapQuotesForOutputA2B,
   getUniswapCrossSwapQuotesForOutputB2A,
 } from "./uniswap/quote-resolver";
-import { getUniversalRouterStrategy } from "./uniswap/universal-router";
+import { getSwapRouter02Strategy } from "./uniswap/swap-router-02";
 import { UniswapQuoteFetchStrategy } from "./uniswap/utils";
 import { CrossSwap, CrossSwapQuotes } from "./types";
 import {
@@ -54,7 +54,7 @@ export const LEFTOVER_TYPE = {
 export const PREFERRED_BRIDGE_TOKENS = ["WETH"];
 
 const defaultQuoteFetchStrategy: UniswapQuoteFetchStrategy =
-  getUniversalRouterStrategy();
+  getSwapRouter02Strategy();
 const strategyOverrides = {
   [CHAIN_IDs.BLAST]: defaultQuoteFetchStrategy,
 };
@@ -202,16 +202,17 @@ export async function buildCrossSwapTxForAllowanceHolder(
 ) {
   const originChainId = crossSwapQuotes.crossSwap.inputToken.chainId;
   const spokePool = getSpokePool(originChainId);
-  const spokePoolPeriphery = getSpokePoolPeriphery(
-    "uniswap-universalRouter",
-    originChainId
-  );
+
   const deposit = await extractDepositDataStruct(crossSwapQuotes);
 
   let tx: PopulatedTransaction;
   let toAddress: string;
 
   if (crossSwapQuotes.originSwapQuote) {
+    const spokePoolPeriphery = getSpokePoolPeriphery(
+      crossSwapQuotes.originSwapQuote.peripheryAddress,
+      originChainId
+    );
     tx = await spokePoolPeriphery.populateTransaction.swapAndBridge(
       crossSwapQuotes.originSwapQuote.tokenIn.address,
       crossSwapQuotes.originSwapQuote.tokenOut.address,

--- a/api/_dexes/cross-swap.ts
+++ b/api/_dexes/cross-swap.ts
@@ -51,7 +51,7 @@ export const LEFTOVER_TYPE = {
   BRIDGEABLE_TOKEN: "bridgeableToken",
 } as const;
 
-export const PREFERRED_BRIDGE_TOKENS = ["WETH", "USDC"];
+export const PREFERRED_BRIDGE_TOKENS = ["WETH"];
 
 const defaultQuoteFetchStrategy: UniswapQuoteFetchStrategy =
   getUniversalRouterStrategy();

--- a/api/_dexes/cross-swap.ts
+++ b/api/_dexes/cross-swap.ts
@@ -159,7 +159,7 @@ export async function getCrossSwapQuotesForOutputA2A(crossSwap: CrossSwap) {
     getQuoteFetchStrategy(crossSwap.outputToken.chainId),
     {
       preferredBridgeTokens: PREFERRED_BRIDGE_TOKENS,
-      bridgeRoutesLimit: 2,
+      bridgeRoutesLimit: 1,
     }
   );
 }

--- a/api/_dexes/types.ts
+++ b/api/_dexes/types.ts
@@ -76,7 +76,9 @@ export type CrossSwapQuotes = {
     suggestedFees: Awaited<ReturnType<typeof getSuggestedFees>>;
   };
   destinationSwapQuote?: SwapQuote;
-  originSwapQuote?: SwapQuote;
+  originSwapQuote?: SwapQuote & {
+    peripheryAddress: string;
+  };
 };
 
 export type CrossSwapQuotesWithFees = CrossSwapQuotes & {

--- a/api/_dexes/uniswap/adapter.ts
+++ b/api/_dexes/uniswap/adapter.ts
@@ -1,0 +1,252 @@
+import { MixedRouteSDK, Trade as RouterTrade } from "@uniswap/router-sdk";
+import {
+  Currency,
+  CurrencyAmount,
+  Ether,
+  Token,
+  TradeType,
+} from "@uniswap/sdk-core";
+import { Pair, Route as V2Route } from "@uniswap/v2-sdk";
+import { Pool, Route as V3Route, FeeAmount } from "@uniswap/v3-sdk";
+import { BigNumber } from "ethers";
+
+export type TokenInRoute = {
+  address: string;
+  chainId: number;
+  symbol: string;
+  decimals: string;
+  name?: string;
+  buyFeeBps?: string;
+  sellFeeBps?: string;
+};
+
+export enum PoolType {
+  V2Pool = "v2-pool",
+  V3Pool = "v3-pool",
+  V4Pool = "v4-pool",
+}
+
+export type V2Reserve = {
+  token: TokenInRoute;
+  quotient: string;
+};
+
+export type V2PoolInRoute = {
+  type: PoolType.V2Pool;
+  address?: string;
+  tokenIn: TokenInRoute;
+  tokenOut: TokenInRoute;
+  reserve0: V2Reserve;
+  reserve1: V2Reserve;
+  amountIn?: string;
+  amountOut?: string;
+};
+
+export type V3PoolInRoute = {
+  type: PoolType.V3Pool;
+  address?: string;
+  tokenIn: TokenInRoute;
+  tokenOut: TokenInRoute;
+  sqrtRatioX96: string;
+  liquidity: string;
+  tickCurrent: string;
+  fee: string;
+  amountIn?: string;
+  amountOut?: string;
+};
+
+export type PartialClassicQuote = {
+  // We need tokenIn/Out to support native currency
+  tokenIn: string;
+  tokenOut: string;
+  tradeType: TradeType;
+  route: Array<(V3PoolInRoute | V2PoolInRoute)[]>;
+};
+
+interface RouteResult {
+  routev3: V3Route<Currency, Currency> | null;
+  routev2: V2Route<Currency, Currency> | null;
+  mixedRoute: MixedRouteSDK<Currency, Currency> | null;
+  inputAmount: CurrencyAmount<Currency>;
+  outputAmount: CurrencyAmount<Currency>;
+}
+
+// Helper class to convert routing-specific quote entities to RouterTrade entities
+// the returned RouterTrade can then be used to build the UniswapTrade entity in this package
+export class RouterTradeAdapter {
+  // Generate a RouterTrade using fields from a classic quote response
+  static fromClassicQuote(quote: PartialClassicQuote) {
+    const { route } = quote;
+
+    if (!route) throw new Error("Expected route to be present");
+    if (!route.length)
+      throw new Error("Expected there to be at least one route");
+    if (route.some((r) => !r.length))
+      throw new Error("Expected all routes to have at least one pool");
+    const firstRoute = route[0];
+
+    const tokenInData = firstRoute[0].tokenIn;
+    const tokenOutData = firstRoute[firstRoute.length - 1].tokenOut;
+
+    if (!tokenInData || !tokenOutData)
+      throw new Error("Expected both tokenIn and tokenOut to be present");
+    if (tokenInData.chainId !== tokenOutData.chainId)
+      throw new Error("Expected tokenIn and tokenOut to be have same chainId");
+
+    const parsedCurrencyIn = RouterTradeAdapter.toCurrency(false, tokenInData);
+    const parsedCurrencyOut = RouterTradeAdapter.toCurrency(
+      false,
+      tokenOutData
+    );
+
+    const typedRoutes: RouteResult[] = route.map((subRoute) => {
+      const rawAmountIn = subRoute[0].amountIn;
+      const rawAmountOut = subRoute[subRoute.length - 1].amountOut;
+
+      if (!rawAmountIn || !rawAmountOut) {
+        throw new Error(
+          "Expected both raw amountIn and raw amountOut to be present"
+        );
+      }
+
+      const inputAmount = CurrencyAmount.fromRawAmount(
+        parsedCurrencyIn,
+        rawAmountIn
+      );
+      const outputAmount = CurrencyAmount.fromRawAmount(
+        parsedCurrencyOut,
+        rawAmountOut
+      );
+
+      const isOnlyV2 = RouterTradeAdapter.isVersionedRoute<V2PoolInRoute>(
+        PoolType.V2Pool,
+        subRoute
+      );
+      const isOnlyV3 = RouterTradeAdapter.isVersionedRoute<V3PoolInRoute>(
+        PoolType.V3Pool,
+        subRoute
+      );
+
+      return {
+        routev3: isOnlyV3
+          ? new V3Route(
+              (subRoute as V3PoolInRoute[]).map(RouterTradeAdapter.toPool),
+              parsedCurrencyIn,
+              parsedCurrencyOut
+            )
+          : null,
+        routev2: isOnlyV2
+          ? new V2Route(
+              (subRoute as V2PoolInRoute[]).map(RouterTradeAdapter.toPair),
+              parsedCurrencyIn,
+              parsedCurrencyOut
+            )
+          : null,
+        mixedRoute:
+          !isOnlyV3 && !isOnlyV2
+            ? new MixedRouteSDK(
+                subRoute.map(RouterTradeAdapter.toPoolOrPair),
+                parsedCurrencyIn,
+                parsedCurrencyOut
+              )
+            : null,
+        inputAmount,
+        outputAmount,
+      };
+    });
+
+    return new RouterTrade({
+      v2Routes: typedRoutes
+        .filter((route) => route.routev2)
+        .map((route) => ({
+          routev2: route.routev2 as V2Route<Currency, Currency>,
+          inputAmount: route.inputAmount,
+          outputAmount: route.outputAmount,
+        })),
+      v3Routes: typedRoutes
+        .filter((route) => route.routev3)
+        .map((route) => ({
+          routev3: route.routev3 as V3Route<Currency, Currency>,
+          inputAmount: route.inputAmount,
+          outputAmount: route.outputAmount,
+        })),
+      // TODO: ROUTE-219 - Support v4 trade in universal-router sdk
+      v4Routes: [],
+      mixedRoutes: typedRoutes
+        .filter((route) => route.mixedRoute)
+        .map((route) => ({
+          mixedRoute: route.mixedRoute as MixedRouteSDK<Currency, Currency>,
+          inputAmount: route.inputAmount,
+          outputAmount: route.outputAmount,
+        })),
+      tradeType: quote.tradeType,
+    });
+  }
+
+  private static toCurrency(isNative: boolean, token: TokenInRoute): Currency {
+    if (isNative) {
+      return Ether.onChain(token.chainId);
+    }
+    return this.toToken(token);
+  }
+
+  private static toPoolOrPair = (
+    pool: V3PoolInRoute | V2PoolInRoute
+  ): Pool | Pair => {
+    return pool.type === PoolType.V3Pool
+      ? RouterTradeAdapter.toPool(pool)
+      : RouterTradeAdapter.toPair(pool);
+  };
+
+  private static toToken(token: TokenInRoute): Token {
+    const { chainId, address, decimals, symbol, buyFeeBps, sellFeeBps } = token;
+    return new Token(
+      chainId,
+      address,
+      parseInt(decimals.toString()),
+      symbol,
+      /* name */ undefined,
+      false,
+      buyFeeBps ? BigNumber.from(buyFeeBps) : undefined,
+      sellFeeBps ? BigNumber.from(sellFeeBps) : undefined
+    );
+  }
+
+  private static toPool({
+    fee,
+    sqrtRatioX96,
+    liquidity,
+    tickCurrent,
+    tokenIn,
+    tokenOut,
+  }: V3PoolInRoute): Pool {
+    return new Pool(
+      RouterTradeAdapter.toToken(tokenIn),
+      RouterTradeAdapter.toToken(tokenOut),
+      parseInt(fee) as FeeAmount,
+      sqrtRatioX96,
+      liquidity,
+      parseInt(tickCurrent)
+    );
+  }
+
+  private static toPair = ({ reserve0, reserve1 }: V2PoolInRoute): Pair => {
+    return new Pair(
+      CurrencyAmount.fromRawAmount(
+        RouterTradeAdapter.toToken(reserve0.token),
+        reserve0.quotient
+      ),
+      CurrencyAmount.fromRawAmount(
+        RouterTradeAdapter.toToken(reserve1.token),
+        reserve1.quotient
+      )
+    );
+  };
+
+  private static isVersionedRoute<T extends V2PoolInRoute | V3PoolInRoute>(
+    type: PoolType,
+    route: (V3PoolInRoute | V2PoolInRoute)[]
+  ): route is T[] {
+    return route.every((pool) => pool.type === type);
+  }
+}

--- a/api/_dexes/uniswap/quote-resolver.ts
+++ b/api/_dexes/uniswap/quote-resolver.ts
@@ -15,7 +15,12 @@ import {
   encodeWethWithdrawCalldata,
   getMultiCallHandlerAddress,
 } from "../../_multicall-handler";
-import { Token as AcrossToken, CrossSwap, SwapQuote } from "../types";
+import {
+  Token as AcrossToken,
+  CrossSwap,
+  CrossSwapQuotes,
+  SwapQuote,
+} from "../types";
 import {
   buildExactOutputBridgeTokenMessage,
   buildMinOutputBridgeTokenMessage,
@@ -24,7 +29,7 @@ import {
 import { AMOUNT_TYPE } from "../cross-swap";
 import { UniswapQuoteFetchStrategy, addMarkupToAmount } from "./utils";
 
-const indicativeQuoteBuffer = 0.5; // 0.5% buffer for indicative quotes
+const indicativeQuoteBuffer = 0.005; // 0.5% buffer for indicative quotes
 
 /**
  * Returns Uniswap v3 quote for a swap with min. output amount for route
@@ -35,7 +40,7 @@ const indicativeQuoteBuffer = 0.5; // 0.5% buffer for indicative quotes
 export async function getUniswapCrossSwapQuotesForOutputB2A(
   crossSwap: CrossSwap,
   strategy: UniswapQuoteFetchStrategy
-) {
+): Promise<CrossSwapQuotes> {
   const destinationSwapChainId = crossSwap.outputToken.chainId;
   const bridgeRoute = getRouteByInputTokenAndDestinationChain(
     crossSwap.inputToken.address,
@@ -116,7 +121,7 @@ export async function getUniswapCrossSwapQuotesForOutputB2A(
 export async function getUniswapCrossSwapQuotesForOutputA2B(
   crossSwap: CrossSwap,
   strategy: UniswapQuoteFetchStrategy
-) {
+): Promise<CrossSwapQuotes> {
   const originSwapChainId = crossSwap.inputToken.chainId;
   const destinationChainId = crossSwap.outputToken.chainId;
   const bridgeRoute = getRouteByOutputTokenAndOriginChain(
@@ -207,7 +212,10 @@ export async function getUniswapCrossSwapQuotesForOutputA2B(
     crossSwap,
     bridgeQuote,
     destinationSwapQuote: undefined,
-    originSwapQuote: adjOriginSwapQuote,
+    originSwapQuote: {
+      ...adjOriginSwapQuote,
+      peripheryAddress: spokePoolPeripheryAddress,
+    },
   };
 }
 
@@ -227,7 +235,7 @@ export async function getBestUniswapCrossSwapQuotesForOutputA2A(
     preferredBridgeTokens: string[];
     bridgeRoutesLimit: number;
   }
-) {
+): Promise<CrossSwapQuotes> {
   const originSwapChainId = crossSwap.inputToken.chainId;
   const destinationSwapChainId = crossSwap.outputToken.chainId;
   const allBridgeRoutes = getRoutesByChainIds(
@@ -292,7 +300,7 @@ export async function getUniswapCrossSwapQuotesForOutputA2A(
   },
   originStrategy: UniswapQuoteFetchStrategy,
   destinationStrategy: UniswapQuoteFetchStrategy
-) {
+): Promise<CrossSwapQuotes> {
   const originSwapChainId = crossSwap.inputToken.chainId;
   const destinationSwapChainId = crossSwap.outputToken.chainId;
 
@@ -407,7 +415,10 @@ export async function getUniswapCrossSwapQuotesForOutputA2A(
     crossSwap,
     destinationSwapQuote,
     bridgeQuote,
-    originSwapQuote: adjOriginSwapQuote,
+    originSwapQuote: {
+      ...adjOriginSwapQuote,
+      peripheryAddress: originStrategy.getPeripheryAddress(originSwapChainId),
+    },
   };
 }
 

--- a/api/_dexes/uniswap/quote-resolver.ts
+++ b/api/_dexes/uniswap/quote-resolver.ts
@@ -180,7 +180,10 @@ export async function getUniswapCrossSwapQuotesForOutputA2B(
       ...originSwap,
       amount: bridgeQuote.inputAmount.toString(),
     },
-    TradeType.EXACT_OUTPUT
+    TradeType.EXACT_OUTPUT,
+    {
+      useIndicativeQuote: true,
+    }
   );
   // 2.2. Re-fetch origin swap quote with updated input amount and EXACT_INPUT type.
   //      This prevents leftover tokens in the SwapAndBridge contract.
@@ -342,8 +345,8 @@ export async function getUniswapCrossSwapQuotesForOutputA2A(
     type: crossSwap.type,
   };
 
-  // 1.1. Get destination swap quote for bridgeable output token -> any token
-  //      with exact output amount
+  // 1. Get destination swap quote for bridgeable output token -> any token
+  //    with exact output amount
   let destinationSwapQuote = await destinationStrategy.fetchFn(
     {
       ...destinationSwap,
@@ -351,20 +354,6 @@ export async function getUniswapCrossSwapQuotesForOutputA2A(
     },
     TradeType.EXACT_OUTPUT
   );
-  // 1.2. Re-fetch destination swap quote with exact input amount if leftover tokens
-  //      should be sent to receiver.
-  if (crossSwap.type === AMOUNT_TYPE.MIN_OUTPUT) {
-    destinationSwapQuote = await destinationStrategy.fetchFn(
-      {
-        ...destinationSwap,
-        amount: addMarkupToAmount(
-          destinationSwapQuote.maximumAmountIn
-        ).toString(),
-      },
-      TradeType.EXACT_INPUT
-    );
-    assertMinOutputAmount(destinationSwapQuote.minAmountOut, crossSwap.amount);
-  }
 
   // 2. Get bridge quote for bridgeable input token -> bridgeable output token
   const bridgeQuote = await getBridgeQuoteForMinOutput({
@@ -388,7 +377,10 @@ export async function getUniswapCrossSwapQuotesForOutputA2A(
       ...originSwap,
       amount: bridgeQuote.inputAmount.toString(),
     },
-    TradeType.EXACT_OUTPUT
+    TradeType.EXACT_OUTPUT,
+    {
+      useIndicativeQuote: true,
+    }
   );
   // 3.2. Re-fetch origin swap quote with updated input amount and EXACT_INPUT type.
   //      This prevents leftover tokens in the SwapAndBridge contract.

--- a/api/_dexes/uniswap/quote-resolver.ts
+++ b/api/_dexes/uniswap/quote-resolver.ts
@@ -12,7 +12,6 @@ import {
   buildMulticallHandlerMessage,
   encodeApproveCalldata,
   encodeDrainCalldata,
-  encodeTransferCalldata,
   encodeWethWithdrawCalldata,
   getMultiCallHandlerAddress,
 } from "../../_multicall-handler";

--- a/api/_dexes/uniswap/quote-resolver.ts
+++ b/api/_dexes/uniswap/quote-resolver.ts
@@ -1,0 +1,542 @@
+import { BigNumber } from "ethers";
+import { TradeType } from "@uniswap/sdk-core";
+
+import {
+  getRouteByInputTokenAndDestinationChain,
+  getTokenByAddress,
+  getBridgeQuoteForMinOutput,
+  getRoutesByChainIds,
+  getRouteByOutputTokenAndOriginChain,
+} from "../../_utils";
+import {
+  buildMulticallHandlerMessage,
+  encodeApproveCalldata,
+  encodeDrainCalldata,
+  encodeTransferCalldata,
+  encodeWethWithdrawCalldata,
+  getMultiCallHandlerAddress,
+} from "../../_multicall-handler";
+import { Token as AcrossToken, CrossSwap, SwapQuote } from "../types";
+import {
+  buildExactOutputBridgeTokenMessage,
+  buildMinOutputBridgeTokenMessage,
+  getFallbackRecipient,
+} from "../utils";
+import { AMOUNT_TYPE } from "../cross-swap";
+import { UniswapQuoteFetchStrategy, addMarkupToAmount } from "./utils";
+
+/**
+ * Returns Uniswap v3 quote for a swap with min. output amount for route
+ * BRIDGEABLE input token -> ANY output token, e.g. USDC -> ARB. Required steps:
+ * 1. Get destination swap quote for bridgeable output token -> any token
+ * 2. Get bridge quote for bridgeable input token -> bridgeable output token
+ */
+export async function getUniswapCrossSwapQuotesForOutputB2A(
+  crossSwap: CrossSwap,
+  strategy: UniswapQuoteFetchStrategy
+) {
+  const destinationSwapChainId = crossSwap.outputToken.chainId;
+  const bridgeRoute = getRouteByInputTokenAndDestinationChain(
+    crossSwap.inputToken.address,
+    destinationSwapChainId
+  );
+
+  if (!bridgeRoute) {
+    throw new Error(
+      `No bridge route found for input token ${crossSwap.inputToken.symbol} ` +
+        `${crossSwap.inputToken.chainId} -> ${destinationSwapChainId}`
+    );
+  }
+
+  const _bridgeableOutputToken = getTokenByAddress(
+    bridgeRoute.toTokenAddress,
+    bridgeRoute.toChain
+  );
+
+  if (!_bridgeableOutputToken) {
+    throw new Error(
+      `No bridgeable output token found for ${bridgeRoute.toTokenAddress} on chain ${bridgeRoute.toChain}`
+    );
+  }
+
+  const bridgeableOutputToken = {
+    address: bridgeRoute.toTokenAddress,
+    decimals: _bridgeableOutputToken.decimals,
+    symbol: _bridgeableOutputToken.symbol,
+    chainId: destinationSwapChainId,
+  };
+
+  const destinationSwap = {
+    chainId: destinationSwapChainId,
+    tokenIn: bridgeableOutputToken,
+    tokenOut: crossSwap.outputToken,
+    recipient: getMultiCallHandlerAddress(destinationSwapChainId),
+    slippageTolerance: crossSwap.slippageTolerance,
+    type: crossSwap.type,
+  };
+  // 1.1. Get destination swap quote for bridgeable output token -> any token
+  //      with exact output amount.
+  let destinationSwapQuote = await strategy.fetchFn(
+    {
+      ...destinationSwap,
+      amount: crossSwap.amount.toString(),
+    },
+    TradeType.EXACT_OUTPUT
+  );
+  // 1.2. Re-fetch destination swap quote with exact input amount if leftover tokens
+  //      should be sent to receiver.
+  if (crossSwap.type === AMOUNT_TYPE.MIN_OUTPUT) {
+    destinationSwapQuote = await strategy.fetchFn(
+      {
+        ...destinationSwap,
+        amount: addMarkupToAmount(
+          destinationSwapQuote.maximumAmountIn
+        ).toString(),
+      },
+      TradeType.EXACT_INPUT
+    );
+    assertMinOutputAmount(destinationSwapQuote.minAmountOut, crossSwap.amount);
+  }
+
+  // 2. Get bridge quote for bridgeable input token -> bridgeable output token
+  const bridgeQuote = await getBridgeQuoteForMinOutput({
+    inputToken: crossSwap.inputToken,
+    outputToken: bridgeableOutputToken,
+    minOutputAmount: destinationSwapQuote.maximumAmountIn,
+    recipient: getMultiCallHandlerAddress(destinationSwapChainId),
+    message: buildDestinationSwapCrossChainMessage({
+      crossSwap,
+      destinationSwapQuote,
+      bridgeableOutputToken,
+      routerAddress: strategy.getRouterAddress(destinationSwapChainId),
+    }),
+  });
+
+  return {
+    crossSwap,
+    bridgeQuote,
+    destinationSwapQuote,
+    originSwapQuote: undefined,
+  };
+}
+
+/**
+ * Returns Uniswap v3 quote for a swap with min. output amount for route
+ * ANY input token -> BRIDGEABLE output token, e.g. ARB -> USDC. Required steps:
+ * 1. Get bridge quote for bridgeable input token -> bridgeable output token
+ * 2. Get origin swap quote for any input token -> bridgeable input token
+ */
+export async function getUniswapCrossSwapQuotesForOutputA2B(
+  crossSwap: CrossSwap,
+  strategy: UniswapQuoteFetchStrategy
+) {
+  const originSwapChainId = crossSwap.inputToken.chainId;
+  const destinationChainId = crossSwap.outputToken.chainId;
+  const bridgeRoute = getRouteByOutputTokenAndOriginChain(
+    crossSwap.outputToken.address,
+    originSwapChainId
+  );
+
+  if (!bridgeRoute) {
+    throw new Error(
+      `No bridge route found for output token ${crossSwap.outputToken.symbol} ` +
+        `${originSwapChainId} -> ${crossSwap.outputToken.chainId}`
+    );
+  }
+
+  const _bridgeableInputToken = getTokenByAddress(
+    bridgeRoute.fromTokenAddress,
+    bridgeRoute.fromChain
+  );
+
+  if (!_bridgeableInputToken) {
+    throw new Error(
+      `No bridgeable input token found for ${bridgeRoute.toTokenAddress} on chain ${bridgeRoute.toChain}`
+    );
+  }
+
+  const bridgeableInputToken = {
+    address: bridgeRoute.fromTokenAddress,
+    decimals: _bridgeableInputToken.decimals,
+    symbol: _bridgeableInputToken.symbol,
+    chainId: bridgeRoute.fromChain,
+  };
+
+  // 1. Get bridge quote for bridgeable input token -> bridgeable output token
+  const bridgeQuote = await getBridgeQuoteForMinOutput({
+    inputToken: bridgeableInputToken,
+    outputToken: crossSwap.outputToken,
+    minOutputAmount: crossSwap.amount,
+    recipient: getMultiCallHandlerAddress(destinationChainId),
+    message: buildExactOutputBridgeTokenMessage(crossSwap),
+  });
+  // 1.1. Update bridge quote message for min. output amount
+  if (crossSwap.type === AMOUNT_TYPE.MIN_OUTPUT && crossSwap.isOutputNative) {
+    bridgeQuote.message = buildMinOutputBridgeTokenMessage(
+      crossSwap,
+      bridgeQuote.outputAmount
+    );
+  }
+
+  const spokePoolPeripheryAddress =
+    strategy.getPeripheryAddress(originSwapChainId);
+  const originSwap = {
+    chainId: originSwapChainId,
+    tokenIn: crossSwap.inputToken,
+    tokenOut: bridgeableInputToken,
+    recipient: spokePoolPeripheryAddress,
+    slippageTolerance: crossSwap.slippageTolerance,
+    type: crossSwap.type,
+  };
+  // 2.1. Get origin swap quote for any input token -> bridgeable input token
+  const originSwapQuote = await strategy.fetchFn(
+    {
+      ...originSwap,
+      amount: bridgeQuote.inputAmount.toString(),
+    },
+    TradeType.EXACT_OUTPUT
+  );
+  // 2.2. Re-fetch origin swap quote with updated input amount and EXACT_INPUT type.
+  //      This prevents leftover tokens in the SwapAndBridge contract.
+  let adjOriginSwapQuote = await strategy.fetchFn(
+    {
+      ...originSwap,
+      amount: addMarkupToAmount(originSwapQuote.maximumAmountIn).toString(),
+    },
+    TradeType.EXACT_INPUT
+  );
+  assertMinOutputAmount(
+    adjOriginSwapQuote.minAmountOut,
+    bridgeQuote.inputAmount
+  );
+
+  return {
+    crossSwap,
+    bridgeQuote,
+    destinationSwapQuote: undefined,
+    originSwapQuote: adjOriginSwapQuote,
+  };
+}
+
+/**
+ * Returns Uniswap v3 quote for a swap with min. output amount for route
+ * ANY input token -> ANY output token, e.g. ARB -> OP. We compare quotes from
+ * different bridge routes and return the best one. In this iteration, we only
+ * consider a hardcoded list of high-liquid bridge routes.
+ * @param crossSwap
+ * @param opts
+ */
+export async function getBestUniswapCrossSwapQuotesForOutputA2A(
+  crossSwap: CrossSwap,
+  originStrategy: UniswapQuoteFetchStrategy,
+  destinationStrategy: UniswapQuoteFetchStrategy,
+  opts: {
+    preferredBridgeTokens: string[];
+    bridgeRoutesLimit: number;
+  }
+) {
+  const originSwapChainId = crossSwap.inputToken.chainId;
+  const destinationSwapChainId = crossSwap.outputToken.chainId;
+  const allBridgeRoutes = getRoutesByChainIds(
+    originSwapChainId,
+    destinationSwapChainId
+  );
+
+  if (allBridgeRoutes.length === 0) {
+    throw new Error(
+      `No bridge routes found for ${originSwapChainId} -> ${destinationSwapChainId}`
+    );
+  }
+
+  const preferredBridgeRoutes = allBridgeRoutes.filter(({ toTokenSymbol }) =>
+    opts.preferredBridgeTokens.includes(toTokenSymbol)
+  );
+  const bridgeRoutesToCompare = (
+    preferredBridgeRoutes.length > 0 ? preferredBridgeRoutes : allBridgeRoutes
+  ).slice(0, opts.bridgeRoutesLimit);
+
+  if (bridgeRoutesToCompare.length === 0) {
+    throw new Error(
+      `No bridge routes to compare for ${originSwapChainId} -> ${destinationSwapChainId}`
+    );
+  }
+
+  const crossSwapQuotes = await Promise.all(
+    bridgeRoutesToCompare.map((bridgeRoute) =>
+      getUniswapCrossSwapQuotesForOutputA2A(
+        crossSwap,
+        bridgeRoute,
+        originStrategy,
+        destinationStrategy
+      )
+    )
+  );
+
+  // Compare quotes by lowest input amount
+  const bestCrossSwapQuote = crossSwapQuotes.reduce((prev, curr) =>
+    prev.originSwapQuote!.maximumAmountIn.lt(
+      curr.originSwapQuote!.maximumAmountIn
+    )
+      ? prev
+      : curr
+  );
+  return bestCrossSwapQuote;
+}
+
+/**
+ * Returns Uniswap v3 quote for a swap with min. output amount for route
+ * ANY input token -> ANY output token, e.g. ARB -> OP, using a specific bridge route.
+ * @param crossSwap
+ * @param bridgeRoute
+ */
+export async function getUniswapCrossSwapQuotesForOutputA2A(
+  crossSwap: CrossSwap,
+  bridgeRoute: {
+    fromTokenAddress: string;
+    fromChain: number;
+    toTokenAddress: string;
+    toChain: number;
+  },
+  originStrategy: UniswapQuoteFetchStrategy,
+  destinationStrategy: UniswapQuoteFetchStrategy
+) {
+  const originSwapChainId = crossSwap.inputToken.chainId;
+  const destinationSwapChainId = crossSwap.outputToken.chainId;
+
+  const _bridgeableInputToken = getTokenByAddress(
+    bridgeRoute.fromTokenAddress,
+    bridgeRoute.fromChain
+  );
+  const _bridgeableOutputToken = getTokenByAddress(
+    bridgeRoute.toTokenAddress,
+    bridgeRoute.toChain
+  );
+
+  if (!_bridgeableInputToken) {
+    throw new Error(
+      `No bridgeable input token found for ${bridgeRoute.fromTokenAddress} on chain ${bridgeRoute.fromChain}`
+    );
+  }
+
+  if (!_bridgeableOutputToken) {
+    throw new Error(
+      `No bridgeable output token found for ${bridgeRoute.toTokenAddress} on chain ${bridgeRoute.toChain}`
+    );
+  }
+
+  const bridgeableInputToken = {
+    address: bridgeRoute.fromTokenAddress,
+    decimals: _bridgeableInputToken.decimals,
+    symbol: _bridgeableInputToken.symbol,
+    chainId: bridgeRoute.fromChain,
+  };
+  const bridgeableOutputToken = {
+    address: bridgeRoute.toTokenAddress,
+    decimals: _bridgeableOutputToken.decimals,
+    symbol: _bridgeableOutputToken.symbol,
+    chainId: bridgeRoute.toChain,
+  };
+  const multiCallHandlerAddress = getMultiCallHandlerAddress(
+    destinationSwapChainId
+  );
+  const originSwap = {
+    chainId: originSwapChainId,
+    tokenIn: crossSwap.inputToken,
+    tokenOut: bridgeableInputToken,
+    recipient: originStrategy.getPeripheryAddress(originSwapChainId),
+    slippageTolerance: crossSwap.slippageTolerance,
+    type: crossSwap.type,
+  };
+  const destinationSwap = {
+    chainId: destinationSwapChainId,
+    tokenIn: bridgeableOutputToken,
+    tokenOut: crossSwap.outputToken,
+    recipient: multiCallHandlerAddress,
+    slippageTolerance: crossSwap.slippageTolerance,
+    type: crossSwap.type,
+  };
+
+  // 1.1. Get destination swap quote for bridgeable output token -> any token
+  //      with exact output amount
+  let destinationSwapQuote = await destinationStrategy.fetchFn(
+    {
+      ...destinationSwap,
+      amount: crossSwap.amount.toString(),
+    },
+    TradeType.EXACT_OUTPUT
+  );
+  // 1.2. Re-fetch destination swap quote with exact input amount if leftover tokens
+  //      should be sent to receiver.
+  if (crossSwap.type === AMOUNT_TYPE.MIN_OUTPUT) {
+    destinationSwapQuote = await destinationStrategy.fetchFn(
+      {
+        ...destinationSwap,
+        amount: addMarkupToAmount(
+          destinationSwapQuote.maximumAmountIn
+        ).toString(),
+      },
+      TradeType.EXACT_INPUT
+    );
+    assertMinOutputAmount(destinationSwapQuote.minAmountOut, crossSwap.amount);
+  }
+
+  // 2. Get bridge quote for bridgeable input token -> bridgeable output token
+  const bridgeQuote = await getBridgeQuoteForMinOutput({
+    inputToken: bridgeableInputToken,
+    outputToken: bridgeableOutputToken,
+    minOutputAmount: destinationSwapQuote.expectedAmountIn,
+    recipient: getMultiCallHandlerAddress(destinationSwapChainId),
+    message: buildDestinationSwapCrossChainMessage({
+      crossSwap,
+      destinationSwapQuote,
+      bridgeableOutputToken,
+      routerAddress: destinationStrategy.getRouterAddress(
+        destinationSwapChainId
+      ),
+    }),
+  });
+
+  // 3.1. Get origin swap quote for any input token -> bridgeable input token
+  const originSwapQuote = await originStrategy.fetchFn(
+    {
+      ...originSwap,
+      amount: bridgeQuote.inputAmount.toString(),
+    },
+    TradeType.EXACT_OUTPUT
+  );
+  // 2.2. Re-fetch origin swap quote with updated input amount and EXACT_INPUT type.
+  //      This prevents leftover tokens in the SwapAndBridge contract.
+  let adjOriginSwapQuote = await originStrategy.fetchFn(
+    {
+      ...originSwap,
+      amount: addMarkupToAmount(originSwapQuote.maximumAmountIn).toString(),
+    },
+    TradeType.EXACT_INPUT
+  );
+  assertMinOutputAmount(
+    adjOriginSwapQuote.minAmountOut,
+    bridgeQuote.inputAmount
+  );
+
+  return {
+    crossSwap,
+    destinationSwapQuote,
+    bridgeQuote,
+    originSwapQuote: adjOriginSwapQuote,
+  };
+}
+
+function buildDestinationSwapCrossChainMessage({
+  crossSwap,
+  destinationSwapQuote,
+  bridgeableOutputToken,
+  routerAddress,
+}: {
+  crossSwap: CrossSwap;
+  bridgeableOutputToken: AcrossToken;
+  destinationSwapQuote: SwapQuote;
+  routerAddress: string;
+}) {
+  const destinationSwapChainId = destinationSwapQuote.tokenOut.chainId;
+
+  let transferActions: {
+    target: string;
+    callData: string;
+    value: string;
+  }[] = [];
+
+  // If output token is native, we need to unwrap WETH before sending it to the
+  // recipient. This is because we only handle WETH in the destination swap.
+  if (crossSwap.isOutputNative) {
+    transferActions = [
+      {
+        target: crossSwap.outputToken.address,
+        callData: encodeWethWithdrawCalldata(crossSwap.amount),
+        value: "0",
+      },
+      {
+        target: crossSwap.recipient,
+        callData: "0x",
+        value: crossSwap.amount.toString(),
+      },
+    ];
+  }
+  // If output token is an ERC-20 token and amount type is EXACT_OUTPUT, we need
+  // to transfer the EXACT output amount to the recipient. The refundAddress / depositor
+  // will receive any leftovers.
+  else if (crossSwap.type === AMOUNT_TYPE.EXACT_OUTPUT) {
+    transferActions = [
+      {
+        target: crossSwap.outputToken.address,
+        callData: encodeTransferCalldata(crossSwap.recipient, crossSwap.amount),
+        value: "0",
+      },
+      {
+        target: getMultiCallHandlerAddress(destinationSwapChainId),
+        callData: encodeDrainCalldata(
+          crossSwap.outputToken.address,
+          crossSwap.refundAddress ?? crossSwap.depositor
+        ),
+        value: "0",
+      },
+    ];
+  }
+  // If output token is an ERC-20 token and amount type is MIN_OUTPUT, we need
+  // to transfer all realized output tokens to the recipient.
+  else if (crossSwap.type === AMOUNT_TYPE.MIN_OUTPUT) {
+    transferActions = [
+      {
+        target: getMultiCallHandlerAddress(destinationSwapChainId),
+        callData: encodeDrainCalldata(
+          crossSwap.outputToken.address,
+          crossSwap.recipient
+        ),
+        value: "0",
+      },
+    ];
+  }
+
+  return buildMulticallHandlerMessage({
+    fallbackRecipient: getFallbackRecipient(crossSwap),
+    actions: [
+      // approve bridgeable output token
+      {
+        target: bridgeableOutputToken.address,
+        callData: encodeApproveCalldata(
+          routerAddress,
+          destinationSwapQuote.maximumAmountIn
+        ),
+        value: "0",
+      },
+      // swap bridgeable output token -> cross swap output token
+      {
+        target: destinationSwapQuote.swapTx.to,
+        callData: destinationSwapQuote.swapTx.data,
+        value: destinationSwapQuote.swapTx.value,
+      },
+      // transfer output tokens to recipient
+      ...transferActions,
+      // drain remaining bridgeable output tokens from MultiCallHandler contract
+      {
+        target: getMultiCallHandlerAddress(destinationSwapChainId),
+        callData: encodeDrainCalldata(
+          bridgeableOutputToken.address,
+          crossSwap.refundAddress ?? crossSwap.depositor
+        ),
+        value: "0",
+      },
+    ],
+  });
+}
+
+function assertMinOutputAmount(
+  amountOut: BigNumber,
+  expectedMinAmountOut: BigNumber
+) {
+  if (amountOut.lt(expectedMinAmountOut)) {
+    throw new Error(
+      `Swap quote output amount ${amountOut.toString()} ` +
+        `is less than required min. output amount ${expectedMinAmountOut.toString()}`
+    );
+  }
+}

--- a/api/_dexes/uniswap/quote-resolver.ts
+++ b/api/_dexes/uniswap/quote-resolver.ts
@@ -24,6 +24,8 @@ import {
 import { AMOUNT_TYPE } from "../cross-swap";
 import { UniswapQuoteFetchStrategy, addMarkupToAmount } from "./utils";
 
+const indicativeQuoteBuffer = 0.5; // 0.5% buffer for indicative quotes
+
 /**
  * Returns Uniswap v3 quote for a swap with min. output amount for route
  * BRIDGEABLE input token -> ANY output token, e.g. USDC -> ARB. Required steps:
@@ -189,7 +191,10 @@ export async function getUniswapCrossSwapQuotesForOutputA2B(
   let adjOriginSwapQuote = await strategy.fetchFn(
     {
       ...originSwap,
-      amount: addMarkupToAmount(originSwapQuote.maximumAmountIn).toString(),
+      amount: addMarkupToAmount(
+        originSwapQuote.maximumAmountIn,
+        indicativeQuoteBuffer
+      ).toString(),
     },
     TradeType.EXACT_INPUT
   );
@@ -386,7 +391,10 @@ export async function getUniswapCrossSwapQuotesForOutputA2A(
   let adjOriginSwapQuote = await originStrategy.fetchFn(
     {
       ...originSwap,
-      amount: addMarkupToAmount(originSwapQuote.maximumAmountIn).toString(),
+      amount: addMarkupToAmount(
+        originSwapQuote.maximumAmountIn,
+        indicativeQuoteBuffer
+      ).toString(),
     },
     TradeType.EXACT_INPUT
   );

--- a/api/_dexes/uniswap/quote-resolver.ts
+++ b/api/_dexes/uniswap/quote-resolver.ts
@@ -372,7 +372,7 @@ export async function getUniswapCrossSwapQuotesForOutputA2A(
   const bridgeQuote = await getBridgeQuoteForMinOutput({
     inputToken: bridgeableInputToken,
     outputToken: bridgeableOutputToken,
-    minOutputAmount: destinationSwapQuote.expectedAmountIn,
+    minOutputAmount: destinationSwapQuote.maximumAmountIn,
     recipient: getMultiCallHandlerAddress(destinationSwapChainId),
     message: buildDestinationSwapCrossChainMessage({
       crossSwap,

--- a/api/_dexes/uniswap/swap-router-02.ts
+++ b/api/_dexes/uniswap/swap-router-02.ts
@@ -90,7 +90,7 @@ export function getSwapRouter02Strategy(): UniswapQuoteFetchStrategy {
       const minAmountOut =
         tradeType === TradeType.EXACT_OUTPUT
           ? expectedAmountOut
-          : addMarkupToAmount(expectedAmountOut, swap.slippageTolerance / 100);
+          : addMarkupToAmount(expectedAmountOut, -swap.slippageTolerance / 100);
 
       swapQuote = {
         tokenIn: swap.tokenIn,

--- a/api/_dexes/uniswap/swap-router-02.ts
+++ b/api/_dexes/uniswap/swap-router-02.ts
@@ -1,4 +1,4 @@
-import { BigNumber, ethers } from "ethers";
+import { ethers } from "ethers";
 import { CurrencyAmount, Percent, Token, TradeType } from "@uniswap/sdk-core";
 import {
   AlphaRouter,
@@ -8,32 +8,11 @@ import {
 import { CHAIN_IDs } from "@across-protocol/constants";
 import { utils } from "@across-protocol/sdk";
 
-import {
-  getProvider,
-  getRouteByInputTokenAndDestinationChain,
-  getTokenByAddress,
-  getBridgeQuoteForMinOutput,
-  getRoutesByChainIds,
-  getRouteByOutputTokenAndOriginChain,
-  getLogger,
-} from "../../_utils";
-import {
-  buildMulticallHandlerMessage,
-  encodeApproveCalldata,
-  encodeDrainCalldata,
-  encodeTransferCalldata,
-  encodeWethWithdrawCalldata,
-  getMultiCallHandlerAddress,
-} from "../../_multicall-handler";
-import { Token as AcrossToken, Swap, CrossSwap, SwapQuote } from "../types";
-import {
-  buildExactOutputBridgeTokenMessage,
-  buildMinOutputBridgeTokenMessage,
-  getFallbackRecipient,
-  NoSwapRouteError,
-} from "../utils";
-import { AMOUNT_TYPE } from "../cross-swap";
+import { getProvider, getLogger } from "../../_utils";
+import { Swap } from "../types";
+import { NoSwapRouteError } from "../utils";
 import { getSpokePoolPeripheryAddress } from "../../_spoke-pool-periphery";
+import { UniswapQuoteFetchStrategy } from "./utils";
 
 // Taken from here: https://docs.uniswap.org/contracts/v3/reference/deployments/
 export const SWAP_ROUTER_02_ADDRESS = {
@@ -48,460 +27,97 @@ export const SWAP_ROUTER_02_ADDRESS = {
   [CHAIN_IDs.ZORA]: "0x7De04c96BE5159c3b5CeffC82aa176dc81281557",
 };
 
-/**
- * Returns Uniswap v3 quote for a swap with min. output amount for route
- * BRIDGEABLE input token -> ANY output token, e.g. USDC -> ARB. Required steps:
- * 1. Get destination swap quote for bridgeable output token -> any token
- * 2. Get bridge quote for bridgeable input token -> bridgeable output token
- */
-export async function getUniswapCrossSwapQuotesForOutputB2A(
-  crossSwap: CrossSwap
-) {
-  const destinationSwapChainId = crossSwap.outputToken.chainId;
-  const bridgeRoute = getRouteByInputTokenAndDestinationChain(
-    crossSwap.inputToken.address,
-    destinationSwapChainId
-  );
+export function getSwapRouter02Strategy(): UniswapQuoteFetchStrategy {
+  const getRouterAddress = (chainId: number) => SWAP_ROUTER_02_ADDRESS[chainId];
+  const getPeripheryAddress = (chainId: number) =>
+    getSpokePoolPeripheryAddress("uniswap-swapRouter02", chainId);
 
-  if (!bridgeRoute) {
-    throw new Error(
-      `No bridge route found for input token ${crossSwap.inputToken.symbol} ` +
-        `${crossSwap.inputToken.chainId} -> ${destinationSwapChainId}`
-    );
-  }
+  const fetchFn = async (swap: Swap, tradeType: TradeType) => {
+    const { router, options } = getSwapRouter02AndOptions(swap);
 
-  const _bridgeableOutputToken = getTokenByAddress(
-    bridgeRoute.toTokenAddress,
-    bridgeRoute.toChain
-  );
+    const amountCurrency =
+      tradeType === TradeType.EXACT_INPUT ? swap.tokenIn : swap.tokenOut;
+    const quoteCurrency =
+      tradeType === TradeType.EXACT_INPUT ? swap.tokenOut : swap.tokenIn;
 
-  if (!_bridgeableOutputToken) {
-    throw new Error(
-      `No bridgeable output token found for ${bridgeRoute.toTokenAddress} on chain ${bridgeRoute.toChain}`
-    );
-  }
-
-  const bridgeableOutputToken = {
-    address: bridgeRoute.toTokenAddress,
-    decimals: _bridgeableOutputToken.decimals,
-    symbol: _bridgeableOutputToken.symbol,
-    chainId: destinationSwapChainId,
-  };
-
-  const destinationSwap = {
-    chainId: destinationSwapChainId,
-    tokenIn: bridgeableOutputToken,
-    tokenOut: crossSwap.outputToken,
-    recipient: getMultiCallHandlerAddress(destinationSwapChainId),
-    slippageTolerance: crossSwap.slippageTolerance,
-  };
-  // 1.1. Get destination swap quote for bridgeable output token -> any token
-  //      with exact output amount.
-  let destinationSwapQuote = await getUniswapQuoteWithSwapRouter02(
-    {
-      ...destinationSwap,
-      amount: crossSwap.amount.toString(),
-    },
-    TradeType.EXACT_OUTPUT
-  );
-  // 1.2. Re-fetch destination swap quote with exact input amount if leftover tokens
-  //      should be sent to receiver.
-  if (crossSwap.type === AMOUNT_TYPE.MIN_OUTPUT) {
-    destinationSwapQuote = await getUniswapQuoteWithSwapRouter02(
-      {
-        ...destinationSwap,
-        amount: addBufferToAmount(destinationSwapQuote.maximumAmountIn),
-      },
-      TradeType.EXACT_INPUT
-    );
-    assertMinOutputAmount(destinationSwapQuote.minAmountOut, crossSwap.amount);
-  }
-
-  // 2. Get bridge quote for bridgeable input token -> bridgeable output token
-  const bridgeQuote = await getBridgeQuoteForMinOutput({
-    inputToken: crossSwap.inputToken,
-    outputToken: bridgeableOutputToken,
-    minOutputAmount: destinationSwapQuote.maximumAmountIn,
-    recipient: getMultiCallHandlerAddress(destinationSwapChainId),
-    message: buildDestinationSwapCrossChainMessage({
-      crossSwap,
-      destinationSwapQuote,
-      bridgeableOutputToken,
-    }),
-  });
-
-  return {
-    crossSwap,
-    bridgeQuote,
-    destinationSwapQuote,
-    originSwapQuote: undefined,
-  };
-}
-
-/**
- * Returns Uniswap v3 quote for a swap with min. output amount for route
- * ANY input token -> BRIDGEABLE output token, e.g. ARB -> USDC. Required steps:
- * 1. Get bridge quote for bridgeable input token -> bridgeable output token
- * 2. Get origin swap quote for any input token -> bridgeable input token
- */
-export async function getUniswapCrossSwapQuotesForOutputA2B(
-  crossSwap: CrossSwap
-) {
-  const originSwapChainId = crossSwap.inputToken.chainId;
-  const destinationChainId = crossSwap.outputToken.chainId;
-  const bridgeRoute = getRouteByOutputTokenAndOriginChain(
-    crossSwap.outputToken.address,
-    originSwapChainId
-  );
-
-  if (!bridgeRoute) {
-    throw new Error(
-      `No bridge route found for output token ${crossSwap.outputToken.symbol} ` +
-        `${originSwapChainId} -> ${crossSwap.outputToken.chainId}`
-    );
-  }
-
-  const _bridgeableInputToken = getTokenByAddress(
-    bridgeRoute.fromTokenAddress,
-    bridgeRoute.fromChain
-  );
-
-  if (!_bridgeableInputToken) {
-    throw new Error(
-      `No bridgeable input token found for ${bridgeRoute.toTokenAddress} on chain ${bridgeRoute.toChain}`
-    );
-  }
-
-  const bridgeableInputToken = {
-    address: bridgeRoute.fromTokenAddress,
-    decimals: _bridgeableInputToken.decimals,
-    symbol: _bridgeableInputToken.symbol,
-    chainId: bridgeRoute.fromChain,
-  };
-
-  // 1. Get bridge quote for bridgeable input token -> bridgeable output token
-  const bridgeQuote = await getBridgeQuoteForMinOutput({
-    inputToken: bridgeableInputToken,
-    outputToken: crossSwap.outputToken,
-    minOutputAmount: crossSwap.amount,
-    recipient: getMultiCallHandlerAddress(destinationChainId),
-    message: buildExactOutputBridgeTokenMessage(crossSwap),
-  });
-  // 1.1. Update bridge quote message for min. output amount
-  if (crossSwap.type === AMOUNT_TYPE.MIN_OUTPUT && crossSwap.isOutputNative) {
-    bridgeQuote.message = buildMinOutputBridgeTokenMessage(
-      crossSwap,
-      bridgeQuote.outputAmount
-    );
-  }
-
-  const originSwap = {
-    chainId: originSwapChainId,
-    tokenIn: crossSwap.inputToken,
-    tokenOut: bridgeableInputToken,
-    recipient: getSpokePoolPeripheryAddress("uniswap", originSwapChainId),
-    slippageTolerance: crossSwap.slippageTolerance,
-  };
-  // 2.1. Get origin swap quote for any input token -> bridgeable input token
-  const originSwapQuote = await getUniswapQuoteWithSwapRouter02(
-    {
-      ...originSwap,
-      amount: bridgeQuote.inputAmount.toString(),
-    },
-    TradeType.EXACT_OUTPUT
-  );
-  // 2.2. Re-fetch origin swap quote with updated input amount and EXACT_INPUT type.
-  //      This prevents leftover tokens in the SwapAndBridge contract.
-  let adjOriginSwapQuote = await getUniswapQuoteWithSwapRouter02(
-    {
-      ...originSwap,
-      amount: addBufferToAmount(originSwapQuote.maximumAmountIn),
-    },
-    TradeType.EXACT_INPUT
-  );
-  assertMinOutputAmount(
-    adjOriginSwapQuote.minAmountOut,
-    bridgeQuote.inputAmount
-  );
-
-  return {
-    crossSwap,
-    bridgeQuote,
-    destinationSwapQuote: undefined,
-    originSwapQuote: adjOriginSwapQuote,
-  };
-}
-
-/**
- * Returns Uniswap v3 quote for a swap with min. output amount for route
- * ANY input token -> ANY output token, e.g. ARB -> OP. We compare quotes from
- * different bridge routes and return the best one. In this iteration, we only
- * consider a hardcoded list of high-liquid bridge routes.
- * @param crossSwap
- * @param opts
- */
-export async function getBestUniswapCrossSwapQuotesForOutputA2A(
-  crossSwap: CrossSwap,
-  opts: {
-    preferredBridgeTokens: string[];
-    bridgeRoutesLimit: number;
-  }
-) {
-  const originSwapChainId = crossSwap.inputToken.chainId;
-  const destinationSwapChainId = crossSwap.outputToken.chainId;
-  const allBridgeRoutes = getRoutesByChainIds(
-    originSwapChainId,
-    destinationSwapChainId
-  );
-
-  if (allBridgeRoutes.length === 0) {
-    throw new Error(
-      `No bridge routes found for ${originSwapChainId} -> ${destinationSwapChainId}`
-    );
-  }
-
-  const preferredBridgeRoutes = allBridgeRoutes.filter(({ toTokenSymbol }) =>
-    opts.preferredBridgeTokens.includes(toTokenSymbol)
-  );
-  const bridgeRoutesToCompare = (
-    preferredBridgeRoutes.length > 0 ? preferredBridgeRoutes : allBridgeRoutes
-  ).slice(0, opts.bridgeRoutesLimit);
-
-  if (bridgeRoutesToCompare.length === 0) {
-    throw new Error(
-      `No bridge routes to compare for ${originSwapChainId} -> ${destinationSwapChainId}`
-    );
-  }
-
-  const crossSwapQuotes = await Promise.all(
-    bridgeRoutesToCompare.map((bridgeRoute) =>
-      getUniswapCrossSwapQuotesForOutputA2A(crossSwap, bridgeRoute)
-    )
-  );
-
-  // Compare quotes by lowest input amount
-  const bestCrossSwapQuote = crossSwapQuotes.reduce((prev, curr) =>
-    prev.originSwapQuote!.maximumAmountIn.lt(
-      curr.originSwapQuote!.maximumAmountIn
-    )
-      ? prev
-      : curr
-  );
-  return bestCrossSwapQuote;
-}
-
-/**
- * Returns Uniswap v3 quote for a swap with min. output amount for route
- * ANY input token -> ANY output token, e.g. ARB -> OP, using a specific bridge route.
- * @param crossSwap
- * @param bridgeRoute
- */
-export async function getUniswapCrossSwapQuotesForOutputA2A(
-  crossSwap: CrossSwap,
-  bridgeRoute: {
-    fromTokenAddress: string;
-    fromChain: number;
-    toTokenAddress: string;
-    toChain: number;
-  }
-) {
-  const originSwapChainId = crossSwap.inputToken.chainId;
-  const destinationSwapChainId = crossSwap.outputToken.chainId;
-
-  const _bridgeableInputToken = getTokenByAddress(
-    bridgeRoute.fromTokenAddress,
-    bridgeRoute.fromChain
-  );
-  const _bridgeableOutputToken = getTokenByAddress(
-    bridgeRoute.toTokenAddress,
-    bridgeRoute.toChain
-  );
-
-  if (!_bridgeableInputToken) {
-    throw new Error(
-      `No bridgeable input token found for ${bridgeRoute.fromTokenAddress} on chain ${bridgeRoute.fromChain}`
-    );
-  }
-
-  if (!_bridgeableOutputToken) {
-    throw new Error(
-      `No bridgeable output token found for ${bridgeRoute.toTokenAddress} on chain ${bridgeRoute.toChain}`
-    );
-  }
-
-  const bridgeableInputToken = {
-    address: bridgeRoute.fromTokenAddress,
-    decimals: _bridgeableInputToken.decimals,
-    symbol: _bridgeableInputToken.symbol,
-    chainId: bridgeRoute.fromChain,
-  };
-  const bridgeableOutputToken = {
-    address: bridgeRoute.toTokenAddress,
-    decimals: _bridgeableOutputToken.decimals,
-    symbol: _bridgeableOutputToken.symbol,
-    chainId: bridgeRoute.toChain,
-  };
-  const originSwap = {
-    chainId: originSwapChainId,
-    tokenIn: crossSwap.inputToken,
-    tokenOut: bridgeableInputToken,
-    recipient: getSpokePoolPeripheryAddress("uniswap", originSwapChainId),
-    slippageTolerance: crossSwap.slippageTolerance,
-  };
-  const destinationSwap = {
-    chainId: destinationSwapChainId,
-    tokenIn: bridgeableOutputToken,
-    tokenOut: crossSwap.outputToken,
-    recipient: getMultiCallHandlerAddress(destinationSwapChainId),
-    slippageTolerance: crossSwap.slippageTolerance,
-  };
-
-  // 1.1. Get destination swap quote for bridgeable output token -> any token
-  //      with exact output amount
-  let destinationSwapQuote = await getUniswapQuoteWithSwapRouter02(
-    {
-      ...destinationSwap,
-      amount: crossSwap.amount.toString(),
-    },
-    TradeType.EXACT_OUTPUT
-  );
-  // 1.2. Re-fetch destination swap quote with exact input amount if leftover tokens
-  //      should be sent to receiver.
-  if (crossSwap.type === AMOUNT_TYPE.MIN_OUTPUT) {
-    destinationSwapQuote = await getUniswapQuoteWithSwapRouter02(
-      {
-        ...destinationSwap,
-        amount: addBufferToAmount(destinationSwapQuote.maximumAmountIn),
-      },
-      TradeType.EXACT_INPUT
-    );
-    assertMinOutputAmount(destinationSwapQuote.minAmountOut, crossSwap.amount);
-  }
-
-  // 2. Get bridge quote for bridgeable input token -> bridgeable output token
-  const bridgeQuote = await getBridgeQuoteForMinOutput({
-    inputToken: bridgeableInputToken,
-    outputToken: bridgeableOutputToken,
-    minOutputAmount: destinationSwapQuote.expectedAmountIn,
-    recipient: getMultiCallHandlerAddress(destinationSwapChainId),
-    message: buildDestinationSwapCrossChainMessage({
-      crossSwap,
-      destinationSwapQuote,
-      bridgeableOutputToken,
-    }),
-  });
-
-  // 3.1. Get origin swap quote for any input token -> bridgeable input token
-  const originSwapQuote = await getUniswapQuoteWithSwapRouter02(
-    {
-      ...originSwap,
-      amount: bridgeQuote.inputAmount.toString(),
-    },
-    TradeType.EXACT_OUTPUT
-  );
-  // 3.2. Re-fetch origin swap quote with updated input amount and EXACT_INPUT type.
-  //      This prevents leftover tokens in the SwapAndBridge contract.
-  const adjOriginSwapQuote = await getUniswapQuoteWithSwapRouter02(
-    {
-      ...originSwap,
-      amount: addBufferToAmount(originSwapQuote.maximumAmountIn),
-    },
-    TradeType.EXACT_INPUT
-  );
-  assertMinOutputAmount(
-    adjOriginSwapQuote.minAmountOut,
-    bridgeQuote.inputAmount
-  );
-
-  return {
-    crossSwap,
-    destinationSwapQuote,
-    bridgeQuote,
-    originSwapQuote: adjOriginSwapQuote,
-  };
-}
-
-export async function getUniswapQuoteWithSwapRouter02(
-  swap: Omit<Swap, "type">,
-  tradeType: TradeType
-): Promise<SwapQuote> {
-  const { router, options } = getSwapRouter02AndOptions(swap);
-
-  const amountCurrency =
-    tradeType === TradeType.EXACT_INPUT ? swap.tokenIn : swap.tokenOut;
-  const quoteCurrency =
-    tradeType === TradeType.EXACT_INPUT ? swap.tokenOut : swap.tokenIn;
-
-  const route = await router.route(
-    CurrencyAmount.fromRawAmount(
-      new Token(
-        amountCurrency.chainId,
-        amountCurrency.address,
-        amountCurrency.decimals
+    const route = await router.route(
+      CurrencyAmount.fromRawAmount(
+        new Token(
+          amountCurrency.chainId,
+          amountCurrency.address,
+          amountCurrency.decimals
+        ),
+        swap.amount
       ),
-      swap.amount
-    ),
-    new Token(
-      quoteCurrency.chainId,
-      quoteCurrency.address,
-      quoteCurrency.decimals
-    ),
-    tradeType,
-    options
-  );
+      new Token(
+        quoteCurrency.chainId,
+        quoteCurrency.address,
+        quoteCurrency.decimals
+      ),
+      tradeType,
+      options
+    );
 
-  if (!route || !route.methodParameters) {
-    throw new NoSwapRouteError({
-      dex: "uniswap",
-      tokenInSymbol: swap.tokenIn.symbol,
-      tokenOutSymbol: swap.tokenOut.symbol,
-      chainId: swap.chainId,
-      swapType:
+    if (!route || !route.methodParameters) {
+      throw new NoSwapRouteError({
+        dex: "uniswap",
+        tokenInSymbol: swap.tokenIn.symbol,
+        tokenOutSymbol: swap.tokenOut.symbol,
+        chainId: swap.chainId,
+        swapType:
+          tradeType === TradeType.EXACT_INPUT ? "EXACT_INPUT" : "EXACT_OUTPUT",
+      });
+    }
+
+    const swapQuote = {
+      tokenIn: swap.tokenIn,
+      tokenOut: swap.tokenOut,
+      maximumAmountIn: ethers.utils.parseUnits(
+        route.trade.maximumAmountIn(options.slippageTolerance).toExact(),
+        swap.tokenIn.decimals
+      ),
+      minAmountOut: ethers.utils.parseUnits(
+        route.trade.minimumAmountOut(options.slippageTolerance).toExact(),
+        swap.tokenOut.decimals
+      ),
+      expectedAmountOut: ethers.utils.parseUnits(
+        route.trade.outputAmount.toExact(),
+        swap.tokenOut.decimals
+      ),
+      expectedAmountIn: ethers.utils.parseUnits(
+        route.trade.inputAmount.toExact(),
+        swap.tokenIn.decimals
+      ),
+      slippageTolerance: swap.slippageTolerance,
+      swapTx: {
+        to: route.methodParameters.to,
+        data: route.methodParameters.calldata,
+        value: route.methodParameters.value,
+      },
+    };
+
+    getLogger().debug({
+      at: "uniswap/universal-router/quoteFetchFn",
+      message: "Swap quote",
+      type:
         tradeType === TradeType.EXACT_INPUT ? "EXACT_INPUT" : "EXACT_OUTPUT",
+      tokenIn: swapQuote.tokenIn.symbol,
+      tokenOut: swapQuote.tokenOut.symbol,
+      chainId: swap.chainId,
+      maximumAmountIn: swapQuote.maximumAmountIn.toString(),
+      minAmountOut: swapQuote.minAmountOut.toString(),
+      expectedAmountOut: swapQuote.expectedAmountOut.toString(),
+      expectedAmountIn: swapQuote.expectedAmountIn.toString(),
     });
-  }
 
-  const swapQuote = {
-    tokenIn: swap.tokenIn,
-    tokenOut: swap.tokenOut,
-    maximumAmountIn: ethers.utils.parseUnits(
-      route.trade.maximumAmountIn(options.slippageTolerance).toExact(),
-      swap.tokenIn.decimals
-    ),
-    minAmountOut: ethers.utils.parseUnits(
-      route.trade.minimumAmountOut(options.slippageTolerance).toExact(),
-      swap.tokenOut.decimals
-    ),
-    expectedAmountOut: ethers.utils.parseUnits(
-      route.trade.outputAmount.toExact(),
-      swap.tokenOut.decimals
-    ),
-    expectedAmountIn: ethers.utils.parseUnits(
-      route.trade.inputAmount.toExact(),
-      swap.tokenIn.decimals
-    ),
-    slippageTolerance: swap.slippageTolerance,
-    swapTx: {
-      to: route.methodParameters.to,
-      data: route.methodParameters.calldata,
-      value: route.methodParameters.value,
-    },
+    return swapQuote;
   };
 
-  getLogger().debug({
-    at: "uniswap/getUniswapQuoteWithSwapRouter02",
-    message: "Swap quote",
-    type: tradeType === TradeType.EXACT_INPUT ? "EXACT_INPUT" : "EXACT_OUTPUT",
-    tokenIn: swapQuote.tokenIn.symbol,
-    tokenOut: swapQuote.tokenOut.symbol,
-    chainId: swap.chainId,
-    maximumAmountIn: swapQuote.maximumAmountIn.toString(),
-    minAmountOut: swapQuote.minAmountOut.toString(),
-    expectedAmountOut: swapQuote.expectedAmountOut.toString(),
-    expectedAmountIn: swapQuote.expectedAmountIn.toString(),
-  });
-
-  return swapQuote;
+  return {
+    getRouterAddress,
+    getPeripheryAddress,
+    fetchFn,
+  };
 }
 
 function getSwapRouter02AndOptions(params: {
@@ -537,124 +153,4 @@ function floatToPercent(value: number) {
     Number(value.toFixed(2)) * 100,
     10_000
   );
-}
-
-function buildDestinationSwapCrossChainMessage({
-  crossSwap,
-  destinationSwapQuote,
-  bridgeableOutputToken,
-}: {
-  crossSwap: CrossSwap;
-  bridgeableOutputToken: AcrossToken;
-  destinationSwapQuote: SwapQuote;
-}) {
-  const destinationSwapChainId = destinationSwapQuote.tokenOut.chainId;
-
-  let transferActions: {
-    target: string;
-    callData: string;
-    value: string;
-  }[] = [];
-
-  // If output token is native, we need to unwrap WETH before sending it to the
-  // recipient. This is because we only handle WETH in the destination swap.
-  if (crossSwap.isOutputNative) {
-    transferActions = [
-      {
-        target: crossSwap.outputToken.address,
-        callData: encodeWethWithdrawCalldata(crossSwap.amount),
-        value: "0",
-      },
-      {
-        target: crossSwap.recipient,
-        callData: "0x",
-        value: crossSwap.amount.toString(),
-      },
-    ];
-  }
-  // If output token is an ERC-20 token and amount type is EXACT_OUTPUT, we need
-  // to transfer the EXACT output amount to the recipient. The refundAddress / depositor
-  // will receive any leftovers.
-  else if (crossSwap.type === AMOUNT_TYPE.EXACT_OUTPUT) {
-    transferActions = [
-      {
-        target: crossSwap.outputToken.address,
-        callData: encodeTransferCalldata(crossSwap.recipient, crossSwap.amount),
-        value: "0",
-      },
-      {
-        target: getMultiCallHandlerAddress(destinationSwapChainId),
-        callData: encodeDrainCalldata(
-          crossSwap.outputToken.address,
-          crossSwap.refundAddress ?? crossSwap.depositor
-        ),
-        value: "0",
-      },
-    ];
-  }
-  // If output token is an ERC-20 token and amount type is MIN_OUTPUT, we need
-  // to transfer all realized output tokens to the recipient.
-  else if (crossSwap.type === AMOUNT_TYPE.MIN_OUTPUT) {
-    transferActions = [
-      {
-        target: getMultiCallHandlerAddress(destinationSwapChainId),
-        callData: encodeDrainCalldata(
-          crossSwap.outputToken.address,
-          crossSwap.recipient
-        ),
-        value: "0",
-      },
-    ];
-  }
-
-  return buildMulticallHandlerMessage({
-    fallbackRecipient: getFallbackRecipient(crossSwap),
-    actions: [
-      // approve bridgeable output token
-      {
-        target: bridgeableOutputToken.address,
-        callData: encodeApproveCalldata(
-          SWAP_ROUTER_02_ADDRESS[destinationSwapChainId],
-          destinationSwapQuote.maximumAmountIn
-        ),
-        value: "0",
-      },
-      // swap bridgeable output token -> cross swap output token
-      {
-        target: destinationSwapQuote.swapTx.to,
-        callData: destinationSwapQuote.swapTx.data,
-        value: destinationSwapQuote.swapTx.value,
-      },
-      // transfer output tokens to recipient
-      ...transferActions,
-      // drain remaining bridgeable output tokens from MultiCallHandler contract
-      {
-        target: getMultiCallHandlerAddress(destinationSwapChainId),
-        callData: encodeDrainCalldata(
-          bridgeableOutputToken.address,
-          crossSwap.refundAddress ?? crossSwap.depositor
-        ),
-        value: "0",
-      },
-    ],
-  });
-}
-
-function assertMinOutputAmount(
-  amountOut: BigNumber,
-  expectedMinAmountOut: BigNumber
-) {
-  if (amountOut.lt(expectedMinAmountOut)) {
-    throw new Error(
-      `Swap quote output amount ${amountOut.toString()} ` +
-        `is less than required min. output amount ${expectedMinAmountOut.toString()}`
-    );
-  }
-}
-
-function addBufferToAmount(amount: BigNumber, buffer = 0.01) {
-  return amount
-    .mul(ethers.utils.parseEther((1 + Number(buffer)).toString()))
-    .div(utils.fixedPointAdjustment)
-    .toString();
 }

--- a/api/_dexes/uniswap/trading-api.ts
+++ b/api/_dexes/uniswap/trading-api.ts
@@ -2,8 +2,9 @@ import { TradeType } from "@uniswap/sdk-core";
 import axios from "axios";
 
 import { Swap } from "../types";
+import { V2PoolInRoute, V3PoolInRoute } from "./adapter";
 
-type UniswapClassicQuoteFromApi = {
+export type UniswapClassicQuoteFromApi = {
   chainId: number;
   input: {
     amount: string;
@@ -15,7 +16,7 @@ type UniswapClassicQuoteFromApi = {
     recipient: string;
   };
   swapper: string;
-  route: any[];
+  route: Array<(V3PoolInRoute | V2PoolInRoute)[]>;
   slippage: number;
   tradeType: "EXACT_OUTPUT" | "EXACT_INPUT";
   quoteId: string;

--- a/api/_dexes/uniswap/trading-api.ts
+++ b/api/_dexes/uniswap/trading-api.ts
@@ -1,0 +1,102 @@
+import { TradeType } from "@uniswap/sdk-core";
+import axios from "axios";
+
+import { Swap } from "../types";
+
+type UniswapClassicQuoteFromApi = {
+  chainId: number;
+  input: {
+    amount: string;
+    token: string;
+  };
+  output: {
+    amount: string;
+    token: string;
+    recipient: string;
+  };
+  swapper: string;
+  route: any[];
+  slippage: number;
+  tradeType: "EXACT_OUTPUT" | "EXACT_INPUT";
+  quoteId: string;
+};
+
+export type UniswapParamForApi = Omit<Swap, "type" | "slippageTolerance"> & {
+  swapper: string;
+  slippageTolerance?: number;
+};
+
+export const UNISWAP_TRADING_API_BASE_URL =
+  process.env.UNISWAP_TRADING_API_BASE_URL ||
+  "https://trading-api-labs.interface.gateway.uniswap.org/v1";
+
+export const UNISWAP_API_KEY =
+  process.env.UNISWAP_API_KEY || "JoyCGj29tT4pymvhaGciK4r1aIPvqW6W53xT1fwo";
+
+/**
+ * Based on https://uniswap-docs.readme.io/reference/aggregator_quote-1
+ */
+export async function getUniswapClassicQuoteFromApi(
+  swap: UniswapParamForApi,
+  tradeType: TradeType
+) {
+  const response = await axios.post<{
+    requestId: string;
+    routing: "CLASSIC";
+    quote: UniswapClassicQuoteFromApi;
+  }>(
+    `${UNISWAP_TRADING_API_BASE_URL}/quote`,
+    {
+      type:
+        tradeType === TradeType.EXACT_INPUT ? "EXACT_INPUT" : "EXACT_OUTPUT",
+      tokenInChainId: swap.tokenIn.chainId,
+      tokenOutChainId: swap.tokenOut.chainId,
+      tokenIn: swap.tokenIn.address,
+      tokenOut: swap.tokenOut.address,
+      swapper: swap.swapper,
+      slippageTolerance: swap.slippageTolerance,
+      autoSlippage: swap.slippageTolerance ? undefined : "DEFAULT",
+      amount: swap.amount,
+      urgency: "urgent",
+      routingPreference: "CLASSIC",
+    },
+    {
+      headers: {
+        "x-api-key": UNISWAP_API_KEY,
+      },
+    }
+  );
+  return response.data;
+}
+
+export async function getUniswapClassicCalldataFromApi(
+  classicQuote: UniswapClassicQuoteFromApi
+) {
+  const response = await axios.post<{
+    requestId: string;
+    swap: {
+      to: string;
+      from: string;
+      data: string;
+      value: string;
+      gasLimit: string;
+      chainId: number;
+      maxFeePerGas: string;
+      maxPriorityFeePerGas: string;
+      gasPrice: string;
+    };
+  }>(
+    `${UNISWAP_TRADING_API_BASE_URL}/swap`,
+    {
+      quote: classicQuote,
+      simulateTransaction: false,
+      urgency: "urgent",
+    },
+    {
+      headers: {
+        "x-api-key": UNISWAP_API_KEY,
+      },
+    }
+  );
+  return response.data;
+}

--- a/api/_dexes/uniswap/trading-api.ts
+++ b/api/_dexes/uniswap/trading-api.ts
@@ -69,6 +69,42 @@ export async function getUniswapClassicQuoteFromApi(
   return response.data;
 }
 
+export async function getUniswapClassicIndicativeQuoteFromApi(
+  swap: UniswapParamForApi,
+  tradeType: TradeType
+) {
+  const response = await axios.post<{
+    requestId: string;
+    input: {
+      amount: string;
+      chainId: number;
+      token: string;
+    };
+    output: {
+      amount: string;
+      chainId: number;
+      token: string;
+    };
+  }>(
+    `${UNISWAP_TRADING_API_BASE_URL}/indicative_quote`,
+    {
+      type:
+        tradeType === TradeType.EXACT_INPUT ? "EXACT_INPUT" : "EXACT_OUTPUT",
+      amount: swap.amount,
+      tokenInChainId: swap.tokenIn.chainId,
+      tokenOutChainId: swap.tokenOut.chainId,
+      tokenIn: swap.tokenIn.address,
+      tokenOut: swap.tokenOut.address,
+    },
+    {
+      headers: {
+        "x-api-key": UNISWAP_API_KEY,
+      },
+    }
+  );
+  return response.data;
+}
+
 export async function getUniswapClassicCalldataFromApi(
   classicQuote: UniswapClassicQuoteFromApi
 ) {

--- a/api/_dexes/uniswap/universal-router.ts
+++ b/api/_dexes/uniswap/universal-router.ts
@@ -1,0 +1,88 @@
+import { BigNumber } from "ethers";
+import { TradeType } from "@uniswap/sdk-core";
+import { CHAIN_IDs } from "@across-protocol/constants";
+
+import { getLogger } from "../../_utils";
+import { Swap } from "../types";
+import { getSpokePoolPeripheryAddress } from "../../_spoke-pool-periphery";
+import {
+  getUniswapClassicCalldataFromApi,
+  getUniswapClassicQuoteFromApi,
+} from "./trading-api";
+import { UniswapQuoteFetchStrategy, addMarkupToAmount } from "./utils";
+
+// https://uniswap-docs.readme.io/reference/faqs#i-need-to-whitelist-the-router-addresses-where-can-i-find-them
+export const UNIVERSAL_ROUTER_ADDRESS = {
+  [CHAIN_IDs.ARBITRUM]: "0x5E325eDA8064b456f4781070C0738d849c824258",
+  [CHAIN_IDs.BASE]: "0x3fC91A3afd70395Cd496C647d5a6CC9D4B2b7FAD",
+  [CHAIN_IDs.BLAST]: "0x643770E279d5D0733F21d6DC03A8efbABf3255B4",
+  [CHAIN_IDs.MAINNET]: "0x3fC91A3afd70395Cd496C647d5a6CC9D4B2b7FAD",
+  [CHAIN_IDs.OPTIMISM]: "0xCb1355ff08Ab38bBCE60111F1bb2B784bE25D7e8",
+  [CHAIN_IDs.POLYGON]: "0xec7BE89e9d109e7e3Fec59c222CF297125FEFda2",
+  [CHAIN_IDs.WORLD_CHAIN]: "0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D",
+  [CHAIN_IDs.ZORA]: "0x2986d9721A49838ab4297b695858aF7F17f38014",
+  [CHAIN_IDs.ZK_SYNC]: "0x28731BCC616B5f51dD52CF2e4dF0E78dD1136C06",
+};
+
+export function getUniversalRouterStrategy(): UniswapQuoteFetchStrategy {
+  const getRouterAddress = (chainId: number) =>
+    UNIVERSAL_ROUTER_ADDRESS[chainId];
+  const getPeripheryAddress = (chainId: number) =>
+    getSpokePoolPeripheryAddress("uniswap-universalRouter", chainId);
+
+  const fetchFn = async (swap: Swap, tradeType: TradeType) => {
+    const { quote } = await getUniswapClassicQuoteFromApi(
+      { ...swap, swapper: swap.recipient },
+      tradeType
+    );
+    const classicSwap = await getUniswapClassicCalldataFromApi(quote);
+
+    const expectedAmountIn = BigNumber.from(quote.input.amount);
+    const maxAmountIn =
+      tradeType === TradeType.EXACT_INPUT
+        ? expectedAmountIn
+        : addMarkupToAmount(expectedAmountIn, quote.slippage / 100);
+    const expectedAmountOut = BigNumber.from(quote.output.amount);
+    const minAmountOut =
+      tradeType === TradeType.EXACT_OUTPUT
+        ? expectedAmountOut
+        : addMarkupToAmount(expectedAmountOut, quote.slippage / 100);
+
+    const swapQuote = {
+      tokenIn: swap.tokenIn,
+      tokenOut: swap.tokenOut,
+      maximumAmountIn: maxAmountIn,
+      minAmountOut,
+      expectedAmountOut,
+      expectedAmountIn,
+      slippageTolerance: quote.slippage,
+      swapTx: {
+        to: classicSwap.swap.to,
+        data: classicSwap.swap.data,
+        value: classicSwap.swap.value,
+      },
+    };
+
+    getLogger().debug({
+      at: "uniswap/universal-router/quoteFetchFn",
+      message: "Swap quote",
+      type:
+        tradeType === TradeType.EXACT_INPUT ? "EXACT_INPUT" : "EXACT_OUTPUT",
+      tokenIn: swapQuote.tokenIn.symbol,
+      tokenOut: swapQuote.tokenOut.symbol,
+      chainId: swap.chainId,
+      maximumAmountIn: swapQuote.maximumAmountIn.toString(),
+      minAmountOut: swapQuote.minAmountOut.toString(),
+      expectedAmountOut: swapQuote.expectedAmountOut.toString(),
+      expectedAmountIn: swapQuote.expectedAmountIn.toString(),
+    });
+
+    return swapQuote;
+  };
+
+  return {
+    getRouterAddress,
+    getPeripheryAddress,
+    fetchFn,
+  };
+}

--- a/api/_dexes/uniswap/universal-router.ts
+++ b/api/_dexes/uniswap/universal-router.ts
@@ -30,12 +30,28 @@ export function getUniversalRouterStrategy(): UniswapQuoteFetchStrategy {
   const getPeripheryAddress = (chainId: number) =>
     getSpokePoolPeripheryAddress("uniswap-universalRouter", chainId);
 
-  const fetchFn = async (swap: Swap, tradeType: TradeType) => {
+  const fetchFn = async (
+    swap: Swap,
+    tradeType: TradeType,
+    opts: Partial<{
+      useIndicativeQuote: boolean;
+    }> = {
+      useIndicativeQuote: false,
+    }
+  ) => {
     const { quote } = await getUniswapClassicQuoteFromApi(
       { ...swap, swapper: swap.recipient },
       tradeType
     );
-    const classicSwap = await getUniswapClassicCalldataFromApi(quote);
+    const classicSwap = opts.useIndicativeQuote
+      ? {
+          swap: {
+            to: "0x",
+            data: "0x",
+            value: "0x",
+          },
+        }
+      : await getUniswapClassicCalldataFromApi(quote);
 
     const expectedAmountIn = BigNumber.from(quote.input.amount);
     const maxAmountIn =

--- a/api/_dexes/uniswap/universal-router.ts
+++ b/api/_dexes/uniswap/universal-router.ts
@@ -90,7 +90,7 @@ export function getUniversalRouterStrategy(): UniswapQuoteFetchStrategy {
       const minAmountOut =
         tradeType === TradeType.EXACT_OUTPUT
           ? expectedAmountOut
-          : addMarkupToAmount(expectedAmountOut, swap.slippageTolerance / 100);
+          : addMarkupToAmount(expectedAmountOut, -swap.slippageTolerance / 100);
 
       swapQuote = {
         tokenIn: swap.tokenIn,

--- a/api/_dexes/uniswap/utils.ts
+++ b/api/_dexes/uniswap/utils.ts
@@ -1,5 +1,20 @@
 import { CHAIN_IDs, TOKEN_SYMBOLS_MAP } from "@across-protocol/constants";
-import { Token } from "../types";
+import { TradeType } from "@uniswap/sdk-core";
+import axios from "axios";
+import { BigNumber, ethers } from "ethers";
+import { utils } from "@across-protocol/sdk";
+
+import { Swap, SwapQuote, Token } from "../types";
+
+export type UniswapQuoteFetchStrategy = {
+  getRouterAddress: (chainId: number) => string;
+  getPeripheryAddress: (chainId: number) => string;
+  fetchFn: UniswapQuoteFetchFn;
+};
+export type UniswapQuoteFetchFn = (
+  swap: Swap,
+  tradeType: TradeType
+) => Promise<SwapQuote>;
 
 // Maps testnet chain IDs to their prod counterparts. Used to get the prod token
 // info for testnet tokens.
@@ -9,6 +24,64 @@ const TESTNET_TO_PROD = {
   [CHAIN_IDs.OPTIMISM_SEPOLIA]: CHAIN_IDs.OPTIMISM,
   [CHAIN_IDs.ARBITRUM_SEPOLIA]: CHAIN_IDs.ARBITRUM,
 };
+
+export const UNISWAP_TRADING_API_BASE_URL =
+  process.env.UNISWAP_TRADING_API_BASE_URL ||
+  "https://trading-api-labs.interface.gateway.uniswap.org/v1";
+
+export const UNISWAP_API_KEY =
+  process.env.UNISWAP_API_KEY || "JoyCGj29tT4pymvhaGciK4r1aIPvqW6W53xT1fwo";
+
+/**
+ * Based on https://uniswap-docs.readme.io/reference/aggregator_quote-1
+ */
+export async function getUniswapClassicQuoteFromApi(
+  swap: Omit<Swap, "type"> & { swapper: string },
+  tradeType: TradeType
+) {
+  const response = await axios.post(
+    `${UNISWAP_TRADING_API_BASE_URL}/quote`,
+    {
+      type:
+        tradeType === TradeType.EXACT_INPUT ? "EXACT_INPUT" : "EXACT_OUTPUT",
+      tokenInChainId: swap.tokenIn.chainId,
+      tokenOutChainId: swap.tokenOut.chainId,
+      tokenIn: swap.tokenIn.address,
+      tokenOut: swap.tokenOut.address,
+      swapper: swap.swapper,
+      slippageTolerance: swap.slippageTolerance,
+      amount: swap.amount,
+      routingPreference: "CLASSIC",
+      urgency: "urgent",
+    },
+    {
+      headers: {
+        "x-api-key": UNISWAP_API_KEY,
+      },
+    }
+  );
+  return response.data as {
+    requestId: string;
+    routing: "CLASSIC";
+    quote: {
+      chainId: number;
+      input: {
+        amount: string;
+        token: string;
+      };
+      output: {
+        amount: string;
+        token: string;
+        recipient: string;
+      };
+      swapper: string;
+      route: any[];
+      slippage: number;
+      tradeType: "EXACT_OUTPUT" | "EXACT_INPUT";
+      quoteId: string;
+    };
+  };
+}
 
 export function getProdToken(token: Token) {
   const prodChainId = TESTNET_TO_PROD[token.chainId] || token.chainId;
@@ -28,4 +101,10 @@ export function getProdToken(token: Token) {
     chainId: prodChainId,
     address: prodTokenAddress,
   };
+}
+
+export function addMarkupToAmount(amount: BigNumber, markup = 0.01) {
+  return amount
+    .mul(ethers.utils.parseEther((1 + Number(markup)).toString()))
+    .div(utils.fixedPointAdjustment);
 }

--- a/api/_dexes/uniswap/utils.ts
+++ b/api/_dexes/uniswap/utils.ts
@@ -1,5 +1,5 @@
 import { CHAIN_IDs, TOKEN_SYMBOLS_MAP } from "@across-protocol/constants";
-import { TradeType } from "@uniswap/sdk-core";
+import { Percent, TradeType } from "@uniswap/sdk-core";
 import axios from "axios";
 import { BigNumber, ethers } from "ethers";
 import { utils } from "@across-protocol/sdk";
@@ -110,4 +110,12 @@ export function addMarkupToAmount(amount: BigNumber, markup = 0.01) {
   return amount
     .mul(ethers.utils.parseEther((1 + Number(markup)).toString()))
     .div(utils.fixedPointAdjustment);
+}
+
+export function floatToPercent(value: number) {
+  return new Percent(
+    // max. slippage decimals is 2
+    Number(value.toFixed(2)) * 100,
+    10_000
+  );
 }

--- a/api/_dexes/uniswap/utils.ts
+++ b/api/_dexes/uniswap/utils.ts
@@ -13,7 +13,10 @@ export type UniswapQuoteFetchStrategy = {
 };
 export type UniswapQuoteFetchFn = (
   swap: Swap,
-  tradeType: TradeType
+  tradeType: TradeType,
+  opts?: Partial<{
+    useIndicativeQuote: boolean;
+  }>
 ) => Promise<SwapQuote>;
 
 // Maps testnet chain IDs to their prod counterparts. Used to get the prod token

--- a/api/_errors.ts
+++ b/api/_errors.ts
@@ -241,7 +241,7 @@ export function handleErrorCondition(
         { cause: error }
       );
     } else {
-      const message = `Upstream http request to ${error.request?.url} failed with ${error.status} ${error.message}`;
+      const message = `Upstream http request to ${error.request?.host} failed with ${error.response?.status}`;
       acrossApiError = new AcrossApiError(
         {
           message,
@@ -276,6 +276,7 @@ export function handleErrorCondition(
     at: endpoint,
     code: acrossApiError.code,
     message: `Status ${acrossApiError.status} - ${acrossApiError.message}`,
+    cause: acrossApiError.cause,
   });
 
   return response.status(acrossApiError.status).json(acrossApiError);

--- a/api/_spoke-pool-periphery.ts
+++ b/api/_spoke-pool-periphery.ts
@@ -25,9 +25,7 @@ export function getSpokePoolPeripheryAddress(dex: string, chainId: number) {
   return address;
 }
 
-export function getSpokePoolPeriphery(dex: string, chainId: number) {
-  const address = getSpokePoolPeripheryAddress(dex, chainId);
-
+export function getSpokePoolPeriphery(address: string, chainId: number) {
   return SpokePoolV3Periphery__factory.connect(address, getProvider(chainId));
 }
 

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -201,7 +201,6 @@ export const getLogger = (): LoggingUtility => {
  * @returns A valid URL of the current endpoint in vercel
  */
 export const resolveVercelEndpoint = () => {
-  return "https://app.across.to";
   const url = process.env.VERCEL_URL ?? "across.to";
   const env = process.env.VERCEL_ENV ?? "development";
   switch (env) {

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -201,6 +201,7 @@ export const getLogger = (): LoggingUtility => {
  * @returns A valid URL of the current endpoint in vercel
  */
 export const resolveVercelEndpoint = () => {
+  return "https://app.across.to";
   const url = process.env.VERCEL_URL ?? "across.to";
   const env = process.env.VERCEL_ENV ?? "development";
   switch (env) {
@@ -971,7 +972,7 @@ export async function getBridgeQuoteForMinOutput(params: {
           { cause: err }
         );
       } else {
-        const message = `Upstream http request to ${err.request?.url} failed with ${err.status} ${err.message}`;
+        const message = `Upstream http request to ${err.request?.host} failed with ${err.response?.status}`;
         throw new AcrossApiError(
           {
             message,

--- a/api/swap/_utils.ts
+++ b/api/swap/_utils.ts
@@ -131,12 +131,12 @@ export async function handleBaseSwapQueryParams({
   });
 
   // 3. Calculate fees based for full route
-  const fees = await calculateCrossSwapFees(crossSwapQuotes);
+  // const fees = await calculateCrossSwapFees(crossSwapQuotes);
 
   return {
     crossSwapQuotes: {
       ...crossSwapQuotes,
-      fees,
+      // fees,
     },
     integratorId,
     skipOriginTxEstimation,

--- a/api/swap/allowance.ts
+++ b/api/swap/allowance.ts
@@ -138,9 +138,7 @@ const handler = async (
         crossSwapQuotes.bridgeQuote.outputAmount.toString(),
       minOutputAmount:
         crossSwapQuotes.destinationSwapQuote?.minAmountOut.toString() ??
-        crossSwapQuotes.crossSwap.type === AMOUNT_TYPE.EXACT_INPUT
-          ? crossSwapQuotes.bridgeQuote.outputAmount.toString()
-          : crossSwapQuotes.crossSwap.amount.toString(),
+        crossSwapQuotes.bridgeQuote.outputAmount.toString(),
       expectedFillTime:
         crossSwapQuotes.bridgeQuote.suggestedFees.estimatedFillTimeSec,
     };

--- a/api/swap/allowance.ts
+++ b/api/swap/allowance.ts
@@ -96,7 +96,7 @@ const handler = async (
       : crossSwapQuotes.bridgeQuote.outputToken;
 
     const responseJson = {
-      fees: crossSwapQuotes.fees,
+      // fees: crossSwapQuotes.fees,
       checks: {
         allowance: {
           token: inputTokenAddress,

--- a/api/swap/allowance.ts
+++ b/api/swap/allowance.ts
@@ -8,7 +8,10 @@ import {
   handleErrorCondition,
   latestGasPriceCache,
 } from "../_utils";
-import { buildCrossSwapTxForAllowanceHolder } from "../_dexes/cross-swap";
+import {
+  AMOUNT_TYPE,
+  buildCrossSwapTxForAllowanceHolder,
+} from "../_dexes/cross-swap";
 import {
   handleBaseSwapQueryParams,
   BaseSwapQueryParams,
@@ -135,7 +138,9 @@ const handler = async (
         crossSwapQuotes.bridgeQuote.outputAmount.toString(),
       minOutputAmount:
         crossSwapQuotes.destinationSwapQuote?.minAmountOut.toString() ??
-        crossSwapQuotes.bridgeQuote.outputAmount.toString(),
+        crossSwapQuotes.crossSwap.type === AMOUNT_TYPE.EXACT_INPUT
+          ? crossSwapQuotes.bridgeQuote.outputAmount.toString()
+          : crossSwapQuotes.crossSwap.amount.toString(),
       expectedFillTime:
         crossSwapQuotes.bridgeQuote.suggestedFees.estimatedFillTimeSec,
     };

--- a/scripts/generate-routes.ts
+++ b/scripts/generate-routes.ts
@@ -105,7 +105,7 @@ const enabledRoutes = {
       },
     },
     spokePoolPeripheryAddresses: {
-      uniswap: {
+      "uniswap-swapRouter02": {
         [CHAIN_IDs.POLYGON]: "0x8EB5FF2e23FD7789e59989aDe055A398800E394e",
         [CHAIN_IDs.OPTIMISM]: "0x8EB5FF2e23FD7789e59989aDe055A398800E394e",
         [CHAIN_IDs.ARBITRUM]: "0x8EB5FF2e23FD7789e59989aDe055A398800E394e",
@@ -115,6 +115,10 @@ const enabledRoutes = {
         [CHAIN_IDs.BLAST]: "0x8EB5FF2e23FD7789e59989aDe055A398800E394e",
         [CHAIN_IDs.ZORA]: "0x8EB5FF2e23FD7789e59989aDe055A398800E394e",
         [CHAIN_IDs.MAINNET]: "0x8EB5FF2e23FD7789e59989aDe055A398800E394e",
+      },
+      "uniswap-universalRouter": {
+        [CHAIN_IDs.OPTIMISM]: "0xaED9bBFdCC63219d77D54F8427aeb84C2Be46c5f",
+        [CHAIN_IDs.ARBITRUM]: "0xaED9bBFdCC63219d77D54F8427aeb84C2Be46c5f",
       },
     },
     routes: transformChainConfigs(enabledMainnetChainConfigs),

--- a/scripts/tests/swap-allowance.ts
+++ b/scripts/tests/swap-allowance.ts
@@ -116,6 +116,7 @@ const MIN_OUTPUT_CASES = [
       outputToken: TOKEN_SYMBOLS_MAP.WETH.addresses[destinationChainId],
       destinationChainId,
       depositor,
+      skipOriginTxEstimation: true,
     },
   },
   {
@@ -178,7 +179,7 @@ async function swap() {
     );
     console.log(response.data);
 
-    if (!process.env.DEV_WALLET_PK) {
+    if (process.env.DEV_WALLET_PK) {
       const wallet = new Wallet(process.env.DEV_WALLET_PK!).connect(
         getProvider(testCase.params.originChainId)
       );

--- a/scripts/tests/swap-allowance.ts
+++ b/scripts/tests/swap-allowance.ts
@@ -143,8 +143,6 @@ const MIN_OUTPUT_CASES = [
       outputToken: anyDestinationOutputTokens[destinationChainId], // APE Coin
       destinationChainId,
       depositor,
-      // skipOriginTxEstimation: true,
-      refundOnOrigin: false,
     },
   },
 ];
@@ -172,16 +170,14 @@ async function swap() {
     console.log("\nTest case:", testCase.labels.join(" "));
     console.log("Params:", testCase.params);
     const response = await axios.get(
-      // `https://preview.across.to/api/swap/allowance`,
       `http://localhost:3000/api/swap/allowance`,
-      // `https://app-frontend-v3-git-universal-router-support-uma.vercel.app/api/swap/allowance`,
       {
         params: testCase.params,
       }
     );
     console.log(response.data);
 
-    if (!process.env.DEV_WALLET_PK) {
+    if (process.env.DEV_WALLET_PK) {
       const wallet = new Wallet(process.env.DEV_WALLET_PK!).connect(
         getProvider(testCase.params.originChainId)
       );

--- a/scripts/tests/swap-allowance.ts
+++ b/scripts/tests/swap-allowance.ts
@@ -109,14 +109,13 @@ const MIN_OUTPUT_CASES = [
   {
     labels: ["A2B", "MIN_OUTPUT", "USDC - WETH"],
     params: {
-      amount: ethers.utils.parseUnits("0.01", 18).toString(),
+      amount: ethers.utils.parseUnits("0.001", 18).toString(),
       tradeType: "minOutput",
       inputToken: TOKEN_SYMBOLS_MAP.USDC.addresses[originChainId],
       originChainId,
       outputToken: TOKEN_SYMBOLS_MAP.WETH.addresses[destinationChainId],
       destinationChainId,
       depositor,
-      skipOriginTxEstimation: true,
     },
   },
   {
@@ -144,6 +143,8 @@ const MIN_OUTPUT_CASES = [
       outputToken: anyDestinationOutputTokens[destinationChainId], // APE Coin
       destinationChainId,
       depositor,
+      // skipOriginTxEstimation: true,
+      refundOnOrigin: false,
     },
   },
 ];
@@ -173,13 +174,14 @@ async function swap() {
     const response = await axios.get(
       // `https://preview.across.to/api/swap/allowance`,
       `http://localhost:3000/api/swap/allowance`,
+      // `https://app-frontend-v3-git-universal-router-support-uma.vercel.app/api/swap/allowance`,
       {
         params: testCase.params,
       }
     );
     console.log(response.data);
 
-    if (process.env.DEV_WALLET_PK) {
+    if (!process.env.DEV_WALLET_PK) {
       const wallet = new Wallet(process.env.DEV_WALLET_PK!).connect(
         getProvider(testCase.params.originChainId)
       );

--- a/src/data/routes_1_0xc186fA914353c44b2E33eBE05f21846F1048bEda.json
+++ b/src/data/routes_1_0xc186fA914353c44b2E33eBE05f21846F1048bEda.json
@@ -21,7 +21,7 @@
     }
   },
   "spokePoolPeripheryAddresses": {
-    "uniswap": {
+    "uniswap-swapRouter02": {
       "1": "0x8EB5FF2e23FD7789e59989aDe055A398800E394e",
       "10": "0x8EB5FF2e23FD7789e59989aDe055A398800E394e",
       "137": "0x8EB5FF2e23FD7789e59989aDe055A398800E394e",
@@ -31,6 +31,10 @@
       "42161": "0x8EB5FF2e23FD7789e59989aDe055A398800E394e",
       "81457": "0x8EB5FF2e23FD7789e59989aDe055A398800E394e",
       "7777777": "0x8EB5FF2e23FD7789e59989aDe055A398800E394e"
+    },
+    "uniswap-universalRouter": {
+      "10": "0xaED9bBFdCC63219d77D54F8427aeb84C2Be46c5f",
+      "42161": "0xaED9bBFdCC63219d77D54F8427aeb84C2Be46c5f"
     }
   },
   "routes": [


### PR DESCRIPTION
Closes ACX-3382

Sorry for the big PR but had to refactor quite a lot to support the Trading API and `UniversalRouter`. This PR allows the usage of different quote resolving + tx building strategies. We also make use the trading API for improved performance.

Note that it is possible to use the Uniswap API to retrieve a quote and use the old SwapRouter02 implementation to build the respective tx. One problem we need to address is the requirement for permit2 support when using the UniversalRouter contract.