### PR TITLE
fix: network switch in staking/rewards

### DIFF
--- a/src/views/Staking/Staking.tsx
+++ b/src/views/Staking/Staking.tsx
@@ -15,6 +15,7 @@ const Staking = () => {
     claimActionMutation,
     unstakeActionMutation,
     isWrongNetwork,
+    isWrongNetworkHandler,
     poolData,
   } = useStakingView();
 
@@ -35,6 +36,7 @@ const Staking = () => {
               stakeActionMutation.isLoading || unstakeActionMutation.isLoading
             }
             isWrongNetwork={isWrongNetwork}
+            switchNetwork={isWrongNetworkHandler}
             isConnected={isConnected}
             stakeActionFn={stakeActionMutation.mutateAsync}
             unstakeActionFn={unstakeActionMutation.mutateAsync}
@@ -46,6 +48,8 @@ const Staking = () => {
             isConnected={isConnected}
             claimActionHandler={claimActionMutation.mutateAsync}
             isMutating={claimActionMutation.isLoading}
+            isWrongNetwork={isWrongNetwork}
+            switchNetwork={isWrongNetworkHandler}
           />
         </Wrapper>
       </LayoutV2>

--- a/src/views/Staking/components/StakingForm/StakingForm.styles.tsx
+++ b/src/views/Staking/components/StakingForm/StakingForm.styles.tsx
@@ -1,5 +1,6 @@
 import styled from "@emotion/styled";
 import ProgressBar from "components/ProgressBar";
+import { PrimaryButton } from "components/Button";
 import { ReactComponent as UnstyledArrowIcon } from "assets/icons/chevron-down.svg";
 import { ReactComponent as II } from "assets/icons/info.svg";
 import { Divider as ExternalDivider } from "../../Staking.styles";
@@ -140,4 +141,8 @@ export const InputBlockWrapper = styled.div`
   > div {
     width: 100%;
   }
+`;
+
+export const SwitchNetworkButton = styled(PrimaryButton)`
+  width: 100%;
 `;

--- a/src/views/Staking/components/StakingForm/StakingForm.tsx
+++ b/src/views/Staking/components/StakingForm/StakingForm.tsx
@@ -13,6 +13,7 @@ import {
   InnerPoolStakeInfo,
   ArrowIconUp,
   ArrowIconDown,
+  SwitchNetworkButton,
 } from "./StakingForm.styles";
 
 import { Tooltip } from "components/Tooltip";
@@ -32,6 +33,7 @@ export const StakingForm = ({
   stakeActionFn,
   unstakeActionFn,
   isWrongNetwork,
+  switchNetwork,
   isDataLoading,
   isMutating,
   poolData: originPoolData,
@@ -114,21 +116,27 @@ export const StakingForm = ({
         </Tabs>
         <InputBlockWrapper>
           {isConnected ? (
-            <StakingInputBlock
-              value={amount ?? ""}
-              setValue={setAmount}
-              valid={isAmountValid}
-              invalid={isAmountInvalid}
-              poolTokenSymbol={tokenSymbol}
-              maxValue={buttonMaxValueText}
-              stakingAction={stakingAction}
-              onClickHandler={buttonHandler}
-              displayLoader={isMutating}
-              warningButtonColor={stakingAction === "unstake"}
-              disableInput={
-                isDataLoading || isMutating || !poolData.poolEnabled
-              }
-            />
+            isWrongNetwork ? (
+              <SwitchNetworkButton size="lg" onClick={() => switchNetwork()}>
+                Switch network
+              </SwitchNetworkButton>
+            ) : (
+              <StakingInputBlock
+                value={amount ?? ""}
+                setValue={setAmount}
+                valid={isAmountValid}
+                invalid={isAmountInvalid}
+                poolTokenSymbol={tokenSymbol}
+                maxValue={buttonMaxValueText}
+                stakingAction={stakingAction}
+                onClickHandler={buttonHandler}
+                displayLoader={isMutating}
+                warningButtonColor={stakingAction === "unstake"}
+                disableInput={
+                  isDataLoading || isMutating || !poolData.poolEnabled
+                }
+              />
+            )
           ) : (
             <ConnectWalletButton reasonToConnect={stakingAction} />
           )}

--- a/src/views/Staking/components/StakingReward/StakingReward.tsx
+++ b/src/views/Staking/components/StakingReward/StakingReward.tsx
@@ -9,12 +9,15 @@ import { StakingRewardPropType } from "../../types";
 import { Text } from "components/Text";
 import ConnectWalletButton from "../ConnectWalletButton";
 import CardWrapper from "components/CardWrapper";
+import { SwitchNetworkButton } from "../StakingForm/StakingForm.styles";
 
 export const StakingReward = ({
   poolData: { outstandingRewards },
   isConnected,
   claimActionHandler,
   isMutating,
+  isWrongNetwork,
+  switchNetwork,
 }: StakingRewardPropType) => {
   const valueOrEmpty = repeatableTernaryBuilder(
     isConnected && BigNumber.from(outstandingRewards).gt(0),
@@ -31,26 +34,34 @@ export const StakingReward = ({
           </Text>
         </Alert>
         {isConnected ? (
-          <ClaimRewardInputGroup>
-            <RewardClaimWrapper>
-              <Text color="white-70">Claimable rewards</Text>
-              {valueOrEmpty(
-                <Text
-                  color={outstandingRewards.gt(0) ? "white-100" : "white-70"}
-                >
-                  {formatUnitsWithMaxFractions(outstandingRewards, 18)} ACX
-                </Text>
-              )}
-            </RewardClaimWrapper>
-            <ClaimRewardButton
-              size="lg"
-              disabled={BigNumber.from(outstandingRewards).lte(0) || isMutating}
-              onClick={() => claimActionHandler()}
-              borderColor="yellow"
-            >
-              {isMutating ? "Claiming..." : "Claim"}
-            </ClaimRewardButton>
-          </ClaimRewardInputGroup>
+          isWrongNetwork ? (
+            <SwitchNetworkButton size="lg" onClick={() => switchNetwork()}>
+              Switch network
+            </SwitchNetworkButton>
+          ) : (
+            <ClaimRewardInputGroup>
+              <RewardClaimWrapper>
+                <Text color="white-70">Claimable rewards</Text>
+                {valueOrEmpty(
+                  <Text
+                    color={outstandingRewards.gt(0) ? "white-100" : "white-70"}
+                  >
+                    {formatUnitsWithMaxFractions(outstandingRewards, 18)} ACX
+                  </Text>
+                )}
+              </RewardClaimWrapper>
+              <ClaimRewardButton
+                size="lg"
+                disabled={
+                  BigNumber.from(outstandingRewards).lte(0) || isMutating
+                }
+                onClick={() => claimActionHandler()}
+                borderColor="yellow"
+              >
+                {isMutating ? "Claiming..." : "Claim"}
+              </ClaimRewardButton>
+            </ClaimRewardInputGroup>
+          )
         ) : (
           <ConnectWalletButton reasonToConnect="claim rewards" />
         )}

--- a/src/views/Staking/types.ts
+++ b/src/views/Staking/types.ts
@@ -4,6 +4,8 @@ import { StakingActionFunctionType } from "./hooks/useStakingAction";
 type GenericStakingComponentProps = {
   isConnected: boolean;
   poolData: StakingPool;
+  isWrongNetwork: boolean;
+  switchNetwork: () => Promise<void>;
 };
 
 export type StakingRewardPropType = GenericStakingComponentProps & {
@@ -20,6 +22,5 @@ export type StakingFormPropType = GenericStakingComponentProps & {
   unstakeActionFn: StakingActionFunctionType;
   isDataLoading: boolean;
   isMutating: boolean;
-  isWrongNetwork: boolean;
   tokenSymbol: string;
 };


### PR DESCRIPTION
If on the staking page with the wrong network in your wallet, clicking the button fails silently. This PR fixes it