### PR TITLE
feat(API): Split gas component cron jobs up into different files

### DIFF
--- a/api/_types/utility.types.ts
+++ b/api/_types/utility.types.ts
@@ -21,3 +21,12 @@ export type TokenInfo = {
   name: string;
   addresses: Record<number, string>;
 };
+
+export type DepositRoute = {
+  originChainId: number;
+  originToken: string;
+  destinationChainId: number;
+  destinationToken: string;
+  originTokenSymbol: string;
+  destinationTokenSymbol: string;
+};

--- a/api/cron-cache-gas-costs.ts
+++ b/api/cron-cache-gas-costs.ts
@@ -108,10 +108,17 @@ const handler = async (
       }
     };
 
-    const getOutputTokensToChain = (chainId: number) =>
+    const getOutputTokensToChain = (chainId: number) => {
+      const destinationTokens = new Set<string>();
       availableRoutes
         .filter(({ destinationChainId }) => destinationChainId === chainId)
-        .map(({ destinationToken }) => destinationToken);
+        .forEach(({ destinationToken }) => {
+          if (!destinationTokens.has(destinationToken)) {
+            destinationTokens.add(destinationToken);
+          }
+        });
+      return Array.from(destinationTokens);
+    };
 
     const cacheUpdatePromise = Promise.all(
       mainnetChains.map(async (chain) => {

--- a/api/cron-cache-gas-costs.ts
+++ b/api/cron-cache-gas-costs.ts
@@ -164,28 +164,26 @@ const handler = async (
     // To circumvent this, we run the function in a loop and update gas prices every
     // `secondsPerUpdateForChain` seconds and stop after `maxDurationSec` seconds (1 minute).
     const cacheUpdatePromises = Promise.all([
-      Promise.all(
-        mainnetChains.map(async (chain) => {
-          const routesToChain = availableRoutes.filter(
-            ({ destinationChainId }) => destinationChainId === chain.chainId
-          );
-          const outputTokensForChain = routesToChain.map(
-            ({ destinationToken }) => destinationToken
-          );
-          await Promise.all([
-            Promise.all(
-              outputTokensForChain.map((outputToken) =>
-                updateNativeGasCostPromise(chain.chainId, outputToken)
-              )
-            ),
-            Promise.all(
-              outputTokensForChain.map((outputToken) =>
-                updateL1DataFeePromise(chain.chainId, outputToken)
-              )
-            ),
-          ]);
-        })
-      ),
+      mainnetChains.map(async (chain) => {
+        const routesToChain = availableRoutes.filter(
+          ({ destinationChainId }) => destinationChainId === chain.chainId
+        );
+        const outputTokensForChain = routesToChain.map(
+          ({ destinationToken }) => destinationToken
+        );
+        return Promise.all([
+          Promise.all(
+            outputTokensForChain.map((outputToken) =>
+              updateNativeGasCostPromise(chain.chainId, outputToken)
+            )
+          ),
+          Promise.all(
+            outputTokensForChain.map((outputToken) =>
+              updateL1DataFeePromise(chain.chainId, outputToken)
+            )
+          ),
+        ]);
+      }),
     ]);
 
     // The above promises are supposed to complete after maxDurationSec seconds, but there are so many of them

--- a/api/cron-cache-gas-costs.ts
+++ b/api/cron-cache-gas-costs.ts
@@ -169,20 +169,24 @@ const handler = async (
     // To circumvent this, we run the function in a loop and update gas prices every
     // `secondsPerUpdateForChain` seconds and stop after `maxDurationSec` seconds (1 minute).
     const cacheUpdatePromise = Promise.all([
-      mainnetChains.map(async (chain) => {
-        await Promise.all(
-          getOutputTokensToChain(chain.chainId).map((outputToken) =>
-            updateNativeGasCostPromise(chain.chainId, outputToken)
-          )
-        );
-      }),
-      mainnetChains.map(async (chain) => {
-        await Promise.all(
-          getOutputTokensToChain(chain.chainId).map((outputToken) =>
-            updateL1DataFeePromise(chain.chainId, outputToken)
-          )
-        );
-      }),
+      Promise.all(
+        mainnetChains.map(async (chain) => {
+          await Promise.all(
+            getOutputTokensToChain(chain.chainId).map((outputToken) =>
+              updateNativeGasCostPromise(chain.chainId, outputToken)
+            )
+          );
+        })
+      ),
+      Promise.all(
+        mainnetChains.map(async (chain) => {
+          await Promise.all(
+            getOutputTokensToChain(chain.chainId).map((outputToken) =>
+              updateL1DataFeePromise(chain.chainId, outputToken)
+            )
+          );
+        })
+      ),
     ]);
     // There are many routes and therefore many promises to wait to resolve so we force the
     // function to stop after `maxDurationSec` seconds.

--- a/api/cron-cache-gas-costs.ts
+++ b/api/cron-cache-gas-costs.ts
@@ -163,7 +163,7 @@ const handler = async (
     // But we want to update gas data more frequently than that.
     // To circumvent this, we run the function in a loop and update gas prices every
     // `secondsPerUpdateForChain` seconds and stop after `maxDurationSec` seconds (1 minute).
-    const cacheUpdatePromises = Promise.all([
+    const cacheUpdatePromises = Promise.all(
       mainnetChains.map(async (chain) => {
         const routesToChain = availableRoutes.filter(
           ({ destinationChainId }) => destinationChainId === chain.chainId
@@ -171,7 +171,7 @@ const handler = async (
         const outputTokensForChain = routesToChain.map(
           ({ destinationToken }) => destinationToken
         );
-        await Promise.all([
+        return Promise.all([
           ...outputTokensForChain.map((outputToken) =>
             updateNativeGasCostPromise(chain.chainId, outputToken)
           ),
@@ -179,8 +179,8 @@ const handler = async (
             updateL1DataFeePromise(chain.chainId, outputToken)
           ),
         ]);
-      }),
-    ]);
+      })
+    );
 
     // The above promises are supposed to complete after maxDurationSec seconds, but there are so many of them
     // (one per route) that they last one can run quite a bit longer, so force the function to stop after maxDurationSec

--- a/api/cron-cache-gas-costs.ts
+++ b/api/cron-cache-gas-costs.ts
@@ -131,8 +131,7 @@ const handler = async (
       message: "Finished",
       updateCounts,
     });
-    response.status(200);
-    response.send("OK");
+    response.status(200).json({ updateCounts });
   } catch (error: unknown) {
     return handleErrorCondition(
       "cron-cache-gas-costs",

--- a/api/cron-cache-gas-costs.ts
+++ b/api/cron-cache-gas-costs.ts
@@ -163,7 +163,7 @@ const handler = async (
     // But we want to update gas data more frequently than that.
     // To circumvent this, we run the function in a loop and update gas prices every
     // `secondsPerUpdateForChain` seconds and stop after `maxDurationSec` seconds (1 minute).
-    const cacheUpdatePromises = Promise.all(
+    await Promise.all(
       mainnetChains.map(async (chain) => {
         const routesToChain = availableRoutes.filter(
           ({ destinationChainId }) => destinationChainId === chain.chainId
@@ -171,21 +171,20 @@ const handler = async (
         const outputTokensForChain = routesToChain.map(
           ({ destinationToken }) => destinationToken
         );
-        return Promise.all([
-          ...outputTokensForChain.map((outputToken) =>
-            updateNativeGasCostPromise(chain.chainId, outputToken)
+        await Promise.all([
+          Promise.all(
+            outputTokensForChain.map((outputToken) =>
+              updateNativeGasCostPromise(chain.chainId, outputToken)
+            )
           ),
-          ...outputTokensForChain.map((outputToken) =>
-            updateL1DataFeePromise(chain.chainId, outputToken)
+          Promise.all(
+            outputTokensForChain.map((outputToken) =>
+              updateL1DataFeePromise(chain.chainId, outputToken)
+            )
           ),
         ]);
       })
     );
-
-    // The above promises are supposed to complete after maxDurationSec seconds, but there are so many of them
-    // (one per route) that they last one can run quite a bit longer, so force the function to stop after maxDurationSec
-    // so that the serverless function can exit successfully.
-    await Promise.race([cacheUpdatePromises, utils.delay(maxDurationSec)]);
 
     logger.debug({
       at: "CronCacheGasPrices",

--- a/api/cron-cache-gas-costs.ts
+++ b/api/cron-cache-gas-costs.ts
@@ -172,15 +172,11 @@ const handler = async (
           ({ destinationToken }) => destinationToken
         );
         return Promise.all([
-          Promise.all(
-            outputTokensForChain.map((outputToken) =>
-              updateNativeGasCostPromise(chain.chainId, outputToken)
-            )
+          ...outputTokensForChain.map((outputToken) =>
+            updateNativeGasCostPromise(chain.chainId, outputToken)
           ),
-          Promise.all(
-            outputTokensForChain.map((outputToken) =>
-              updateL1DataFeePromise(chain.chainId, outputToken)
-            )
+          ...outputTokensForChain.map((outputToken) =>
+            updateL1DataFeePromise(chain.chainId, outputToken)
           ),
         ]);
       }),

--- a/api/cron-cache-gas-costs.ts
+++ b/api/cron-cache-gas-costs.ts
@@ -37,7 +37,6 @@ const updateNativeGasCostIntervalsSecPerChain = {
   default: 30,
 };
 
-// Force the cache update promises to stop 1s before the Vercel serverless function times out.
 const maxDurationSec = 60;
 
 const getDepositArgsForChainId = (chainId: number, tokenAddress: string) => {
@@ -164,7 +163,7 @@ const handler = async (
     // But we want to update gas data more frequently than that.
     // To circumvent this, we run the function in a loop and update gas prices every
     // `secondsPerUpdateForChain` seconds and stop after `maxDurationSec` seconds (1 minute).
-    const cacheUpdatePromises = Promise.all([
+    await Promise.all([
       Promise.all(
         mainnetChains.map(async (chain) => {
           const routesToChain = availableRoutes.filter(
@@ -188,7 +187,6 @@ const handler = async (
         })
       ),
     ]);
-    await Promise.race([cacheUpdatePromises, utils.delay(maxDurationSec)]);
 
     logger.debug({
       at: "CronCacheGasPrices",

--- a/api/cron-cache-gas-costs.ts
+++ b/api/cron-cache-gas-costs.ts
@@ -1,0 +1,209 @@
+import { VercelResponse } from "@vercel/node";
+import { TypedVercelRequest } from "./_types";
+import {
+  HUB_POOL_CHAIN_ID,
+  getCachedNativeGasCost,
+  getCachedOpStackL1DataFee,
+  getLogger,
+  handleErrorCondition,
+  resolveVercelEndpoint,
+} from "./_utils";
+import { UnauthorizedError } from "./_errors";
+
+import mainnetChains from "../src/data/chains_1.json";
+import { utils, constants } from "@across-protocol/sdk";
+import { DEFAULT_SIMULATED_RECIPIENT_ADDRESS } from "./_constants";
+import axios from "axios";
+import { ethers } from "ethers";
+
+type Route = {
+  originChainId: number;
+  originToken: string;
+  destinationChainId: number;
+  destinationToken: string;
+  originTokenSymbol: string;
+  destinationTokenSymbol: string;
+};
+
+// Set lower than TTL in getCachedOpStackL1DataFee
+// Set lower than the L1 block time so we can try to get as up to date L1 data fees based on L1 base fees as possible.
+const updateL1DataFeeIntervalsSecPerChain = {
+  default: 10,
+};
+
+// Set lower than TTL in getCachedNativeGasCost. This should rarely change so we should just make sure
+// we keep this cache warm.
+const updateNativeGasCostIntervalsSecPerChain = {
+  default: 30,
+};
+
+// Force the cache update promises to stop 1s before the Vercel serverless function times out.
+const maxDurationSec = 60;
+
+const getDepositArgsForChainId = (chainId: number, tokenAddress: string) => {
+  return {
+    amount: ethers.BigNumber.from(100),
+    inputToken: constants.ZERO_ADDRESS,
+    outputToken: tokenAddress,
+    recipientAddress: DEFAULT_SIMULATED_RECIPIENT_ADDRESS,
+    originChainId: 0, // Shouldn't matter for simulation
+    destinationChainId: Number(chainId),
+  };
+};
+
+const handler = async (
+  request: TypedVercelRequest<Record<string, never>>,
+  response: VercelResponse
+) => {
+  const logger = getLogger();
+  logger.debug({
+    at: "CronCacheGasPrices",
+    message: "Starting cron job...",
+  });
+  try {
+    const authHeader = request.headers?.["authorization"];
+    if (
+      !process.env.CRON_SECRET ||
+      authHeader !== `Bearer ${process.env.CRON_SECRET}`
+    ) {
+      throw new UnauthorizedError();
+    }
+
+    // Skip cron job on testnet
+    if (HUB_POOL_CHAIN_ID !== 1) {
+      logger.info({
+        at: "CronCacheGasPrices",
+        message: "Skipping cron job on testnet",
+      });
+      return;
+    }
+
+    const availableRoutes = (
+      await axios(`${resolveVercelEndpoint()}/api/available-routes`)
+    ).data as Array<Route>;
+
+    // This marks the timestamp when the function started
+    const functionStart = Date.now();
+
+    /**
+     * @notice Updates the L1 data fee gas cost cache every `updateL1DataFeeIntervalsSecPerChain` seconds
+     * up to `maxDurationSec` seconds.
+     * @param chainId Chain to estimate l1 data fee for
+     * @param outputTokenAddress This output token will be used to construct a fill transaction to simulate
+     * gas costs for.
+     */
+    const updateL1DataFeePromise = async (
+      chainId: number,
+      outputTokenAddress: string
+    ): Promise<void> => {
+      const secondsPerUpdate = updateL1DataFeeIntervalsSecPerChain.default;
+      const depositArgs = getDepositArgsForChainId(chainId, outputTokenAddress);
+      const gasCostCache = getCachedNativeGasCost(depositArgs);
+
+      while (true) {
+        const diff = Date.now() - functionStart;
+        // Stop after `maxDurationSec` seconds
+        if (diff >= maxDurationSec * 1000) {
+          break;
+        }
+        const gasCost = await gasCostCache.get();
+        if (utils.chainIsOPStack(chainId)) {
+          const cache = getCachedOpStackL1DataFee(depositArgs, gasCost);
+          try {
+            await cache.set();
+          } catch (err) {
+            logger.warn({
+              at: "CronCacheGasPrices#updateL1DataFeePromise",
+              message: `Failed to set l1 data fee cache for chain ${chainId}`,
+              depositArgs,
+              gasCost,
+              error: err,
+            });
+          }
+        }
+        await utils.delay(secondsPerUpdate);
+      }
+    };
+
+    /**
+     * @notice Updates the native gas cost cache every `updateNativeGasCostIntervalsSecPerChain` seconds
+     * up to `maxDurationSec` seconds.
+     * @param chainId Chain to estimate gas cost for
+     * @param outputTokenAddress This output token will be used to construct a fill transaction to simulate
+     * gas costs for.
+     */
+    const updateNativeGasCostPromise = async (
+      chainId: number,
+      outputTokenAddress: string
+    ): Promise<void> => {
+      const secondsPerUpdate = updateNativeGasCostIntervalsSecPerChain.default;
+      const depositArgs = getDepositArgsForChainId(chainId, outputTokenAddress);
+      const cache = getCachedNativeGasCost(depositArgs);
+
+      while (true) {
+        const diff = Date.now() - functionStart;
+        // Stop after `maxDurationSec` seconds
+        if (diff >= maxDurationSec * 1000) {
+          break;
+        }
+        try {
+          await cache.set();
+        } catch (err) {
+          logger.warn({
+            at: "CronCacheGasPrices#updateNativeGasCostPromise",
+            message: `Failed to set native gas cost cache for chain ${chainId}`,
+            depositArgs,
+            error: err,
+          });
+        }
+        await utils.delay(secondsPerUpdate);
+      }
+    };
+
+    // The minimum interval for Vercel Serverless Functions cron jobs is 1 minute.
+    // But we want to update gas data more frequently than that.
+    // To circumvent this, we run the function in a loop and update gas prices every
+    // `secondsPerUpdateForChain` seconds and stop after `maxDurationSec` seconds (1 minute).
+    const cacheUpdatePromises = Promise.all([
+      Promise.all(
+        mainnetChains.map(async (chain) => {
+          const routesToChain = availableRoutes.filter(
+            ({ destinationChainId }) => destinationChainId === chain.chainId
+          );
+          const outputTokensForChain = routesToChain.map(
+            ({ destinationToken }) => destinationToken
+          );
+          await Promise.all([
+            Promise.all(
+              outputTokensForChain.map((outputToken) =>
+                updateNativeGasCostPromise(chain.chainId, outputToken)
+              )
+            ),
+            Promise.all(
+              outputTokensForChain.map((outputToken) =>
+                updateL1DataFeePromise(chain.chainId, outputToken)
+              )
+            ),
+          ]);
+        })
+      ),
+    ]);
+    await Promise.race([cacheUpdatePromises, utils.delay(maxDurationSec)]);
+
+    logger.debug({
+      at: "CronCacheGasPrices",
+      message: "Finished",
+    });
+    response.status(200);
+    response.send("OK");
+  } catch (error: unknown) {
+    return handleErrorCondition(
+      "cron-cache-gas-prices",
+      response,
+      logger,
+      error
+    );
+  }
+};
+
+export default handler;

--- a/api/cron-cache-gas-costs.ts
+++ b/api/cron-cache-gas-costs.ts
@@ -171,7 +171,7 @@ const handler = async (
         const outputTokensForChain = routesToChain.map(
           ({ destinationToken }) => destinationToken
         );
-        return Promise.all([
+        await Promise.all([
           ...outputTokensForChain.map((outputToken) =>
             updateNativeGasCostPromise(chain.chainId, outputToken)
           ),

--- a/api/cron-cache-gas-prices.ts
+++ b/api/cron-cache-gas-prices.ts
@@ -107,9 +107,15 @@ const handler = async (
       }
     };
 
-    const lineaDestinationRoutes = availableRoutes.filter(
-      ({ destinationChainId }) => destinationChainId === CHAIN_IDs.LINEA
-    );
+    const lineaDestinationRoutes = () => {
+      const routes = new Set<string>();
+      availableRoutes
+        .filter(
+          ({ destinationChainId }) => destinationChainId === CHAIN_IDs.LINEA
+        )
+        .forEach(({ destinationToken }) => routes.add(destinationToken));
+      return Array.from(routes);
+    };
     // The minimum interval for Vercel Serverless Functions cron jobs is 1 minute.
     // But we want to update gas data more frequently than that.
     // To circumvent this, we run the function in a loop and update gas prices every
@@ -123,7 +129,7 @@ const handler = async (
           .map((chain) => updateGasPricePromise(chain.chainId))
       ),
       Promise.all(
-        lineaDestinationRoutes.map(({ destinationToken }) =>
+        lineaDestinationRoutes().map((destinationToken) =>
           updateGasPricePromise(CHAIN_IDs.LINEA, destinationToken)
         )
       ),

--- a/api/cron-cache-gas-prices.ts
+++ b/api/cron-cache-gas-prices.ts
@@ -119,7 +119,7 @@ const handler = async (
     // But we want to update gas data more frequently than that.
     // To circumvent this, we run the function in a loop and update gas prices every
     // `secondsPerUpdateForChain` seconds and stop after `maxDurationSec` seconds (1 minute).
-    const cacheUpdatePromises = Promise.all([
+    await Promise.all([
       // @dev Linea gas prices are dependent on the L2 calldata to be submitted so compute one gas price for each output token,
       // so we compute one gas price per output token for Linea
       Promise.all(
@@ -133,7 +133,6 @@ const handler = async (
         )
       ),
     ]);
-    await Promise.race([cacheUpdatePromises, utils.delay(maxDurationSec)]);
 
     logger.debug({
       at: "CronCacheGasPrices",

--- a/api/cron-cache-gas-prices.ts
+++ b/api/cron-cache-gas-prices.ts
@@ -134,8 +134,7 @@ const handler = async (
       message: "Finished",
       updateCounts,
     });
-    response.status(200);
-    response.send("OK");
+    response.status(200).json({ updateCounts });
   } catch (error: unknown) {
     return handleErrorCondition(
       "cron-cache-gas-prices",

--- a/api/cron-cache-gas-prices.ts
+++ b/api/cron-cache-gas-prices.ts
@@ -29,7 +29,6 @@ const updateIntervalsSecPerChain = {
   default: 5,
 };
 
-// Force the cache update promises to stop 1s before the Vercel serverless function times out.
 const maxDurationSec = 60;
 
 const getDepositArgsForChainId = (chainId: number, tokenAddress: string) => {

--- a/api/cron-cache-gas-prices.ts
+++ b/api/cron-cache-gas-prices.ts
@@ -2,8 +2,6 @@ import { VercelResponse } from "@vercel/node";
 import { TypedVercelRequest } from "./_types";
 import {
   HUB_POOL_CHAIN_ID,
-  getCachedNativeGasCost,
-  getCachedOpStackL1DataFee,
   getLogger,
   handleErrorCondition,
   latestGasPriceCache,
@@ -31,18 +29,7 @@ const updateIntervalsSecPerChain = {
   default: 5,
 };
 
-// Set lower than TTL in getCachedOpStackL1DataFee
-// Set lower than the L1 block time so we can try to get as up to date L1 data fees based on L1 base fees as possible.
-const updateL1DataFeeIntervalsSecPerChain = {
-  default: 10,
-};
-
-// Set lower than TTL in getCachedNativeGasCost. This should rarely change so we should just make sure
-// we keep this cache warm.
-const updateNativeGasCostIntervalsSecPerChain = {
-  default: 30,
-};
-
+// Force the cache update promises to stop 1s before the Vercel serverless function times out.
 const maxDurationSec = 60;
 
 const getDepositArgsForChainId = (chainId: number, tokenAddress: string) => {
@@ -101,12 +88,10 @@ const handler = async (
       outputTokenAddress?: string
     ): Promise<void> => {
       const secondsPerUpdateForChain = updateIntervalsSecPerChain.default;
-      const cache = latestGasPriceCache(
-        chainId,
-        outputTokenAddress
-          ? getDepositArgsForChainId(chainId, outputTokenAddress)
-          : undefined
-      );
+      const depositArgs = outputTokenAddress
+        ? getDepositArgsForChainId(chainId, outputTokenAddress)
+        : undefined;
+      const cache = latestGasPriceCache(chainId, depositArgs);
 
       while (true) {
         const diff = Date.now() - functionStart;
@@ -114,64 +99,17 @@ const handler = async (
         if (diff >= maxDurationSec * 1000) {
           break;
         }
-        await cache.set();
-        await utils.delay(secondsPerUpdateForChain);
-      }
-    };
-
-    /**
-     * @notice Updates the L1 data fee gas cost cache every `updateL1DataFeeIntervalsSecPerChain` seconds
-     * up to `maxDurationSec` seconds.
-     * @param chainId Chain to estimate l1 data fee for
-     * @param outputTokenAddress This output token will be used to construct a fill transaction to simulate
-     * gas costs for.
-     */
-    const updateL1DataFeePromise = async (
-      chainId: number,
-      outputTokenAddress: string
-    ): Promise<void> => {
-      const secondsPerUpdate = updateL1DataFeeIntervalsSecPerChain.default;
-      const depositArgs = getDepositArgsForChainId(chainId, outputTokenAddress);
-      const gasCostCache = getCachedNativeGasCost(depositArgs);
-
-      while (true) {
-        const diff = Date.now() - functionStart;
-        // Stop after `maxDurationSec` seconds
-        if (diff >= maxDurationSec * 1000) {
-          break;
-        }
-        const gasCost = await gasCostCache.get();
-        if (utils.chainIsOPStack(chainId)) {
-          const cache = getCachedOpStackL1DataFee(depositArgs, gasCost);
+        try {
           await cache.set();
+        } catch (err) {
+          logger.warn({
+            at: "CronCacheGasPrices#updateGasPricePromise",
+            message: `Failed to set gas price cache for chain ${chainId}`,
+            depositArgs,
+            error: err,
+          });
         }
-        await utils.delay(secondsPerUpdate);
-      }
-    };
-
-    /**
-     * @notice Updates the native gas cost cache every `updateNativeGasCostIntervalsSecPerChain` seconds
-     * up to `maxDurationSec` seconds.
-     * @param chainId Chain to estimate gas cost for
-     * @param outputTokenAddress This output token will be used to construct a fill transaction to simulate
-     * gas costs for.
-     */
-    const updateNativeGasCostPromise = async (
-      chainId: number,
-      outputTokenAddress: string
-    ): Promise<void> => {
-      const secondsPerUpdate = updateNativeGasCostIntervalsSecPerChain.default;
-      const depositArgs = getDepositArgsForChainId(chainId, outputTokenAddress);
-      const cache = getCachedNativeGasCost(depositArgs);
-
-      while (true) {
-        const diff = Date.now() - functionStart;
-        // Stop after `maxDurationSec` seconds
-        if (diff >= maxDurationSec * 1000) {
-          break;
-        }
-        await cache.set();
-        await utils.delay(secondsPerUpdate);
+        await utils.delay(secondsPerUpdateForChain);
       }
     };
 
@@ -182,7 +120,7 @@ const handler = async (
     // But we want to update gas data more frequently than that.
     // To circumvent this, we run the function in a loop and update gas prices every
     // `secondsPerUpdateForChain` seconds and stop after `maxDurationSec` seconds (1 minute).
-    await Promise.all([
+    const cacheUpdatePromises = Promise.all([
       // @dev Linea gas prices are dependent on the L2 calldata to be submitted so compute one gas price for each output token,
       // so we compute one gas price per output token for Linea
       Promise.all(
@@ -195,29 +133,8 @@ const handler = async (
           updateGasPricePromise(CHAIN_IDs.LINEA, destinationToken)
         )
       ),
-      Promise.all(
-        mainnetChains.map(async (chain) => {
-          const routesToChain = availableRoutes.filter(
-            ({ destinationChainId }) => destinationChainId === chain.chainId
-          );
-          const outputTokensForChain = routesToChain.map(
-            ({ destinationToken }) => destinationToken
-          );
-          await Promise.all([
-            Promise.all(
-              outputTokensForChain.map((outputToken) =>
-                updateNativeGasCostPromise(chain.chainId, outputToken)
-              )
-            ),
-            Promise.all(
-              outputTokensForChain.map((outputToken) =>
-                updateL1DataFeePromise(chain.chainId, outputToken)
-              )
-            ),
-          ]);
-        })
-      ),
     ]);
+    await Promise.race([cacheUpdatePromises, utils.delay(maxDurationSec)]);
 
     logger.debug({
       at: "CronCacheGasPrices",

--- a/api/cron-cache-l1-data-fee.ts
+++ b/api/cron-cache-l1-data-fee.ts
@@ -137,8 +137,7 @@ const handler = async (
       message: "Finished",
       updateCounts,
     });
-    response.status(200);
-    response.send("OK");
+    response.status(200).json({ updateCounts });
   } catch (error: unknown) {
     return handleErrorCondition(
       "cron-cache-l1-data-fee",

--- a/api/cron-cache-l1-data-fee.ts
+++ b/api/cron-cache-l1-data-fee.ts
@@ -112,10 +112,17 @@ const handler = async (
       }
     };
 
-    const getOutputTokensToChain = (chainId: number) =>
+    const getOutputTokensToChain = (chainId: number) => {
+      const destinationTokens = new Set<string>();
       availableRoutes
         .filter(({ destinationChainId }) => destinationChainId === chainId)
-        .map(({ destinationToken }) => destinationToken);
+        .forEach(({ destinationToken }) => {
+          if (!destinationTokens.has(destinationToken)) {
+            destinationTokens.add(destinationToken);
+          }
+        });
+      return Array.from(destinationTokens);
+    };
 
     const cacheUpdatePromise = Promise.all(
       mainnetChains

--- a/vercel.json
+++ b/vercel.json
@@ -14,6 +14,10 @@
       "schedule": "* * * * *"
     },
     {
+      "path": "/api/cron-cache-l1-data-fee",
+      "schedule": "* * * * *"
+    },
+    {
       "path": "/api/cron-ping-endpoints",
       "schedule": "* * * * *"
     }
@@ -23,6 +27,9 @@
       "maxDuration": 90
     },
     "api/cron-cache-gas-costs.ts": {
+      "maxDuration": 90
+    },
+    "api/cron-cache-l1-data-fee.ts": {
       "maxDuration": 90
     },
     "api/cron-ping-endpoints.ts": {

--- a/vercel.json
+++ b/vercel.json
@@ -10,12 +10,19 @@
       "schedule": "* * * * *"
     },
     {
+      "path": "/api/cron-cache-gas-costs",
+      "schedule": "* * * * *"
+    },
+    {
       "path": "/api/cron-ping-endpoints",
       "schedule": "* * * * *"
     }
   ],
   "functions": {
     "api/cron-cache-gas-prices.ts": {
+      "maxDuration": 90
+    },
+    "api/cron-cache-gas-costs.ts": {
       "maxDuration": 90
     },
     "api/cron-ping-endpoints.ts": {


### PR DESCRIPTION
Updating the gas costs and gas prices in the same cron job makes the cache resets slower due to the memory constraints of a single file, and when updating the gas price every 5s, this makes a difference.

This PR splits the gas cost updates, which are 10s and 30s for l1 data fees and native gas costs, separate from the gas price updates so that the gas price updates can be closer to 5s. Currently its anywhere from 5s to 10s.

Additionally, this PR adds try-catches around the `await cache.set()` calls so that the a failure due to an upstream RPC call (e.g. I've seen this happen with linea_estimateGas calls a lot) doesn't take down the cron job for the full run.

Finally, there was an issue with the current cron job where all combinations of chainId+outputToken were repeated many times, leading to tons of wasteful computation. This PR uses `Set's` to make sure costs are computed once for each destinationChain+outputToken combination