### PR TITLE
chore: Drop max message length description

### DIFF
--- a/api-docs-openapi.yaml
+++ b/api-docs-openapi.yaml
@@ -103,10 +103,7 @@ paths:
           description: >
             Calldata passed to the `recipient` if `recipient` is a contract
             address.  This calldata is passed to the recipient via the
-            recipient's handleAcrossMessage() public function. The length of
-            this value is constrained by the API to ~12288 chars (12KB) minus 
-            the length of the full URL.
-
+            recipient's handleAcrossMessage() public function.
 
             _Example:_ 0xABC123
           schema:


### PR DESCRIPTION
This encourages integrators to work around the limit. Better to have it fail and let them reach out.