### PR TITLE
improve(API): Make gasFeeTotal more accurate in /limits and increase cache hit frequency

### DIFF
--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -1979,7 +1979,7 @@ export function getCachedNativeGasCost(
   // We can use a long TTL since we are fetching only the native gas cost which should rarely change.
   // Set this longer than the secondsPerUpdate value in the cron cache gas prices job.
   const ttlPerChain = {
-    default: 60,
+    default: 120,
   };
   const cacheKey = buildInternalCacheKey(
     "nativeGasCost",

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -1979,7 +1979,7 @@ export function getCachedNativeGasCost(
   // We can use a long TTL since we are fetching only the native gas cost which should rarely change.
   // Set this longer than the secondsPerUpdate value in the cron cache gas prices job.
   const ttlPerChain = {
-    default: 120,
+    default: 60,
   };
   const cacheKey = buildInternalCacheKey(
     "nativeGasCost",

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -2089,7 +2089,14 @@ export function latestGasPriceCache(
     default: 5,
   };
   return makeCacheGetterAndSetter(
-    buildInternalCacheKey("latestGasPriceCache", chainId),
+    // If deposit is defined, then the gas price will be dependent on the fill transaction derived from the deposit.
+    // Therefore, we technically should cache a different gas price per different types of deposit so we add
+    // an additional outputToken to the cache key to distinguish between gas prices dependent on deposit args
+    // for different output tokens, which should be the main factor affecting the fill gas cost.
+    buildInternalCacheKey(
+      `latestGasPriceCache${deposit ? `-${deposit.outputToken}` : ""}`,
+      chainId
+    ),
     ttlPerChain.default,
     async () =>
       (await getMaxFeePerGas(chainId, deposit, overrides)).maxFeePerGas,

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -2022,11 +2022,13 @@ export function getCachedOpStackL1DataFee(
     relayerAddress: string;
   }>
 ) {
-  // This should roughly be the length of 1 block on Ethereum mainnet which is how often the L1 data fee should
+  // This should roughly be longer than the length of 1 block on Ethereum mainnet which is how often the L1 data fee should
   // change since its based on the L1 base fee. However, this L1 data fee is mostly affected by the L1 base fee which
   // should only change by 12.5% at most per block.
+  // We set this higher than the secondsPerUpdate value in the cron cache gas prices job which will update this
+  // more frequently.
   const ttlPerChain = {
-    default: 12,
+    default: 24,
   };
 
   const cacheKey = buildInternalCacheKey(
@@ -2077,6 +2079,8 @@ export function latestGasPriceCache(
     relayerAddress: string;
   }>
 ) {
+  // We set this higher than the secondsPerUpdate value in the cron cache gas prices job which will update this
+  // more frequently.
   const ttlPerChain = {
     default: 10,
     [CHAIN_IDs.MAINNET]: 24,

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -2023,13 +2023,12 @@ export function getCachedOpStackL1DataFee(
     relayerAddress: string;
   }>
 ) {
-  // This should be longer than the length of 1 block on Ethereum mainnet which is how often the L1 data fee should
-  // change since its based on the L1 base fee. However, this L1 data fee is mostly affected by the L1 base fee which
-  // should only change by 12.5% at most per block.
+  // The L1 data fee should change after each Ethereum block since its based on the L1 base fee.
+  // However, the L1 base fee should only change by 12.5% at most per block.
   // We set this higher than the secondsPerUpdate value in the cron cache gas prices job which will update this
   // more frequently.
   const ttlPerChain = {
-    default: 30,
+    default: 60,
   };
 
   const cacheKey = buildInternalCacheKey(

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -1979,7 +1979,6 @@ export function getCachedFillGasUsage(
 ) {
   const ttlPerChain = {
     default: 10,
-    [CHAIN_IDs.ARBITRUM]: 10,
   };
 
   const cacheKey = buildInternalCacheKey(
@@ -1987,7 +1986,7 @@ export function getCachedFillGasUsage(
     deposit.destinationChainId,
     deposit.outputToken
   );
-  const ttl = ttlPerChain[deposit.destinationChainId] || ttlPerChain.default;
+  const ttl = ttlPerChain.default;
   const fetchFn = async () => {
     const relayerFeeCalculatorQueries = getRelayerFeeCalculatorQueries(
       deposit.destinationChainId,
@@ -2032,13 +2031,12 @@ export function getCachedFillGasUsage(
 
 export function latestGasPriceCache(chainId: number) {
   const ttlPerChain = {
-    default: 30,
-    [CHAIN_IDs.ARBITRUM]: 15,
+    default: 10,
   };
 
   return makeCacheGetterAndSetter(
     buildInternalCacheKey("latestGasPriceCache", chainId),
-    ttlPerChain[chainId] || ttlPerChain.default,
+    ttlPerChain.default,
     async () => (await getMaxFeePerGas(chainId)).maxFeePerGas,
     (bnFromCache) => BigNumber.from(bnFromCache)
   );

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -2083,9 +2083,13 @@ export function latestGasPriceCache(
       chainId
     ),
     ttlPerChain.default,
-    async () =>
-      (await getMaxFeePerGas(chainId, deposit, overrides)).maxFeePerGas,
-    (bnFromCache) => BigNumber.from(bnFromCache)
+    async () => await getMaxFeePerGas(chainId, deposit, overrides),
+    (gasPrice: sdk.gasPriceOracle.GasPriceEstimate) => {
+      return {
+        maxFeePerGas: BigNumber.from(gasPrice.maxFeePerGas),
+        maxPriorityFeePerGas: BigNumber.from(gasPrice.maxPriorityFeePerGas),
+      };
+    }
   );
 }
 

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -1977,8 +1977,9 @@ export function getCachedNativeGasCost(
   }>
 ) {
   // We can use a long TTL since we are fetching only the native gas cost which should rarely change.
+  // Set this longer than the secondsPerUpdate value in the cron cache gas prices job.
   const ttlPerChain = {
-    default: 60,
+    default: 120,
   };
   const cacheKey = buildInternalCacheKey(
     "nativeGasCost",
@@ -2022,13 +2023,13 @@ export function getCachedOpStackL1DataFee(
     relayerAddress: string;
   }>
 ) {
-  // This should roughly be longer than the length of 1 block on Ethereum mainnet which is how often the L1 data fee should
+  // This should be longer than the length of 1 block on Ethereum mainnet which is how often the L1 data fee should
   // change since its based on the L1 base fee. However, this L1 data fee is mostly affected by the L1 base fee which
   // should only change by 12.5% at most per block.
   // We set this higher than the secondsPerUpdate value in the cron cache gas prices job which will update this
   // more frequently.
   const ttlPerChain = {
-    default: 24,
+    default: 30,
   };
 
   const cacheKey = buildInternalCacheKey(
@@ -2082,8 +2083,7 @@ export function latestGasPriceCache(
   // We set this higher than the secondsPerUpdate value in the cron cache gas prices job which will update this
   // more frequently.
   const ttlPerChain = {
-    default: 10,
-    [CHAIN_IDs.MAINNET]: 24,
+    default: 30,
   };
   return makeCacheGetterAndSetter(
     // If deposit is defined, then the gas price will be dependent on the fill transaction derived from the deposit.

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -1980,13 +1980,11 @@ export function getCachedNativeGasCost(
   const ttlPerChain = {
     default: 60,
   };
-
   const cacheKey = buildInternalCacheKey(
     "nativeGasCost",
     deposit.destinationChainId,
     deposit.outputToken
   );
-  const ttl = ttlPerChain.default;
   const fetchFn = async () => {
     const relayerAddress =
       overrides?.relayerAddress ??
@@ -2007,9 +2005,14 @@ export function getCachedNativeGasCost(
     return voidSigner.estimateGas(unsignedFillTxn);
   };
 
-  return getCachedValue(cacheKey, ttl, fetchFn, (nativeGasCostFromCache) => {
-    return BigNumber.from(nativeGasCostFromCache);
-  });
+  return makeCacheGetterAndSetter(
+    cacheKey,
+    ttlPerChain.default,
+    fetchFn,
+    (nativeGasCostFromCache) => {
+      return BigNumber.from(nativeGasCostFromCache);
+    }
+  );
 }
 
 export function getCachedOpStackL1DataFee(
@@ -2032,7 +2035,6 @@ export function getCachedOpStackL1DataFee(
     deposit.outputToken // This should technically differ based on the output token since the L2 calldata
     // size affects the L1 data fee and this calldata can differ based on the output token.
   );
-  const ttl = ttlPerChain.default;
   const fetchFn = async () => {
     // We don't care about the gas token price or the token gas price, only the raw gas units. In the API
     // we'll compute the gas price separately.
@@ -2058,9 +2060,14 @@ export function getCachedOpStackL1DataFee(
     return opStackL1GasCost;
   };
 
-  return getCachedValue(cacheKey, ttl, fetchFn, (l1DataFeeFromCache) => {
-    return BigNumber.from(l1DataFeeFromCache);
-  });
+  return makeCacheGetterAndSetter(
+    cacheKey,
+    ttlPerChain.default,
+    fetchFn,
+    (l1DataFeeFromCache) => {
+      return BigNumber.from(l1DataFeeFromCache);
+    }
+  );
 }
 
 export function latestGasPriceCache(
@@ -2071,7 +2078,8 @@ export function latestGasPriceCache(
   }>
 ) {
   const ttlPerChain = {
-    default: 5,
+    default: 10,
+    [CHAIN_IDs.MAINNET]: 24,
   };
   return makeCacheGetterAndSetter(
     // If deposit is defined, then the gas price will be dependent on the fill transaction derived from the deposit.

--- a/api/cron-cache-gas-prices.ts
+++ b/api/cron-cache-gas-prices.ts
@@ -165,14 +165,14 @@ const handler = async (
         )
       ),
       Promise.all(
-        mainnetChains.map((chain) => {
+        mainnetChains.map(async (chain) => {
           const routesToChain = availableRoutes.filter(
             ({ destinationChainId }) => destinationChainId === chain.chainId
           );
           const outputTokensForChain = routesToChain.map(
             ({ destinationToken }) => destinationToken
           );
-          return Promise.all(
+          await Promise.all(
             outputTokensForChain.map((outputToken) =>
               updateL1DataFeePromise(chain.chainId, outputToken)
             )

--- a/api/cron-cache-gas-prices.ts
+++ b/api/cron-cache-gas-prices.ts
@@ -11,7 +11,6 @@ import { UnauthorizedError } from "./_errors";
 import mainnetChains from "../src/data/chains_1.json";
 import { utils } from "@across-protocol/sdk";
 import { CHAIN_IDs } from "./_constants";
-import { BigNumber } from "ethers";
 
 const updateIntervalsSecPerChain = {
   default: 10,

--- a/api/cron-cache-gas-prices.ts
+++ b/api/cron-cache-gas-prices.ts
@@ -139,8 +139,10 @@ const handler = async (
           break;
         }
         const gasCost = await gasCostCache.get();
-        const cache = getCachedOpStackL1DataFee(depositArgs, gasCost);
-        await cache.set();
+        if (utils.chainIsOPStack(chainId)) {
+          const cache = getCachedOpStackL1DataFee(depositArgs, gasCost);
+          await cache.set();
+        }
         await utils.delay(secondsPerUpdate);
       }
     };

--- a/api/cron-cache-gas-prices.ts
+++ b/api/cron-cache-gas-prices.ts
@@ -29,7 +29,6 @@ type Route = {
 // Set lower than TTL in latestGasPriceCache
 const updateIntervalsSecPerChain = {
   default: 5,
-  1: 12,
 };
 
 // Set lower than TTL in getCachedOpStackL1DataFee and getCachedNativeGasCost

--- a/api/cron-cache-gas-prices.ts
+++ b/api/cron-cache-gas-prices.ts
@@ -163,17 +163,13 @@ const handler = async (
       const outputTokensForChain = routesToChain.map(
         ({ destinationToken }) => destinationToken
       );
-      Promise.all(
-        outputTokensForChain.map((outputToken) =>
-          updateL1DataFeePromise(chain.chainId, outputToken)
-        )
+      outputTokensForChain.map((outputToken) =>
+        updateL1DataFeePromise(chain.chainId, outputToken)
       );
       // @dev Linea gas prices are dependent on the L2 calldata to be submitted so compute one gas price for each output token
       if (chain.chainId === CHAIN_IDs.LINEA) {
-        Promise.all(
-          outputTokensForChain.map((outputToken) =>
-            updateGasPricePromise(chain.chainId, outputToken)
-          )
+        outputTokensForChain.map((outputToken) =>
+          updateGasPricePromise(chain.chainId, outputToken)
         );
       }
     });

--- a/api/cron-cache-gas-prices.ts
+++ b/api/cron-cache-gas-prices.ts
@@ -33,7 +33,7 @@ const updateIntervalsSecPerChain = {
 
 // Set lower than TTL in getCachedOpStackL1DataFee and getCachedNativeGasCost
 const updateL1DataFeeIntervalsSecPerChain = {
-  default: 12,
+  default: 10,
 };
 
 const maxDurationSec = 60;

--- a/api/cron-cache-gas-prices.ts
+++ b/api/cron-cache-gas-prices.ts
@@ -31,10 +31,16 @@ const updateIntervalsSecPerChain = {
   default: 5,
 };
 
-// Set lower than TTL in getCachedOpStackL1DataFee and getCachedNativeGasCost.
+// Set lower than TTL in getCachedOpStackL1DataFee
 // Set lower than the L1 block time so we can try to get as up to date L1 data fees based on L1 base fees as possible.
 const updateL1DataFeeIntervalsSecPerChain = {
   default: 10,
+};
+
+// Set lower than TTL in getCachedNativeGasCost. This should rarely change so we should just make sure
+// we keep this cache warm.
+const updateNativeGasCostIntervalsSecPerChain = {
+  default: 30,
 };
 
 const maxDurationSec = 60;
@@ -114,10 +120,9 @@ const handler = async (
     };
 
     /**
-     * @notice Updates the L1 data fee and L2 gas cost caches every `updateL1DataFeeIntervalsSecPerChain` seconds
+     * @notice Updates the L1 data fee gas cost cache every `updateL1DataFeeIntervalsSecPerChain` seconds
      * up to `maxDurationSec` seconds.
-     * @dev This function will also update the L2 gas costs because this value is required to get the L1 data fee.
-     * @param chainId Chain to estimate gas price for
+     * @param chainId Chain to estimate l1 data fee for
      * @param outputTokenAddress This output token will be used to construct a fill transaction to simulate
      * gas costs for.
      */
@@ -140,6 +145,32 @@ const handler = async (
           const cache = getCachedOpStackL1DataFee(depositArgs, gasCost);
           await cache.set();
         }
+        await utils.delay(secondsPerUpdate);
+      }
+    };
+
+    /**
+     * @notice Updates the native gas cost cache every `updateNativeGasCostIntervalsSecPerChain` seconds
+     * up to `maxDurationSec` seconds.
+     * @param chainId Chain to estimate gas cost for
+     * @param outputTokenAddress This output token will be used to construct a fill transaction to simulate
+     * gas costs for.
+     */
+    const updateNativeGasCostPromise = async (
+      chainId: number,
+      outputTokenAddress: string
+    ): Promise<void> => {
+      const secondsPerUpdate = updateNativeGasCostIntervalsSecPerChain.default;
+      const depositArgs = getDepositArgsForChainId(chainId, outputTokenAddress);
+      const cache = getCachedNativeGasCost(depositArgs);
+
+      while (true) {
+        const diff = Date.now() - functionStart;
+        // Stop after `maxDurationSec` seconds
+        if (diff >= maxDurationSec * 1000) {
+          break;
+        }
+        await cache.set();
         await utils.delay(secondsPerUpdate);
       }
     };
@@ -172,11 +203,18 @@ const handler = async (
           const outputTokensForChain = routesToChain.map(
             ({ destinationToken }) => destinationToken
           );
-          await Promise.all(
-            outputTokensForChain.map((outputToken) =>
-              updateL1DataFeePromise(chain.chainId, outputToken)
-            )
-          );
+          await Promise.all([
+            Promise.all(
+              outputTokensForChain.map((outputToken) =>
+                updateNativeGasCostPromise(chain.chainId, outputToken)
+              )
+            ),
+            Promise.all(
+              outputTokensForChain.map((outputToken) =>
+                updateL1DataFeePromise(chain.chainId, outputToken)
+              )
+            ),
+          ]);
         })
       ),
     ]);

--- a/api/cron-cache-gas-prices.ts
+++ b/api/cron-cache-gas-prices.ts
@@ -2,22 +2,53 @@ import { VercelResponse } from "@vercel/node";
 import { TypedVercelRequest } from "./_types";
 import {
   HUB_POOL_CHAIN_ID,
+  getCachedNativeGasCost,
+  getCachedOpStackL1DataFee,
   getLogger,
   handleErrorCondition,
   latestGasPriceCache,
+  resolveVercelEndpoint,
 } from "./_utils";
 import { UnauthorizedError } from "./_errors";
 
 import mainnetChains from "../src/data/chains_1.json";
-import { utils } from "@across-protocol/sdk";
-import { CHAIN_IDs } from "./_constants";
+import { utils, constants } from "@across-protocol/sdk";
+import { CHAIN_IDs, DEFAULT_SIMULATED_RECIPIENT_ADDRESS } from "./_constants";
+import axios from "axios";
+import { ethers } from "ethers";
 
+type Route = {
+  originChainId: number;
+  originToken: string;
+  destinationChainId: number;
+  destinationToken: string;
+  originTokenSymbol: string;
+  destinationTokenSymbol: string;
+};
+
+// Set slightly lower than TTL in latestGasPriceCache
 const updateIntervalsSecPerChain = {
-  default: 10,
+  default: 5,
   1: 12,
 };
 
+// Set slightly lower than TTL in getCachedOpStackL1DataFee.
+const updateL1DataFeeIntervalsSecPerChain = {
+  default: 10,
+};
+
 const maxDurationSec = 60;
+
+const getDepositArgsForChainId = (chainId: number, tokenAddress: string) => {
+  return {
+    amount: ethers.BigNumber.from(100),
+    inputToken: constants.ZERO_ADDRESS,
+    outputToken: tokenAddress,
+    recipientAddress: DEFAULT_SIMULATED_RECIPIENT_ADDRESS,
+    originChainId: 0, // Shouldn't matter for simulation
+    destinationChainId: Number(chainId),
+  };
+};
 
 const handler = async (
   request: TypedVercelRequest<Record<string, never>>,
@@ -46,36 +77,106 @@ const handler = async (
       return;
     }
 
+    const availableRoutes = (
+      await axios(`${resolveVercelEndpoint()}/api/available-routes`)
+    ).data as Array<Route>;
+
     // This marks the timestamp when the function started
     const functionStart = Date.now();
 
+    /**
+     * @notice Updates the gas price cache every `updateIntervalsSecPerChain` seconds up to `maxDurationSec` seconds.
+     * @param chainId Chain to estimate gas price for
+     * @param outputTokenAddress Optional param to set if the gas price is dependent on the calldata of the transaction
+     * to be submitted on the chainId. This output token will be used to construct a fill transaction to simulate.
+     */
+    const updateGasPricePromise = async (
+      chainId: number,
+      outputTokenAddress?: string
+    ) => {
+      const secondsPerUpdateForChain =
+        updateIntervalsSecPerChain[
+          chainId as keyof typeof updateIntervalsSecPerChain
+        ] || updateIntervalsSecPerChain.default;
+      const cache = latestGasPriceCache(
+        chainId,
+        outputTokenAddress
+          ? getDepositArgsForChainId(chainId, outputTokenAddress)
+          : undefined
+      );
+
+      while (true) {
+        const diff = Date.now() - functionStart;
+        // Stop after `maxDurationSec` seconds
+        if (diff >= maxDurationSec * 1000) {
+          break;
+        }
+        await cache.set();
+        await utils.delay(secondsPerUpdateForChain);
+      }
+    };
+
+    /**
+     * @notice Updates the L1 data fee and L2 gas cost caches every `updateL1DataFeeIntervalsSecPerChain` seconds
+     * up to `maxDurationSec` seconds.
+     * @dev This function will also update the L2 gas costs because this value is required to get the L1 data fee.
+     * @param chainId Chain to estimate gas price for
+     * @param outputTokenAddress This output token will be used to construct a fill transaction to simulate
+     * gas costs for.
+     */
+    const updateL1DataFeePromise = async (
+      chainId: number,
+      outputTokenAddress: string
+    ) => {
+      const secondsPerUpdateForChain =
+        updateL1DataFeeIntervalsSecPerChain.default;
+      const depositArgs = getDepositArgsForChainId(chainId, outputTokenAddress);
+      const gasCostCache = getCachedNativeGasCost(depositArgs);
+
+      while (true) {
+        const diff = Date.now() - functionStart;
+        // Stop after `maxDurationSec` seconds
+        if (diff >= maxDurationSec * 1000) {
+          break;
+        }
+        const gasCost = await gasCostCache.get();
+        const cache = getCachedOpStackL1DataFee(depositArgs, gasCost);
+        await cache.set();
+        await utils.delay(secondsPerUpdateForChain);
+      }
+    };
+
     // The minimum interval for Vercel Serverless Functions cron jobs is 1 minute.
-    // But we want to update gas prices more frequently than that.
+    // But we want to update gas data more frequently than that.
     // To circumvent this, we run the function in a loop and update gas prices every
     // `secondsPerUpdateForChain` seconds and stop after `maxDurationSec` seconds (1 minute).
-    const gasPricePromises = mainnetChains
-      // @dev Remove Linea from this cron cache job because Linea's gas price is dependent on the
-      // calldata of the transaction to be submitted on Linea.
-      .filter((chain) => CHAIN_IDs.LINEA !== chain.chainId)
-      .map(async (chain) => {
-        const secondsPerUpdateForChain =
-          updateIntervalsSecPerChain[
-            chain.chainId as keyof typeof updateIntervalsSecPerChain
-          ] || updateIntervalsSecPerChain.default;
-        // The deposit args don't matter for any chain besides Linea, which is why we filter it out
-        // above, because gas price on Linea is dependent on the fill transaction args.
-        const cache = latestGasPriceCache(chain.chainId);
-
-        while (true) {
-          const diff = Date.now() - functionStart;
-          // Stop after `maxDurationSec` seconds
-          if (diff >= maxDurationSec * 1000) {
-            break;
-          }
-          await cache.set();
-          await utils.delay(secondsPerUpdateForChain);
-        }
-      });
+    const gasPricePromises = mainnetChains.map(async (chain) => {
+      // For each chain:
+      //    - update the destination gas price for the chain
+      //  For each output token on that chain:
+      //    - update the simulated gas costs for the token
+      const routesToChain = availableRoutes.filter(
+        ({ destinationChainId }) => destinationChainId === chain.chainId
+      );
+      const outputTokensForChain = routesToChain.map(
+        ({ destinationToken }) => destinationToken
+      );
+      Promise.all(
+        outputTokensForChain.map((outputToken) =>
+          updateL1DataFeePromise(chain.chainId, outputToken)
+        )
+      );
+      // @dev Linea gas prices are dependent on the L2 calldata to be submitted so compute one gas price for each output token
+      if (chain.chainId === CHAIN_IDs.LINEA) {
+        Promise.all(
+          outputTokensForChain.map((outputToken) =>
+            updateGasPricePromise(chain.chainId, outputToken)
+          )
+        );
+      } else {
+        updateGasPricePromise(chain.chainId);
+      }
+    });
     await Promise.all(gasPricePromises);
 
     logger.debug({

--- a/api/cron-cache-gas-prices.ts
+++ b/api/cron-cache-gas-prices.ts
@@ -93,7 +93,7 @@ const handler = async (
     const updateGasPricePromise = async (
       chainId: number,
       outputTokenAddress?: string
-    ) => {
+    ): Promise<void> => {
       const secondsPerUpdateForChain =
         updateIntervalsSecPerChain[
           chainId as keyof typeof updateIntervalsSecPerChain
@@ -143,6 +143,7 @@ const handler = async (
           const cache = getCachedOpStackL1DataFee(depositArgs, gasCost);
           await cache.set();
         }
+        console.log(`updateL1DataFeePromise: updated gas price for ${chainId}`);
         await utils.delay(secondsPerUpdate);
       }
     };

--- a/api/cron-cache-gas-prices.ts
+++ b/api/cron-cache-gas-prices.ts
@@ -54,6 +54,8 @@ const handler = async (
     // To circumvent this, we run the function in a loop and update gas prices every
     // `secondsPerUpdateForChain` seconds and stop after `maxDurationSec` seconds (1 minute).
     const gasPricePromises = mainnetChains
+      // @dev Remove Linea from this cron cache job because Linea's gas price is dependent on the
+      // calldata of the transaction to be submitted on Linea.
       .filter((chain) => CHAIN_IDs.LINEA !== chain.chainId)
       .map(async (chain) => {
         const secondsPerUpdateForChain =

--- a/api/cron-cache-gas-prices.ts
+++ b/api/cron-cache-gas-prices.ts
@@ -31,7 +31,8 @@ const updateIntervalsSecPerChain = {
   default: 5,
 };
 
-// Set lower than TTL in getCachedOpStackL1DataFee and getCachedNativeGasCost
+// Set lower than TTL in getCachedOpStackL1DataFee and getCachedNativeGasCost.
+// Set lower than the L1 block time so we can try to get as up to date L1 data fees based on L1 base fees as possible.
 const updateL1DataFeeIntervalsSecPerChain = {
   default: 10,
 };

--- a/api/cron-cache-gas-prices.ts
+++ b/api/cron-cache-gas-prices.ts
@@ -157,23 +157,23 @@ const handler = async (
       if (chain.chainId !== CHAIN_IDs.LINEA) {
         updateGasPricePromise(chain.chainId);
       }
-      //  For each output token on that chain:
-      //    - update the simulated gas costs for the token
-      const routesToChain = availableRoutes.filter(
-        ({ destinationChainId }) => destinationChainId === chain.chainId
-      );
-      const outputTokensForChain = routesToChain.map(
-        ({ destinationToken }) => destinationToken
-      );
-      outputTokensForChain.map((outputToken) =>
-        updateL1DataFeePromise(chain.chainId, outputToken)
-      );
-      // @dev Linea gas prices are dependent on the L2 calldata to be submitted so compute one gas price for each output token
-      if (chain.chainId === CHAIN_IDs.LINEA) {
-        outputTokensForChain.map((outputToken) =>
-          updateGasPricePromise(chain.chainId, outputToken)
-        );
-      }
+      // //  For each output token on that chain:
+      // //    - update the simulated gas costs for the token
+      // const routesToChain = availableRoutes.filter(
+      //   ({ destinationChainId }) => destinationChainId === chain.chainId
+      // );
+      // const outputTokensForChain = routesToChain.map(
+      //   ({ destinationToken }) => destinationToken
+      // );
+      // outputTokensForChain.map((outputToken) =>
+      //   updateL1DataFeePromise(chain.chainId, outputToken)
+      // );
+      // // @dev Linea gas prices are dependent on the L2 calldata to be submitted so compute one gas price for each output token
+      // if (chain.chainId === CHAIN_IDs.LINEA) {
+      //   outputTokensForChain.map((outputToken) =>
+      //     updateGasPricePromise(chain.chainId, outputToken)
+      //   );
+      // }
     });
     await Promise.all(gasPricePromises);
 

--- a/api/gas-prices.ts
+++ b/api/gas-prices.ts
@@ -1,11 +1,11 @@
 import { VercelResponse } from "@vercel/node";
 import {
-  buildDepositForSimulation,
+  getCachedNativeGasCost,
+  getCachedOpStackL1DataFee,
   getGasMarkup,
   getLogger,
-  getMaxFeePerGas,
-  getRelayerFeeCalculatorQueries,
   handleErrorCondition,
+  latestGasPriceCache,
   sendResponse,
 } from "./_utils";
 import { TypedVercelRequest } from "./_types";
@@ -27,6 +27,16 @@ const QueryParamsSchema = object({
 });
 type QueryParams = Infer<typeof QueryParamsSchema>;
 
+const getDepositArgsForChainId = (chainId: number, tokenAddress: string) => {
+  return {
+    amount: ethers.BigNumber.from(100),
+    inputToken: sdk.constants.ZERO_ADDRESS,
+    outputToken: tokenAddress,
+    recipientAddress: DEFAULT_SIMULATED_RECIPIENT_ADDRESS,
+    originChainId: 0, // Shouldn't matter for simulation
+    destinationChainId: Number(chainId),
+  };
+};
 const handler = async (
   { query }: TypedVercelRequest<QueryParams>,
   response: VercelResponse
@@ -46,56 +56,41 @@ const handler = async (
         })
         .filter(([, tokenAddress]) => tokenAddress !== undefined)
     );
-    // getMaxFeePerGas will return the gas price after including the baseFeeMultiplier.
-    const gasPrices = await Promise.all(
-      Object.keys(chainIdsWithToken).map((chainId) => {
-        return getMaxFeePerGas(Number(chainId));
+    const gasData = await Promise.all(
+      Object.entries(chainIdsWithToken).map(([chainId, tokenAddress]) => {
+        const depositArgs = getDepositArgsForChainId(
+          Number(chainId),
+          tokenAddress
+        );
+        return Promise.all([
+          getCachedNativeGasCost(depositArgs),
+          latestGasPriceCache(
+            Number(chainId),
+            CHAIN_IDs.LINEA === Number(chainId) ? depositArgs : undefined
+          ).get(),
+        ]);
       })
     );
+    // We query the following gas costs after gas prices because token gas costs and op stack l1 gas costs
+    // depend on the gas price and native gas unit results.
     const gasCosts = await Promise.all(
       Object.entries(chainIdsWithToken).map(
         async ([chainId, tokenAddress], i) => {
-          // This is a dummy deposit used to pass into buildDepositForSimulation() to build a fill transaction
-          // that we can simulate without reversion. The only parameter that matters is that the destinationChainId
-          // is set to the spoke pool's chain ID we'll be simulating the fill call on.
-          const depositArgs = {
-            amount: ethers.BigNumber.from(100),
-            inputToken: sdk.constants.ZERO_ADDRESS,
-            outputToken: tokenAddress,
-            recipientAddress: DEFAULT_SIMULATED_RECIPIENT_ADDRESS,
-            originChainId: 0, // Shouldn't matter for simulation
-            destinationChainId: Number(chainId),
-          };
-          const deposit = buildDepositForSimulation(depositArgs);
-          const relayerFeeCalculatorQueries = getRelayerFeeCalculatorQueries(
-            Number(chainId)
+          const depositArgs = getDepositArgsForChainId(
+            Number(chainId),
+            tokenAddress
           );
-          const { baseFeeMarkup, priorityFeeMarkup, opStackL1DataFeeMarkup } =
-            getGasMarkup(Number(chainId));
-          const { nativeGasCost, tokenGasCost, opStackL1GasCost, gasPrice } =
-            await relayerFeeCalculatorQueries.getGasCosts(
-              deposit,
-              relayerFeeCalculatorQueries.simulatedRelayerAddress,
-              {
-                // Pass in the already-computed gasPrice into this query so that the tokenGasCost includes
-                // the scaled gas price,
-                // e.g. tokenGasCost = nativeGasCost * (baseFee * baseFeeMultiplier + priorityFee).
-                // Except for Linea, where the gas price is dependent on the unsignedTx produced from the deposit,
-                // so let the SDK compute its gas price here.
-                gasPrice:
-                  Number(chainId) === CHAIN_IDs.LINEA
-                    ? undefined
-                    : gasPrices[i].maxFeePerGas,
-                opStackL1GasCostMultiplier: opStackL1DataFeeMarkup,
-                baseFeeMultiplier: baseFeeMarkup,
-                priorityFeeMultiplier: priorityFeeMarkup,
-              }
-            );
+          const [nativeGasCost, gasPrice] = gasData[i];
+          const opStackL1GasCost = sdk.utils.chainIsOPStack(Number(chainId))
+            ? await getCachedOpStackL1DataFee(depositArgs, nativeGasCost)
+            : undefined;
+          const tokenGasCost = nativeGasCost
+            .mul(gasPrice.maxFeePerGas)
+            .add(opStackL1GasCost ?? ethers.BigNumber.from("0"));
           return {
             nativeGasCost,
             tokenGasCost,
             opStackL1GasCost,
-            gasPrice,
           };
         }
       )
@@ -106,23 +101,12 @@ const handler = async (
         Object.keys(chainIdsWithToken).map((chainId, i) => [
           chainId,
           {
-            gasPrice:
-              Number(chainId) === CHAIN_IDs.LINEA
-                ? gasCosts[i].gasPrice.toString()
-                : gasPrices[i].maxFeePerGas.toString(),
+            gasPrice: gasData[i][1].maxFeePerGas.toString(),
             gasPriceComponents: {
-              // Linea hardcodes base fee at 7 wei so we can always back it out fromthe gasPrice returned by the
-              // getGasCosts method.
-              maxFeePerGas:
-                Number(chainId) === CHAIN_IDs.LINEA
-                  ? gasCosts[i].gasPrice.sub(7).toString()
-                  : gasPrices[i].maxFeePerGas
-                      .sub(gasPrices[i].maxPriorityFeePerGas)
-                      .toString(),
-              priorityFeePerGas:
-                Number(chainId) === CHAIN_IDs.LINEA
-                  ? "7"
-                  : gasPrices[i].maxPriorityFeePerGas.toString(),
+              maxFeePerGas: gasData[i][1].maxFeePerGas
+                .sub(gasData[i][1].maxPriorityFeePerGas)
+                .toString(),
+              priorityFeePerGas: gasData[i][1].maxPriorityFeePerGas.toString(),
               baseFeeMultiplier: ethers.utils.formatEther(
                 getGasMarkup(chainId).baseFeeMarkup
               ),

--- a/api/gas-prices.ts
+++ b/api/gas-prices.ts
@@ -9,9 +9,8 @@ import {
   sendResponse,
 } from "./_utils";
 import { TypedVercelRequest } from "./_types";
-import { ethers, providers, VoidSigner } from "ethers";
+import { ethers } from "ethers";
 import * as sdk from "@across-protocol/sdk";
-import { L2Provider } from "@eth-optimism/sdk/dist/interfaces/l2-provider";
 
 import mainnetChains from "../src/data/chains_1.json";
 import {

--- a/api/gas-prices.ts
+++ b/api/gas-prices.ts
@@ -63,7 +63,7 @@ const handler = async (
           tokenAddress
         );
         return Promise.all([
-          getCachedNativeGasCost(depositArgs),
+          getCachedNativeGasCost(depositArgs).get(),
           latestGasPriceCache(
             Number(chainId),
             CHAIN_IDs.LINEA === Number(chainId) ? depositArgs : undefined
@@ -82,7 +82,7 @@ const handler = async (
           );
           const [nativeGasCost, gasPrice] = gasData[i];
           const opStackL1GasCost = sdk.utils.chainIsOPStack(Number(chainId))
-            ? await getCachedOpStackL1DataFee(depositArgs, nativeGasCost)
+            ? await getCachedOpStackL1DataFee(depositArgs, nativeGasCost).get()
             : undefined;
           const tokenGasCost = nativeGasCost
             .mul(gasPrice.maxFeePerGas)

--- a/api/limits.ts
+++ b/api/limits.ts
@@ -180,11 +180,7 @@ const handler = async (
       ),
       getCachedTokenPrice(l1Token.address, "usd"),
       getCachedLatestBlock(HUB_POOL_CHAIN_ID),
-      // If Linea, then we will defer gas price estimation to the SDK in getCachedFillGasUsage because
-      // the priority fee depends upon the fill transaction calldata.
-      destinationChainId === CHAIN_IDs.LINEA
-        ? undefined
-        : latestGasPriceCache(destinationChainId).get(),
+      latestGasPriceCache(depositArgs, { relayerAddress: relayer }).get(),
       isMessageDefined
         ? undefined // Only use cached gas units if message is not defined, i.e. standard for standard bridges
         : getCachedNativeGasCost(depositArgs, { relayerAddress: relayer }),

--- a/api/limits.ts
+++ b/api/limits.ts
@@ -235,14 +235,14 @@ const handler = async (
         )
       ),
     ]);
-    // This call should not make any additional RPC queries since we are passing in gasPrice, nativeGasCost
-    // and tokenGasCost.
     const tokenGasCost =
       nativeGasCost && gasPrice
         ? nativeGasCost
             .mul(gasPrice)
             .add(opStackL1GasCost ?? ethers.BigNumber.from("0"))
         : undefined;
+    // This call should not make any additional RPC queries since we are passing in gasPrice, nativeGasCost
+    // and tokenGasCost.
     const relayerFeeDetails = await getRelayerFeeDetails(
       depositArgs,
       tokenPriceNative,

--- a/api/limits.ts
+++ b/api/limits.ts
@@ -417,6 +417,14 @@ const handler = async (
         capitalFeeTotal: relayerFeeDetails.capitalFeeTotal,
         capitalFeePercent: relayerFeeDetails.capitalFeePercent,
       },
+      gasFeeDetails: tokenGasCost
+        ? {
+            nativeGasCost: nativeGasCost!.toString(), // Should exist if tokenGasCost exists
+            opStackL1GasCost: opStackL1GasCost?.toString(),
+            gasPrice: gasPrice.toString(),
+            tokenGasCost: tokenGasCost.toString(),
+          }
+        : undefined,
     };
     logger.debug({
       at: "Limits",

--- a/api/limits.ts
+++ b/api/limits.ts
@@ -169,7 +169,7 @@ const handler = async (
       tokenPriceNative,
       _tokenPriceUsd,
       latestBlock,
-      gasPrice,
+      { maxFeePerGas: gasPrice },
       nativeGasCost,
     ] = await Promise.all([
       getCachedTokenPrice(

--- a/api/limits.ts
+++ b/api/limits.ts
@@ -401,9 +401,9 @@ const handler = async (
       message: "Response data",
       responseJson,
     });
-    // Respond with a 200 status code and 10 seconds of cache with
-    // 45 seconds of stale-while-revalidate.
-    sendResponse(response, responseJson, 200, 10, 45);
+    // Respond with a 200 status code and 1 second of cache time with
+    // 59s to keep serving the stale data while recomputing the cached value.
+    sendResponse(response, responseJson, 200, 1, 59);
   } catch (error: unknown) {
     return handleErrorCondition("limits", response, logger, error);
   }

--- a/api/limits.ts
+++ b/api/limits.ts
@@ -189,7 +189,9 @@ const handler = async (
       ).get(),
       isMessageDefined
         ? undefined // Only use cached gas units if message is not defined, i.e. standard for standard bridges
-        : getCachedNativeGasCost(depositArgs, { relayerAddress: relayer }),
+        : getCachedNativeGasCost(depositArgs, {
+            relayerAddress: relayer,
+          }).get(),
     ]);
     const tokenPriceUsd = ethers.utils.parseUnits(_tokenPriceUsd.toString());
 
@@ -204,7 +206,7 @@ const handler = async (
         ? // Only use cached gas units if message is not defined, i.e. standard for standard bridges
           getCachedOpStackL1DataFee(depositArgs, nativeGasCost, {
             relayerAddress: relayer,
-          })
+          }).get()
         : undefined,
       callViaMulticall3(provider, multiCalls, {
         blockTag: latestBlock.number,

--- a/api/limits.ts
+++ b/api/limits.ts
@@ -178,9 +178,15 @@ const handler = async (
       ),
       getCachedTokenPrice(l1Token.address, "usd"),
       getCachedLatestBlock(HUB_POOL_CHAIN_ID),
-      latestGasPriceCache(destinationChainId, depositArgs, {
-        relayerAddress: relayer,
-      }).get(),
+      // We only want to derive an unsigned fill txn from the deposit args if the destination chain is Linea
+      // because only Linea's priority fee depends on the destination chain call data.
+      latestGasPriceCache(
+        destinationChainId,
+        CHAIN_IDs.LINEA === destinationChainId ? depositArgs : undefined,
+        {
+          relayerAddress: relayer,
+        }
+      ).get(),
       isMessageDefined
         ? undefined // Only use cached gas units if message is not defined, i.e. standard for standard bridges
         : getCachedNativeGasCost(depositArgs, { relayerAddress: relayer }),

--- a/api/limits.ts
+++ b/api/limits.ts
@@ -37,7 +37,6 @@ import {
   getCachedOpStackL1DataFee,
 } from "./_utils";
 import { MissingParamError } from "./_errors";
-import { bnZero } from "utils";
 
 const LimitsQueryParamsSchema = object({
   token: optional(validAddress()),
@@ -234,7 +233,9 @@ const handler = async (
     // and tokenGasCost.
     const tokenGasCost =
       nativeGasCost && gasPrice
-        ? nativeGasCost.mul(gasPrice).add(opStackL1GasCost ?? bnZero)
+        ? nativeGasCost
+            .mul(gasPrice)
+            .add(opStackL1GasCost ?? ethers.BigNumber.from("0"))
         : undefined;
     const relayerFeeDetails = await getRelayerFeeDetails(
       depositArgs,

--- a/api/limits.ts
+++ b/api/limits.ts
@@ -32,7 +32,6 @@ import {
   getCachedLatestBlock,
   parsableBigNumberString,
   validateDepositMessage,
-  getCachedFillGasUsage,
   latestGasPriceCache,
   getCachedNativeGasCost,
   getCachedOpStackL1DataFee,
@@ -180,7 +179,9 @@ const handler = async (
       ),
       getCachedTokenPrice(l1Token.address, "usd"),
       getCachedLatestBlock(HUB_POOL_CHAIN_ID),
-      latestGasPriceCache(depositArgs, { relayerAddress: relayer }).get(),
+      latestGasPriceCache(destinationChainId, depositArgs, {
+        relayerAddress: relayer,
+      }).get(),
       isMessageDefined
         ? undefined // Only use cached gas units if message is not defined, i.e. standard for standard bridges
         : getCachedNativeGasCost(depositArgs, { relayerAddress: relayer }),

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@across-protocol/constants": "^3.1.24",
     "@across-protocol/contracts": "^3.0.19",
     "@across-protocol/contracts-v3.0.6": "npm:@across-protocol/contracts@3.0.6",
-    "@across-protocol/sdk": "^3.4.10-beta.1",
+    "@across-protocol/sdk": "^3.4.10",
     "@amplitude/analytics-browser": "^2.3.5",
     "@balancer-labs/sdk": "1.1.6-beta.16",
     "@emotion/react": "^11.13.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@across-protocol/constants": "^3.1.24",
     "@across-protocol/contracts": "^3.0.19",
     "@across-protocol/contracts-v3.0.6": "npm:@across-protocol/contracts@3.0.6",
-    "@across-protocol/sdk": "^3.4.8",
+    "@across-protocol/sdk": "^3.4.10-beta.1",
     "@amplitude/analytics-browser": "^2.3.5",
     "@balancer-labs/sdk": "1.1.6-beta.16",
     "@emotion/react": "^11.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,10 +16,15 @@
     "@uma/common" "^2.17.0"
     hardhat "^2.9.3"
 
-"@across-protocol/constants@^3.1.24", "@across-protocol/constants@^3.1.25":
+"@across-protocol/constants@^3.1.24":
   version "3.1.25"
   resolved "https://registry.yarnpkg.com/@across-protocol/constants/-/constants-3.1.25.tgz#60d6d9814582ff91faf2b6d9f51d6dccb447b4ce"
   integrity sha512-GpZoYn7hETYL2BPMM2GqXAer6+l/xuhder+pvpb00HJcb/sqCjF7vaaeKxjKJ3jKtyeulYmdu0NDkeNm5KbNWA==
+
+"@across-protocol/constants@^3.1.27":
+  version "3.1.28"
+  resolved "https://registry.yarnpkg.com/@across-protocol/constants/-/constants-3.1.28.tgz#0540f5a44b085b0951a853898afe174ea113db3a"
+  integrity sha512-rnI1pQgkJ6+hPIQNomsi8eQreVfWKfFn9i9Z39U0fAnoXodZklW0eqj5N0cXlEfahp5j2u1RCs7s6fQ9megCdw==
 
 "@across-protocol/constants@^3.1.9":
   version "3.1.13"
@@ -83,14 +88,42 @@
     yargs "^17.7.2"
     zksync-web3 "^0.14.3"
 
-"@across-protocol/sdk@^3.4.8":
-  version "3.4.8"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-3.4.8.tgz#070abb97b687cfe22d89349d776f68008af5f6a7"
-  integrity sha512-m4JnT3Sh+zmTZ/Oi7QrTv3IuNB+myBcbnPnEEssZroyBost/yEPyxXks+EHeU67KrT84t/otGyNb5YpTOvOK0A==
+"@across-protocol/contracts@^3.0.20":
+  version "3.0.20"
+  resolved "https://registry.yarnpkg.com/@across-protocol/contracts/-/contracts-3.0.20.tgz#5a70782093d21a96b2e955b7ed725bea7af6e804"
+  integrity sha512-ufyO+MrbY7+0TDm/1cDl9iAeR4P8jt0AM1F9wiCBHVIYtj1wMD4eNm7G5Am3u8p1ruMjRhi6dJEVQcRF2O+LUg==
+  dependencies:
+    "@across-protocol/constants" "^3.1.27"
+    "@coral-xyz/anchor" "^0.30.1"
+    "@defi-wonderland/smock" "^2.3.4"
+    "@eth-optimism/contracts" "^0.5.40"
+    "@ethersproject/abstract-provider" "5.7.0"
+    "@ethersproject/abstract-signer" "5.7.0"
+    "@ethersproject/bignumber" "5.7.0"
+    "@openzeppelin/contracts" "4.9.6"
+    "@openzeppelin/contracts-upgradeable" "4.9.6"
+    "@scroll-tech/contracts" "^0.1.0"
+    "@solana-developers/helpers" "^2.4.0"
+    "@solana/spl-token" "^0.4.6"
+    "@solana/web3.js" "^1.31.0"
+    "@types/yargs" "^17.0.33"
+    "@uma/common" "^2.37.3"
+    "@uma/contracts-node" "^0.4.17"
+    "@uma/core" "^2.61.0"
+    axios "^1.7.4"
+    bs58 "^6.0.0"
+    prettier-plugin-rust "^0.1.9"
+    yargs "^17.7.2"
+    zksync-web3 "^0.14.3"
+
+"@across-protocol/sdk@^3.4.10-beta.1":
+  version "3.4.10-beta.1"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-3.4.10-beta.1.tgz#81d56458d97dec424e2fe51730f8ae3953c84e6c"
+  integrity sha512-c4tD6RQBKiok4fAK99Kh69B5+PIcAz0DLaAhfWxInRxW4kBeAKSrOtjETxuYN1wRZ89qRsGx+N+7c/wDpeQDxg==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
-    "@across-protocol/constants" "^3.1.25"
-    "@across-protocol/contracts" "^3.0.19"
+    "@across-protocol/constants" "^3.1.27"
+    "@across-protocol/contracts" "^3.0.20"
     "@eth-optimism/sdk" "^3.3.1"
     "@ethersproject/bignumber" "^5.7.0"
     "@pinata/sdk" "^2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -116,10 +116,10 @@
     yargs "^17.7.2"
     zksync-web3 "^0.14.3"
 
-"@across-protocol/sdk@^3.4.10-beta.1":
-  version "3.4.10-beta.1"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-3.4.10-beta.1.tgz#81d56458d97dec424e2fe51730f8ae3953c84e6c"
-  integrity sha512-c4tD6RQBKiok4fAK99Kh69B5+PIcAz0DLaAhfWxInRxW4kBeAKSrOtjETxuYN1wRZ89qRsGx+N+7c/wDpeQDxg==
+"@across-protocol/sdk@^3.4.10":
+  version "3.4.10"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-3.4.10.tgz#b74c551f1625afccc10f5b792f1f61395771cf40"
+  integrity sha512-kM+RyTNVXzS4dl5zwJZh6es5FTouN1nECd0cckE7Z/FzEFdMmQmCn4I1Ojgt4gmE5AuUBZef4/11ZvT8uRmutQ==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/constants" "^3.1.27"


### PR DESCRIPTION
This PR contains several optimizations that ultimately make the `gasFeeTotal` as accurate as possible while ensuring that the `/limits` endpoint is retrieving gas fee components from the cache as often as possible, keeping the endpoint latency down.

## `stale-while-revalidate`

We can reduce the /limits endpoint cache time to 1s while the revalidate period is 59s so that after the cached value is >1s old we can immediately start recomputing the limits value. This means in the best case we'll have as fresh gas cost data as possible--essentially, as quickly as we can re-compute the gas fee totals.

## Gas price caching:

We should ideally use less stale gas price data. This PR reduces the gas price caching time to 10s from 5s.

## Gas cost caching:

We currently cache the entire `tokenGasCost` value but this means we are negating some of the optimizations we have made to use as accurate gas fee estimation as possible.  This is because `tokenGasCost` is dependent on the `gasPrice` so if we cache the `tokenGasCost` longer than the gas price gets updated, then we're ultimately returning stale gas price data. 

This PR breaks down the `tokenGasCost` computation into `nativeGasCost` and `l1DataFee` values and caches them individually. This allows us to use a longer TTL for these values which are expected to change less frequently than the `gasPrice` estimation which we can reset the cached value very frequently.

## Cron job 

This PR adds `nativeGasCost` and `l1DataFee` cache resets to the cron job to keep these values fresh in the cache as often as possible. The ultimate effect is that the `/limits` endpoint should always hit the cache for `nativeGasCost`, `gasPrice` and `l1DataFee` and that these cached values are as fresh as possible.

This PR depends on https://github.com/across-protocol/sdk/pull/826