### PR TITLE
improve: reduce edgecase on delayed deposits

### DIFF
--- a/src/components/DepositsTable/hooks/useDepositStatus.ts
+++ b/src/components/DepositsTable/hooks/useDepositStatus.ts
@@ -34,7 +34,7 @@ export function useDepositStatus(deposit: Deposit) {
       DateTime.fromSeconds(deposit.depositTime).diffNow("seconds").as("seconds")
     ) > pendingStateTimeUntilDelayed &&
     limits
-      ? BigNumber.from(deposit.amount).gt(limits?.maxDepositInstant)
+      ? BigNumber.from(deposit.amount).gt(limits?.maxDepositShortDelay)
       : false;
 
   const isExpired = deposit.fillDeadline


### PR DESCRIPTION
Currently we have a case where if a deposit takes longer than 5 minutes and is larger than the max deposit instant then we display a 3-hour warning. This change updates the deposit to only mark delay if the deposit amount is larger than the max deposit short delay