### PR TITLE
feat(hyperliquid): estimate fees properly

### DIFF
--- a/src/utils/bridge.ts
+++ b/src/utils/bridge.ts
@@ -1,17 +1,25 @@
-import { ethers, BigNumber } from "ethers";
+import { ethers, BigNumber, utils } from "ethers";
 import {
+  acrossPlusMulticallHandler,
   ChainId,
   fixedPointAdjustment,
+  getToken,
+  hyperLiquidBridge2Address,
   referrerDelimiterHex,
 } from "./constants";
 import { DOMAIN_CALLDATA_DELIMITER, tagAddress, tagHex } from "./format";
 import { getProvider } from "./providers";
-import { getConfig, isContractDeployedToAddress } from "utils";
+import {
+  generateHyperLiquidPayload,
+  getConfig,
+  isContractDeployedToAddress,
+} from "utils";
 import getApiEndpoint from "./serverless-api";
 import { BridgeLimitInterface } from "./serverless-api/types";
 import { DepositNetworkMismatchProperties } from "ampli";
 import { SwapQuoteApiResponse } from "./serverless-api/prod/swap-quote";
 import { SpokePool, SpokePoolVerifier } from "./typechain";
+import { CHAIN_IDs } from "@across-protocol/constants";
 
 export type Fee = {
   total: ethers.BigNumber;
@@ -41,11 +49,80 @@ type GetBridgeFeesArgs = {
   fromChainId: ChainId;
   toChainId: ChainId;
   recipientAddress?: string;
+  message?: string;
 };
 
 export type GetBridgeFeesResult = BridgeFees & {
   isAmountTooLow: boolean;
 };
+
+/**
+ *
+ */
+export async function getBridgeFeesWithExternalProjectId(
+  externalProjectId: string,
+  args: GetBridgeFeesArgs
+) {
+  let message = undefined;
+  let recipientAddress = args.recipientAddress;
+
+  if (externalProjectId === "hyper-liquid") {
+    const arbitrumProvider = getProvider(CHAIN_IDs.ARBITRUM);
+
+    const wallet = ethers.Wallet.createRandom();
+
+    const signer = new ethers.Wallet(wallet.privateKey, arbitrumProvider);
+
+    const recipient = await signer.getAddress();
+
+    // Build the payload
+    const hyperLiquidPayload = await generateHyperLiquidPayload(
+      signer,
+      recipient,
+      args.amount
+    );
+    // Create a txn calldata for transfering amount to recipient
+    const erc20Interface = new utils.Interface([
+      "function transfer(address to, uint256 amount) returns (bool)",
+    ]);
+
+    const transferCalldata = erc20Interface.encodeFunctionData("transfer", [
+      recipient,
+      args.amount,
+    ]);
+
+    // Encode Instructions struct directly
+    message = utils.defaultAbiCoder.encode(
+      [
+        "tuple(tuple(address target, bytes callData, uint256 value)[] calls, address fallbackRecipient)",
+      ],
+      [
+        {
+          calls: [
+            {
+              target: getToken("USDC").addresses![CHAIN_IDs.ARBITRUM],
+              callData: transferCalldata,
+              value: 0,
+            },
+            {
+              target: hyperLiquidBridge2Address,
+              callData: hyperLiquidPayload,
+              value: 0,
+            },
+          ],
+          fallbackRecipient: args.recipientAddress!,
+        },
+      ]
+    );
+    recipientAddress = acrossPlusMulticallHandler[args.toChainId];
+  }
+
+  return getBridgeFees({
+    ...args,
+    recipientAddress,
+    message,
+  });
+}
 
 /**
  *
@@ -63,6 +140,7 @@ export async function getBridgeFees({
   fromChainId,
   toChainId,
   recipientAddress,
+  message,
 }: GetBridgeFeesArgs): Promise<GetBridgeFeesResult> {
   const timeBeforeRequests = Date.now();
   const {
@@ -84,7 +162,8 @@ export async function getBridgeFees({
     getConfig().getTokenInfoBySymbol(toChainId, outputTokenSymbol).address,
     toChainId,
     fromChainId,
-    recipientAddress
+    recipientAddress,
+    message
   );
   const timeAfterRequests = Date.now();
 

--- a/src/utils/bridge.ts
+++ b/src/utils/bridge.ts
@@ -65,11 +65,8 @@ export async function getBridgeFeesWithExternalProjectId(
 
   if (externalProjectId === "hyper-liquid") {
     const arbitrumProvider = getProvider(CHAIN_IDs.ARBITRUM);
-
     const wallet = ethers.Wallet.createRandom();
-
     const signer = new ethers.Wallet(wallet.privateKey, arbitrumProvider);
-
     const recipient = await signer.getAddress();
 
     // Build the payload

--- a/src/utils/bridge.ts
+++ b/src/utils/bridge.ts
@@ -56,9 +56,6 @@ export type GetBridgeFeesResult = BridgeFees & {
   isAmountTooLow: boolean;
 };
 
-/**
- *
- */
 export async function getBridgeFeesWithExternalProjectId(
   externalProjectId: string,
   args: GetBridgeFeesArgs

--- a/src/utils/hyperliquid.ts
+++ b/src/utils/hyperliquid.ts
@@ -1,8 +1,8 @@
 import { Deposit } from "hooks/useDeposits";
 import { CHAIN_IDs } from "@across-protocol/constants";
-import { utils } from "ethers";
+import { BigNumber, Contract, providers, Signer, utils } from "ethers";
 import { compareAddressesSimple } from "./sdk";
-import { hyperLiquidBridge2Address } from "./constants";
+import { getToken, hyperLiquidBridge2Address } from "./constants";
 
 export function isHyperLiquidBoundDeposit(deposit: Deposit) {
   if (deposit.destinationChainId !== CHAIN_IDs.ARBITRUM || !deposit.message) {
@@ -31,4 +31,78 @@ export function isHyperLiquidBoundDeposit(deposit: Deposit) {
   } catch {
     return false;
   }
+}
+
+/**
+ * Creates a payload that will be ingested by Bridge2/batchedDepositWithPermit of a single deposit
+ */
+export async function generateHyperLiquidPayload(
+  signer: Signer,
+  recipient: string,
+  amount: BigNumber
+) {
+  const source = await signer.getAddress();
+
+  if (!compareAddressesSimple(source, recipient)) {
+    throw new Error("Source and recipient must be the same");
+  }
+
+  const timestamp = Date.now();
+  const deadline = Math.floor(timestamp / 1000) + 3600;
+
+  // Create USDC contract interface
+  const usdcInterface = new utils.Interface([
+    "function nonces(address owner) view returns (uint256)",
+    "function permit(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s)",
+  ]);
+
+  const usdcContract = new Contract(
+    getToken("USDC").addresses![CHAIN_IDs.ARBITRUM],
+    usdcInterface,
+    signer
+  );
+
+  // USDC permit signature with verified domain parameters
+  const usdcDomain = {
+    name: "USD Coin",
+    version: "2",
+    chainId: CHAIN_IDs.ARBITRUM,
+    verifyingContract: getToken("USDC").addresses![CHAIN_IDs.ARBITRUM]!,
+  };
+
+  const permitTypes = {
+    Permit: [
+      { name: "owner", type: "address" },
+      { name: "spender", type: "address" },
+      { name: "value", type: "uint256" },
+      { name: "nonce", type: "uint256" },
+      { name: "deadline", type: "uint256" },
+    ],
+  };
+
+  const permitValue = {
+    owner: source,
+    spender: hyperLiquidBridge2Address,
+    value: amount,
+    nonce: await usdcContract.nonces(source),
+    deadline,
+  };
+
+  const permitSignature = await (
+    signer as providers.JsonRpcSigner
+  )._signTypedData(usdcDomain, permitTypes, permitValue);
+  const { r, s, v } = utils.splitSignature(permitSignature);
+
+  const deposit = {
+    user: source,
+    usd: amount,
+    deadline,
+    signature: { r: BigNumber.from(r), s: BigNumber.from(s), v },
+  };
+
+  const iface = new utils.Interface([
+    "function batchedDepositWithPermit(tuple(address user, uint64 usd, uint64 deadline, tuple(uint256 r, uint256 s, uint8 v) signature)[] deposits)",
+  ]);
+
+  return iface.encodeFunctionData("batchedDepositWithPermit", [[deposit]]);
 }

--- a/src/utils/query-keys.ts
+++ b/src/utils/query-keys.ts
@@ -31,6 +31,8 @@ export function balanceQueryKey(
  * @param amount  The amount to check bridge fees for.
  * @param fromChainId The origin chain of this bridge action
  * @param toChainId The destination chain of this bridge action
+ * @param externalProjectId The external project id to check bridge fees for.
+ * @param recipientAddress The recipient address to check bridge fees for.
  * @returns An array of query keys for @tanstack/react-query `useQuery` hook.
  */
 export function bridgeFeesQueryKey(
@@ -38,7 +40,9 @@ export function bridgeFeesQueryKey(
   inputToken: string,
   outputToken: string,
   fromChainId: ChainId,
-  toChainId: ChainId
+  toChainId: ChainId,
+  externalProjectId?: string,
+  recipientAddress?: string
 ) {
   return [
     "bridgeFees",
@@ -47,6 +51,8 @@ export function bridgeFeesQueryKey(
     amount.toString(),
     fromChainId,
     toChainId,
+    externalProjectId,
+    recipientAddress,
   ] as const;
 }
 

--- a/src/utils/serverless-api/mocked/suggested-fees.mocked.ts
+++ b/src/utils/serverless-api/mocked/suggested-fees.mocked.ts
@@ -17,7 +17,8 @@ export async function suggestedFeesMockedApiCall(
   _outputToken: string,
   _toChainid: ChainId,
   _fromChainid: ChainId,
-  _recipientAddress?: string
+  _recipientAddress?: string,
+  _message?: string
 ): Promise<SuggestedApiFeeReturnType> {
   const token = getTokenByAddress(_inputToken);
   const decimals = token?.decimals ?? 18;

--- a/src/utils/serverless-api/prod/suggested-fees.prod.ts
+++ b/src/utils/serverless-api/prod/suggested-fees.prod.ts
@@ -17,7 +17,8 @@ export async function suggestedFeesApiCall(
   outputToken: string,
   toChainid: ChainId,
   fromChainid: ChainId,
-  recipientAddress?: string
+  recipientAddress?: string,
+  message?: string
 ): Promise<SuggestedApiFeeReturnType> {
   const response = await axios.get(`${vercelApiBaseUrl}/api/suggested-fees`, {
     params: {
@@ -29,6 +30,7 @@ export async function suggestedFeesApiCall(
       amount: amount.toString(),
       skipAmountLimit: true,
       depositMethod: "depositExclusive",
+      message,
     },
   });
   const result = response.data;

--- a/src/utils/serverless-api/types.ts
+++ b/src/utils/serverless-api/types.ts
@@ -67,7 +67,8 @@ export type SuggestedApiFeeType = (
   outputToken: string,
   toChainid: ChainId,
   fromChainid: ChainId,
-  recipientAddress?: string
+  recipientAddress?: string,
+  message?: string
 ) => Promise<SuggestedApiFeeReturnType>;
 
 export type RetrieveLinkedWalletType = (

--- a/src/views/Bridge/hooks/useBridgeAction.ts
+++ b/src/views/Bridge/hooks/useBridgeAction.ts
@@ -28,6 +28,7 @@ import {
   hyperLiquidBridge2Address,
   externalProjectNameToId,
   generateHyperLiquidPayload,
+  fixedPointAdjustment,
 } from "utils";
 import { TransferQuote } from "./useTransferQuote";
 import { SelectedRoute } from "../utils";
@@ -127,11 +128,12 @@ export function useBridgeAction(
         // 4. We must construct a payload to send to HL's Bridge2 contract
         // 5. The user must sign this signature
 
-        // Estimated fee for this HL deposit. Sum of the fees plus a 2 unit buffer
-        const estimatedFee = frozenFeeQuote.relayerCapitalFee.total
-          .add(frozenFeeQuote.lpFee.total)
-          .add(frozenFeeQuote.relayerGasFee.total);
-        const amount = frozenDepositArgs.amount.sub(estimatedFee).sub(2);
+        // Subtract the relayer fee pct just like we do for our output token amount
+        const amount = frozenDepositArgs.amount.sub(
+          frozenDepositArgs.amount
+            .mul(frozenDepositArgs.relayerFeePct)
+            .div(fixedPointAdjustment)
+        );
 
         // Build the payload
         const hyperLiquidPayload = await generateHyperLiquidPayload(

--- a/src/views/Bridge/hooks/useBridgeAction.ts
+++ b/src/views/Bridge/hooks/useBridgeAction.ts
@@ -3,7 +3,7 @@ import {
   TransferQuoteReceivedProperties,
   ampli,
 } from "ampli";
-import { BigNumber, constants, providers, Signer, utils } from "ethers";
+import { BigNumber, constants, providers, utils } from "ethers";
 import {
   useConnection,
   useApprove,
@@ -23,11 +23,11 @@ import {
   sendSpokePoolVerifierDepositTx,
   sendDepositV3Tx,
   sendSwapAndBridgeTx,
-  compareAddressesSimple,
   getToken,
   acrossPlusMulticallHandler,
   hyperLiquidBridge2Address,
   externalProjectNameToId,
+  generateHyperLiquidPayload,
 } from "utils";
 import { TransferQuote } from "./useTransferQuote";
 import { SelectedRoute } from "../utils";
@@ -35,7 +35,6 @@ import useReferrer from "hooks/useReferrer";
 import { SwapQuoteApiResponse } from "utils/serverless-api/prod/swap-quote";
 import { BridgeLimitInterface } from "utils/serverless-api/types";
 import { CHAIN_IDs } from "@across-protocol/constants";
-import { Contract } from "ethers";
 
 const config = getConfig();
 
@@ -128,13 +127,11 @@ export function useBridgeAction(
         // 4. We must construct a payload to send to HL's Bridge2 contract
         // 5. The user must sign this signature
 
-        // Estimated fee for this HL deposit. Sum of the relayer capital fee,
-        // the lp fee, and 2x the relayer gas fee.
+        // Estimated fee for this HL deposit. Sum of the fees plus a 2 unit buffer
         const estimatedFee = frozenFeeQuote.relayerCapitalFee.total
           .add(frozenFeeQuote.lpFee.total)
-          .add(frozenFeeQuote.relayerGasFee.total.mul(2));
-
-        const amount = frozenDepositArgs.amount.sub(estimatedFee);
+          .add(frozenFeeQuote.relayerGasFee.total);
+        const amount = frozenDepositArgs.amount.sub(estimatedFee).sub(2);
 
         // Build the payload
         const hyperLiquidPayload = await generateHyperLiquidPayload(
@@ -430,78 +427,4 @@ function getButtonLabel(args: {
     return "Switch network and confirm transaction";
   }
   return "Confirm transaction";
-}
-
-/**
- * Creates a payload that will be ingested by Bridge2/batchedDepositWithPermit of a single deposit
- */
-export async function generateHyperLiquidPayload(
-  signer: Signer,
-  recipient: string,
-  amount: BigNumber
-) {
-  const source = await signer.getAddress();
-
-  if (!compareAddressesSimple(source, recipient)) {
-    throw new Error("Source and recipient must be the same");
-  }
-
-  const timestamp = Date.now();
-  const deadline = Math.floor(timestamp / 1000) + 3600;
-
-  // Create USDC contract interface
-  const usdcInterface = new utils.Interface([
-    "function nonces(address owner) view returns (uint256)",
-    "function permit(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s)",
-  ]);
-
-  const usdcContract = new Contract(
-    getToken("USDC").addresses![CHAIN_IDs.ARBITRUM],
-    usdcInterface,
-    signer
-  );
-
-  // USDC permit signature with verified domain parameters
-  const usdcDomain = {
-    name: "USD Coin",
-    version: "2",
-    chainId: CHAIN_IDs.ARBITRUM,
-    verifyingContract: getToken("USDC").addresses![CHAIN_IDs.ARBITRUM]!,
-  };
-
-  const permitTypes = {
-    Permit: [
-      { name: "owner", type: "address" },
-      { name: "spender", type: "address" },
-      { name: "value", type: "uint256" },
-      { name: "nonce", type: "uint256" },
-      { name: "deadline", type: "uint256" },
-    ],
-  };
-
-  const permitValue = {
-    owner: source,
-    spender: hyperLiquidBridge2Address,
-    value: amount,
-    nonce: await usdcContract.nonces(source),
-    deadline,
-  };
-
-  const permitSignature = await (
-    signer as providers.JsonRpcSigner
-  )._signTypedData(usdcDomain, permitTypes, permitValue);
-  const { r, s, v } = utils.splitSignature(permitSignature);
-
-  const deposit = {
-    user: source,
-    usd: amount,
-    deadline,
-    signature: { r: BigNumber.from(r), s: BigNumber.from(s), v },
-  };
-
-  const iface = new utils.Interface([
-    "function batchedDepositWithPermit(tuple(address user, uint64 usd, uint64 deadline, tuple(uint256 r, uint256 s, uint8 v) signature)[] deposits)",
-  ]);
-
-  return iface.encodeFunctionData("batchedDepositWithPermit", [[deposit]]);
 }

--- a/src/views/Bridge/hooks/useTransferQuote.ts
+++ b/src/views/Bridge/hooks/useTransferQuote.ts
@@ -51,6 +51,7 @@ export function useTransferQuote(
     selectedRoute.toChain,
     selectedRoute.fromTokenSymbol,
     selectedRoute.toTokenSymbol,
+    selectedRoute.externalProjectId,
     toAddress
   );
   const limitsQuery = useBridgeLimits(


### PR DESCRIPTION
This update sets the fees more accurately by calling into the suggested fees API endpoint with a simulated message payload. 

~~The caveat here is that due to rounding issues there's sometimes a 1 unit refund against the recipient (0.000001 USDC). Examples:~~
~~* https://arbiscan.io/tx/0x0ad884bf8eadcda92a2ad3fc55d62d79bac30ac80c83f0d0c32e04b06e8ace56~~
~~* https://arbiscan.io/tx/0xc800914ff0d79bc6c5032abfe3a90cfbd35c48109420b1d0f1b04d4720dab0f5~~