### PR TITLE
fix: custom gas token bridging

### DIFF
--- a/scripts/generate-routes.ts
+++ b/scripts/generate-routes.ts
@@ -276,6 +276,7 @@ function transformChainConfigs(
           ];
         }
 
+        // Handle WGRASS -> GRASS
         if (
           tokenSymbol === "WGRASS" &&
           toChainConfig.tokens.includes("GRASS")
@@ -563,6 +564,11 @@ function transformToRoute(
     throw new Error("Mismatching L1 addresses");
   }
 
+  const fromChain = Object.values(chainConfigs).find(
+    (config) => config.chainId === route.fromChain
+  )!;
+  const isNative = inputTokenSymbol === fromChain.nativeToken;
+
   return {
     fromChain: route.fromChain,
     toChain: toChain.chainId,
@@ -571,7 +577,7 @@ function transformToRoute(
     fromSpokeAddress: utils.getAddress(route.fromSpokeAddress),
     fromTokenSymbol: inputTokenSymbol,
     toTokenSymbol: outputTokenSymbol,
-    isNative: inputTokenSymbol === TOKEN_SYMBOLS_MAP.ETH.symbol,
+    isNative,
     l1TokenAddress: inputToken.l1TokenAddress,
   };
 }

--- a/src/data/routes_11155111_0x14224e63716afAcE30C9a417E0542281869f7d9e.json
+++ b/src/data/routes_11155111_0x14224e63716afAcE30C9a417E0542281869f7d9e.json
@@ -1518,7 +1518,7 @@
       "fromSpokeAddress": "0x6A0a7f39530923911832Dd60667CE5da5449967B",
       "fromTokenSymbol": "GRASS",
       "toTokenSymbol": "GRASS",
-      "isNative": false,
+      "isNative": true,
       "l1TokenAddress": "0x2Be68B15c693D3b5747F9F0D49D30A2E81BAA2Df"
     },
     {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -342,7 +342,10 @@ export class ConfigClient {
         address:
           token.addresses?.[chainId || constants.hubPoolChainId] ||
           token.mainnetAddress!,
-        isNative: token.symbol === "ETH",
+        isNative: chainId
+          ? constants.chainInfoTable[chainId].nativeCurrencySymbol ===
+            token.symbol
+          : token.symbol === "ETH",
       };
     });
   }


### PR DESCRIPTION
When bridging from a chain with a custom gas token (e.g. GRASS Lens Sepolia), the dApp was not correctly handling it as a native token.