### PR TITLE
nit: remove unused vars

### DIFF
--- a/src/views/Bridge/utils.ts
+++ b/src/views/Bridge/utils.ts
@@ -12,8 +12,6 @@ import {
   interchangeableTokensMap,
   nonEthChains,
   GetBridgeFeesResult,
-  isDefined,
-  parseUnits,
 } from "utils";
 import { SwapQuoteApiResponse } from "utils/serverless-api/prod/swap-quote";
 


### PR DESCRIPTION
To drop the warning on `yarn lint`