### PR TITLE
fix: correct codeowner file syntax

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,5 +10,5 @@
 *       @mrice32 @nicholaspai @dohaki @james-a-morris
 
 # Serverless api
-api/* @mrice32 @nicholaspai @dohaki @james-a-morris @pxrl
+/api/ @mrice32 @nicholaspai @dohaki @james-a-morris @pxrl
 


### PR DESCRIPTION
The syntax used in the codeowners file that was just committed differs slightly from the github canonical syntax.
- They use a preceding / for root of the repo. Not sure if this is implicit if you drop it, but this is corrected to be safe.
- api/* would only apply to files in the api directory, not to files in subdirectories. This is fixed by dropping the *.

Sorry for the confusion, I should have checked the syntax more carefully!

Feel free to merge once approved.