### PR TITLE
fix: cron ping endpoints

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -17,6 +17,9 @@
   "functions": {
     "api/cron-cache-gas-prices.ts": {
       "maxDuration": 90
+    },
+		"api/cron-ping-endpoints.ts": {
+      "maxDuration": 90
     }
   },
   "rewrites": [

--- a/vercel.json
+++ b/vercel.json
@@ -18,7 +18,7 @@
     "api/cron-cache-gas-prices.ts": {
       "maxDuration": 90
     },
-		"api/cron-ping-endpoints.ts": {
+    "api/cron-ping-endpoints.ts": {
       "maxDuration": 90
     }
   },


### PR DESCRIPTION
The cron job works but leads a `Gateway Timeout` because the default exec time is 15 sec. Bump to 60 seconds.