### PR TITLE
improve(API): Pass gasPrice into relayerFeeDetails call

### DIFF
--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -1948,6 +1948,7 @@ export function isContractCache(chainId: number, address: string) {
 
 export function getCachedFillGasUsage(
   deposit: Parameters<typeof buildDepositForSimulation>[0],
+  gasPrice: BigNumber,
   overrides?: Partial<{
     spokePoolAddress: string;
     relayerAddress: string;
@@ -1975,6 +1976,7 @@ export function getCachedFillGasUsage(
       buildDepositForSimulation(deposit),
       overrides?.relayerAddress,
       {
+        gasPrice,
         // Scale the op stack L1 gas cost component by the base fee multiplier.
         // Consider adding a new environment variable OP_STACK_L1_GAS_COST_MARKUP if we want finer-grained control.
         opStackL1GasCostMultiplier: getGasMarkup(deposit.destinationChainId)

--- a/api/limits.ts
+++ b/api/limits.ts
@@ -164,7 +164,7 @@ const handler = async (
       message,
     };
 
-    const [tokenPriceNative, _tokenPriceUsd, latestBlock, gasCosts, gasPrice] =
+    const [tokenPriceNative, _tokenPriceUsd, latestBlock, gasPrice] =
       await Promise.all([
         getCachedTokenPrice(
           l1Token.address,
@@ -172,31 +172,22 @@ const handler = async (
         ),
         getCachedTokenPrice(l1Token.address, "usd"),
         getCachedLatestBlock(HUB_POOL_CHAIN_ID),
-        // Only use cached gas units if message is not defined, i.e. standard for standard bridges
-        isMessageDefined
-          ? undefined
-          : getCachedFillGasUsage(depositArgs, {
-              relayerAddress: relayer,
-            }),
         latestGasPriceCache(destinationChainId).get(),
       ]);
     const tokenPriceUsd = ethers.utils.parseUnits(_tokenPriceUsd.toString());
 
     const [
-      relayerFeeDetails,
+      gasCosts,
       multicallOutput,
       fullRelayerBalances,
       transferRestrictedBalances,
       fullRelayerMainnetBalances,
     ] = await Promise.all([
-      getRelayerFeeDetails(
-        depositArgs,
-        tokenPriceNative,
-        relayer,
-        gasPrice,
-        gasCosts?.nativeGasCost,
-        gasCosts?.tokenGasCost
-      ),
+      isMessageDefined
+        ? undefined // Only use cached gas units if message is not defined, i.e. standard for standard bridges
+        : getCachedFillGasUsage(depositArgs, gasPrice, {
+            relayerAddress: relayer,
+          }),
       callViaMulticall3(provider, multiCalls, {
         blockTag: latestBlock.number,
       }),
@@ -226,6 +217,16 @@ const handler = async (
         )
       ),
     ]);
+    // This call should not make any additional RPC queries if gasCosts is defined--for any deposit
+    // with an empty message.
+    const relayerFeeDetails = await getRelayerFeeDetails(
+      depositArgs,
+      tokenPriceNative,
+      relayer,
+      gasPrice,
+      gasCosts?.nativeGasCost,
+      gasCosts?.tokenGasCost
+    );
     logger.debug({
       at: "Limits",
       message: "Relayer fee details from SDK",


### PR DESCRIPTION
We should pass the pre-computed gas price into this call so that we don't query the gas price twice. Additionally, we can use the scaled up gas price value to derive the gas fee totals, which currently are not using the scaled up values