### PR TITLE
chore: bump api spec

### DIFF
--- a/api-docs-openapi.yaml
+++ b/api-docs-openapi.yaml
@@ -104,8 +104,8 @@ paths:
             Calldata passed to the `recipient` if `recipient` is a contract
             address.  This calldata is passed to the recipient via the
             recipient's handleAcrossMessage() public function. The length of
-            this value is constrained by the API to ~4096 chars minus the length
-            of the full URL.
+            this value is constrained by the API to ~12288 chars (12KB) minus 
+            the length of the full URL.
 
 
             _Example:_ 0xABC123


### PR DESCRIPTION
4KB -> 12KB