### PR TITLE
improve(API): Derive tokenGasCost locally in /limits

### DIFF
--- a/api/_cache.ts
+++ b/api/_cache.ts
@@ -84,7 +84,7 @@ export async function getCachedValue<T>(
 ): Promise<T> {
   const cachedValue = await redisCache.get<T>(key);
   if (cachedValue) {
-    console.log(`Cache hit for key: ${key}: ${cachedValue.toString()}`);
+    console.log(`Cache hit for key: ${key}: ${cachedValue}`);
     return parser ? parser(cachedValue) : cachedValue;
   }
 

--- a/api/_cache.ts
+++ b/api/_cache.ts
@@ -84,12 +84,16 @@ export async function getCachedValue<T>(
 ): Promise<T> {
   const cachedValue = await redisCache.get<T>(key);
   if (cachedValue) {
-    console.log(`Cache hit for key: ${key}: ${cachedValue}`);
+    if (key.includes("latestGasPriceCache")) {
+      console.log(`Cache hit for key: ${key}: ${cachedValue}`);
+    }
     return parser ? parser(cachedValue) : cachedValue;
   }
 
   const value = await fetcher();
-  console.log(`Cache miss for key: ${key}: ${value}`);
+  if (key.includes("latestGasPriceCache")) {
+    console.log(`Cache miss for key: ${key}: ${value}`);
+  }
   await redisCache.set(key, value, ttl);
   return value;
 }

--- a/api/_cache.ts
+++ b/api/_cache.ts
@@ -84,10 +84,12 @@ export async function getCachedValue<T>(
 ): Promise<T> {
   const cachedValue = await redisCache.get<T>(key);
   if (cachedValue) {
+    console.log(`Cache hit for key: ${key}: ${cachedValue.toString()}`);
     return parser ? parser(cachedValue) : cachedValue;
   }
 
   const value = await fetcher();
+  console.log(`Cache miss for key: ${key}: ${value}`);
   await redisCache.set(key, value, ttl);
   return value;
 }

--- a/api/_cache.ts
+++ b/api/_cache.ts
@@ -85,7 +85,9 @@ export async function getCachedValue<T>(
   const cachedValue = await redisCache.get<T>(key);
   if (cachedValue) {
     if (key.includes("latestGasPriceCache")) {
-      console.log(`Cache hit for key: ${key}: ${cachedValue}`);
+      console.log(
+        `Cache hit for key: ${key}: ${parser ? parser(cachedValue) : cachedValue}`
+      );
     }
     return parser ? parser(cachedValue) : cachedValue;
   }

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -1982,6 +1982,7 @@ export function getCachedFillGasUsage(
       }
     );
     return {
+      opStackL1GasCost: gasCosts.opStackL1GasCost,
       nativeGasCost: gasCosts.nativeGasCost,
       tokenGasCost: gasCosts.tokenGasCost,
     };
@@ -1991,10 +1992,17 @@ export function getCachedFillGasUsage(
     cacheKey,
     ttl,
     fetchFn,
-    (gasCosts: { nativeGasCost: BigNumber; tokenGasCost: BigNumber }) => {
+    (gasCosts: {
+      nativeGasCost: BigNumber;
+      tokenGasCost: BigNumber;
+      opStackL1GasCost: BigNumber | undefined;
+    }) => {
       return {
         nativeGasCost: BigNumber.from(gasCosts.nativeGasCost),
         tokenGasCost: BigNumber.from(gasCosts.tokenGasCost),
+        opStackL1GasCost: gasCosts.opStackL1GasCost
+          ? BigNumber.from(gasCosts.opStackL1GasCost)
+          : undefined,
       };
     }
   );

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -2032,7 +2032,7 @@ export function getMaxFeePerGas(
     priorityFeeMarkup: priorityFeeMultiplier,
   } = getGasMarkup(chainId);
   console.log(
-    "getMaxFeePerGas",
+    "fresh query getGasPriceEstimate",
     baseFeeMultiplier.toString(),
     priorityFeeMultiplier.toString()
   );

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -1984,7 +1984,6 @@ export function getCachedFillGasUsage(
     return {
       opStackL1GasCost: gasCosts.opStackL1GasCost,
       nativeGasCost: gasCosts.nativeGasCost,
-      tokenGasCost: gasCosts.tokenGasCost,
     };
   };
 
@@ -1994,12 +1993,10 @@ export function getCachedFillGasUsage(
     fetchFn,
     (gasCosts: {
       nativeGasCost: BigNumber;
-      tokenGasCost: BigNumber;
       opStackL1GasCost: BigNumber | undefined;
     }) => {
       return {
         nativeGasCost: BigNumber.from(gasCosts.nativeGasCost),
-        tokenGasCost: BigNumber.from(gasCosts.tokenGasCost),
         opStackL1GasCost: gasCosts.opStackL1GasCost
           ? BigNumber.from(gasCosts.opStackL1GasCost)
           : undefined,
@@ -2034,6 +2031,11 @@ export function getMaxFeePerGas(
     baseFeeMarkup: baseFeeMultiplier,
     priorityFeeMarkup: priorityFeeMultiplier,
   } = getGasMarkup(chainId);
+  console.log(
+    "getMaxFeePerGas",
+    baseFeeMultiplier.toString(),
+    priorityFeeMarkup.toString()
+  );
   return sdk.gasPriceOracle.getGasPriceEstimate(getProvider(chainId), {
     chainId,
     baseFeeMultiplier,

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -2034,7 +2034,7 @@ export function getMaxFeePerGas(
   console.log(
     "getMaxFeePerGas",
     baseFeeMultiplier.toString(),
-    priorityFeeMarkup.toString()
+    priorityFeeMultiplier.toString()
   );
   return sdk.gasPriceOracle.getGasPriceEstimate(getProvider(chainId), {
     chainId,

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -2012,7 +2012,10 @@ export function latestGasPriceCache(chainId: number) {
   };
 
   return makeCacheGetterAndSetter(
-    buildInternalCacheKey("latestGasPriceCache", chainId),
+    buildInternalCacheKey(
+      `${process.env.CACHE_PREFIX ? process.env.CACHE_PREFIX + "-" : ""}latestGasPriceCache`,
+      chainId
+    ),
     ttlPerChain[chainId] || ttlPerChain.default,
     async () => (await getMaxFeePerGas(chainId)).maxFeePerGas,
     (bnFromCache) => BigNumber.from(bnFromCache)

--- a/api/limits.ts
+++ b/api/limits.ts
@@ -181,7 +181,7 @@ const handler = async (
         latestGasPriceCache(destinationChainId).get(),
       ]);
     console.log(
-      `Got gasPrice: ${gasPrice.toString} and gasCosts ${gasCosts?.nativeGasCost.toString()}`
+      `Got gasPrice: ${gasPrice.toString()} and gasCosts ${gasCosts?.nativeGasCost.toString()}`
     );
     const tokenPriceUsd = ethers.utils.parseUnits(_tokenPriceUsd.toString());
     let tokenGasCost = gasCosts?.nativeGasCost;

--- a/api/limits.ts
+++ b/api/limits.ts
@@ -181,6 +181,13 @@ const handler = async (
         latestGasPriceCache(destinationChainId).get(),
       ]);
     const tokenPriceUsd = ethers.utils.parseUnits(_tokenPriceUsd.toString());
+    let tokenGasCost = gasCosts?.nativeGasCost;
+    if (tokenGasCost !== undefined) {
+      tokenGasCost = tokenGasCost.mul(gasPrice);
+      if (gasCosts?.opStackL1GasCost) {
+        tokenGasCost = tokenGasCost.add(gasCosts.opStackL1GasCost);
+      }
+    }
 
     const [
       relayerFeeDetails,
@@ -195,7 +202,7 @@ const handler = async (
         relayer,
         gasPrice,
         gasCosts?.nativeGasCost,
-        gasCosts?.tokenGasCost
+        tokenGasCost
       ),
       callViaMulticall3(provider, multiCalls, {
         blockTag: latestBlock.number,

--- a/api/limits.ts
+++ b/api/limits.ts
@@ -180,6 +180,9 @@ const handler = async (
             }),
         latestGasPriceCache(destinationChainId).get(),
       ]);
+    console.log(
+      `Got gasPrice: ${gasPrice.toString} and gasCosts ${gasCosts?.nativeGasCost.toString()}`
+    );
     const tokenPriceUsd = ethers.utils.parseUnits(_tokenPriceUsd.toString());
     let tokenGasCost = gasCosts?.nativeGasCost;
     if (tokenGasCost !== undefined) {
@@ -188,6 +191,7 @@ const handler = async (
         tokenGasCost = tokenGasCost.add(gasCosts.opStackL1GasCost);
       }
     }
+    console.log(`tokenGasCosts: ${tokenGasCost?.toString()}`);
 
     const [
       relayerFeeDetails,

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@across-protocol/constants": "^3.1.24",
     "@across-protocol/contracts": "^3.0.19",
     "@across-protocol/contracts-v3.0.6": "npm:@across-protocol/contracts@3.0.6",
-    "@across-protocol/sdk": "^3.4.7",
+    "@across-protocol/sdk": "^3.4.8-beta.1",
     "@amplitude/analytics-browser": "^2.3.5",
     "@balancer-labs/sdk": "1.1.6-beta.16",
     "@emotion/react": "^11.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -83,10 +83,10 @@
     yargs "^17.7.2"
     zksync-web3 "^0.14.3"
 
-"@across-protocol/sdk@^3.4.7":
-  version "3.4.7"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-3.4.7.tgz#6ddf9698f918d7b7e0216327d60b54b37fe14f22"
-  integrity sha512-GeyzDG8EzlN8oddmjXASqND+usZPkWDLpzbdWfAfBfHT3pjIMatntZqZghfCfjy+ICf+rlYrAb8I24H4jlct8Q==
+"@across-protocol/sdk@^3.4.8-beta.1":
+  version "3.4.8-beta.1"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-3.4.8-beta.1.tgz#f9366cf7a30bf44a655d25efa03dd9101cdb96ca"
+  integrity sha512-uVkvdrnQt2Gtdel9H4isDRB+5iTn/fj1zamQzWqvaknSHftdFm2nbiRmNkB7fm2o41XanxTcXRN3rYUNWTGb1Q==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/constants" "^3.1.25"


### PR DESCRIPTION
Rather than pass the `tokenGasCosts` derived from the SDK.estimateGasCosts call, derive it locally. The current code doesn't use the `gasPrice` fetched from the SDK to compute the `tokenGasCosts` so the token gas costs are inaccurate