### PR TITLE
feat: add unblocking warning-level input validation

### DIFF
--- a/src/components/AmountInput/AmountInput.tsx
+++ b/src/components/AmountInput/AmountInput.tsx
@@ -138,7 +138,7 @@ export function AmountInput({
             ${formatUSD(estimatedUsdInputAmount)}
           </Text>
         )}
-        {validationLevel === "valid" && !disableErrorText && (
+        {validationLevel !== "valid" && !disableErrorText && (
           <Text size="md" color="error">
             {validationError}
           </Text>

--- a/src/components/AmountInput/AmountInput.tsx
+++ b/src/components/AmountInput/AmountInput.tsx
@@ -139,8 +139,8 @@ export function AmountInput({
           </Text>
         )}
         {validationLevel !== "valid" && !disableErrorText && (
-          <Text size="md" color="error">
-            {validationError}
+          <Text size="md" color={validationError ? "error" : "warning"}>
+            {validationError || validationWarning}
           </Text>
         )}
       </InfoTextWrapper>

--- a/src/components/AmountInput/AmountInput.tsx
+++ b/src/components/AmountInput/AmountInput.tsx
@@ -8,11 +8,11 @@ import { Text } from "components/Text";
 import { Tooltip } from "components/Tooltip";
 import { useTokenConversion } from "hooks/useTokenConversion";
 import {
+  COLORS,
   QUERIESV2,
   formatUSD,
   formatUnitsWithMaxFractions,
   getToken,
-  isDefined,
   isNumberEthersParseable,
   parseUnits,
 } from "utils";
@@ -25,6 +25,7 @@ export type Props = {
   onClickMaxBalance: () => void;
   inputTokenSymbol: string;
   validationError?: string;
+  validationWarning?: string;
   dataCy?: string;
   disableErrorText?: boolean;
   disableInput?: boolean;
@@ -41,6 +42,7 @@ export function AmountInput({
   onClickMaxBalance,
   inputTokenSymbol,
   validationError,
+  validationWarning,
   disableErrorText,
   disableInput,
   disableMaxButton,
@@ -48,8 +50,14 @@ export function AmountInput({
 }: Props) {
   const token = getToken(inputTokenSymbol);
 
-  const isAmountValid =
-    (amountInput ?? "") === "" || !isDefined(validationError);
+  const validationLevel =
+    (amountInput ?? "") === ""
+      ? "valid"
+      : validationError
+        ? "error"
+        : validationWarning
+          ? "warning"
+          : "valid";
 
   const { convertTokenToBaseCurrency } = useTokenConversion(
     inputTokenSymbol,
@@ -68,7 +76,7 @@ export function AmountInput({
 
   return (
     <Wrapper>
-      <InputGroupWrapper valid={isAmountValid}>
+      <InputGroupWrapper validationLevel={validationLevel}>
         {displayTokenIcon ? (
           token.logoURIs?.length === 2 ? (
             <IconPairContainer>
@@ -84,7 +92,7 @@ export function AmountInput({
         ) : null}
         <Input
           type="number"
-          valid={isAmountValid}
+          validationLevel={validationLevel}
           placeholder="Enter amount"
           value={amountInput}
           onWheel={(e) => e.currentTarget.blur()}
@@ -130,7 +138,7 @@ export function AmountInput({
             ${formatUSD(estimatedUsdInputAmount)}
           </Text>
         )}
-        {!isAmountValid && !disableErrorText && (
+        {validationLevel === "valid" && !disableErrorText && (
           <Text size="md" color="error">
             {validationError}
           </Text>
@@ -143,8 +151,23 @@ export function AmountInput({
 export default AmountInput;
 
 interface IValidInput {
-  valid: boolean;
+  validationLevel: "valid" | "error" | "warning";
 }
+
+const colorMap = {
+  valid: {
+    border: COLORS["grey-600"],
+    text: COLORS["white-100"],
+  },
+  error: {
+    border: COLORS.red,
+    text: COLORS.red,
+  },
+  warning: {
+    border: COLORS.yellow,
+    text: COLORS.yellow,
+  },
+};
 
 const Wrapper = styled.div`
   display: flex;
@@ -159,7 +182,7 @@ const InputGroupWrapper = styled.div<IValidInput>`
   align-items: center;
   padding: 9px 12px 9px 16px;
   background: #2d2e33;
-  border: 1px solid ${({ valid }) => (valid ? "#3E4047" : "#f96c6c")};
+  border: 1px solid ${({ validationLevel }) => colorMap[validationLevel].border};
   border-radius: 12px;
   height: 48px;
   gap: 8px;
@@ -173,9 +196,7 @@ const Input = styled.input<IValidInput>`
   font-weight: 400;
   font-size: 18px;
   line-height: 26px;
-  color: #e0f3ff;
-
-  color: ${({ valid }) => (valid ? "#e0f3ff" : "#f96c6c")};
+  color: ${({ validationLevel }) => colorMap[validationLevel].text};
   background: none;
 
   width: 100%;

--- a/src/views/Bridge/Bridge.tsx
+++ b/src/views/Bridge/Bridge.tsx
@@ -23,6 +23,7 @@ const Bridge = () => {
     fees,
     balance,
     amountValidationError,
+    amountValidationWarning,
     userAmountInput,
     swapSlippage,
     parsedAmountInput,
@@ -78,6 +79,7 @@ const Bridge = () => {
             buttonLabel={buttonLabel}
             isBridgeDisabled={isBridgeDisabled}
             validationError={amountValidationError}
+            validationWarning={amountValidationWarning}
             balance={balance}
             isQuoteLoading={isQuoteLoading}
             swapQuote={swapQuote}

--- a/src/views/Bridge/components/AmountInput.tsx
+++ b/src/views/Bridge/components/AmountInput.tsx
@@ -50,9 +50,18 @@ export function AmountInput({
           : selectedRoute.fromTokenSymbol
       }
       validationError={
-        validationError || validationWarning
+        validationError
           ? getValidationErrorText({
-              validationError: validationError || validationWarning,
+              validationError: validationError,
+              selectedRoute,
+              limits,
+            })
+          : undefined
+      }
+      validationWarning={
+        validationWarning
+          ? getValidationErrorText({
+              validationError: validationWarning,
               selectedRoute,
               limits,
             })

--- a/src/views/Bridge/components/AmountInput.tsx
+++ b/src/views/Bridge/components/AmountInput.tsx
@@ -27,6 +27,7 @@ type Props = {
   onClickMaxBalance: () => void;
   selectedRoute: SelectedRoute;
   validationError?: AmountInputError;
+  validationWarning?: AmountInputError;
   limits?: BridgeLimits;
 };
 
@@ -37,6 +38,7 @@ export function AmountInput({
   onClickMaxBalance,
   selectedRoute,
   validationError,
+  validationWarning,
   limits,
 }: Props) {
   return (
@@ -48,16 +50,12 @@ export function AmountInput({
           : selectedRoute.fromTokenSymbol
       }
       validationError={
-        validationError
-          ? validationErrorTextMap[validationError]
-              .replace("[INPUT_TOKEN]", selectedRoute.fromTokenSymbol)
-              .replace(
-                "[MAX_DEPOSIT]",
-                `${formatUnitsWithMaxFractions(
-                  limits?.maxDeposit || 0,
-                  getToken(selectedRoute.fromTokenSymbol).decimals
-                )} ${selectedRoute.fromTokenSymbol}`
-              )
+        validationError || validationWarning
+          ? getValidationErrorText({
+              validationError: validationError || validationWarning,
+              selectedRoute,
+              limits,
+            })
           : undefined
       }
       onChangeAmountInput={onChangeAmountInput}
@@ -67,6 +65,25 @@ export function AmountInput({
       amountInput={amountInput}
     />
   );
+}
+
+function getValidationErrorText(props: {
+  validationError?: AmountInputError;
+  selectedRoute: SelectedRoute;
+  limits?: BridgeLimits;
+}) {
+  if (!props.validationError) {
+    return undefined;
+  }
+  return validationErrorTextMap[props.validationError]
+    .replace("[INPUT_TOKEN]", props.selectedRoute.fromTokenSymbol)
+    .replace(
+      "[MAX_DEPOSIT]",
+      `${formatUnitsWithMaxFractions(
+        props.limits?.maxDeposit || 0,
+        getToken(props.selectedRoute.fromTokenSymbol).decimals
+      )} ${props.selectedRoute.fromTokenSymbol}`
+    );
 }
 
 export default AmountInput;

--- a/src/views/Bridge/components/BridgeForm.tsx
+++ b/src/views/Bridge/components/BridgeForm.tsx
@@ -66,6 +66,7 @@ export type BridgeFormProps = {
   buttonLabel: string;
   isBridgeDisabled: boolean;
   validationError?: AmountInputError;
+  validationWarning?: AmountInputError;
   isQuoteLoading: boolean;
 };
 
@@ -101,6 +102,7 @@ const BridgeForm = ({
   buttonLabel,
   isBridgeDisabled,
   validationError,
+  validationWarning,
   isQuoteLoading,
 }: BridgeFormProps) => {
   const programName = chainIdToRewardsProgramName[selectedRoute.toChain];
@@ -149,6 +151,9 @@ const BridgeForm = ({
             onChangeAmountInput={onChangeAmountInput}
             onClickMaxBalance={onClickMaxBalance}
             validationError={parsedAmountInput ? validationError : undefined}
+            validationWarning={
+              parsedAmountInput ? validationWarning : undefined
+            }
             balance={balance}
             limits={limits}
           />

--- a/src/views/Bridge/hooks/useBridge.ts
+++ b/src/views/Bridge/hooks/useBridge.ts
@@ -59,15 +59,16 @@ export function useBridge() {
     (transferQuoteQuery.isInitialLoading || feesQuery.isInitialLoading) &&
     !transferQuote;
 
-  const { error: amountValidationError } = validateBridgeAmount(
-    parsedAmount,
-    quotedFees,
-    maxBalance,
-    limitsQuery.limits?.maxDeposit,
-    selectedRoute.type === "swap" && quotedSwap?.minExpectedInputTokenAmount
-      ? BigNumber.from(quotedSwap?.minExpectedInputTokenAmount)
-      : parsedAmount
-  );
+  const { error: amountValidationError, warn: amountValidationWarning } =
+    validateBridgeAmount(
+      parsedAmount,
+      quotedFees,
+      maxBalance,
+      limitsQuery.limits?.maxDeposit,
+      selectedRoute.type === "swap" && quotedSwap?.minExpectedInputTokenAmount
+        ? BigNumber.from(quotedSwap?.minExpectedInputTokenAmount)
+        : parsedAmount
+    );
   const isAmountValid = !amountValidationError;
 
   const {
@@ -138,6 +139,7 @@ export function useBridge() {
     userAmountInput,
     swapSlippage,
     amountValidationError,
+    amountValidationWarning,
     handleSelectFromChain,
     handleSelectToChain,
     handleSelectInputToken,

--- a/src/views/Bridge/utils.ts
+++ b/src/views/Bridge/utils.ts
@@ -145,7 +145,7 @@ export function validateBridgeAmount(
       .div(fixedPointAdjustment);
     if (totalFeeInL1.gt(maximalFee)) {
       return {
-        error: AmountInputError.PRICE_IMPACT_TOO_HIGH,
+        warn: AmountInputError.PRICE_IMPACT_TOO_HIGH,
       };
     }
   }


### PR DESCRIPTION
This PR unblocks the user from depositing if the suggested fees pct is > 5bps. It still shows a warning like in the screenshot below:

<img width="635" alt="image" src="https://github.com/user-attachments/assets/32171a5d-bcd4-4f1b-8de6-39d284064ff9">
