### PR TITLE
ci: add deps to dependabot ignore list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,8 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+      # Packages that need manual upgrades or should be pinned to a specific version
+      - dependency-name: "@across-protocol/sdk"
+      - dependency-name: "@across-protocol/contracts"
+      - dependency-name: "@across-protocol/constants"
+      - dependency-name: "@balancer-labs/sdk"

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "jest-transform-stub": "^2.0.0",
     "lint-staged": "^13.0.3",
     "patch-package": "^7.0.0",
-    "prettier": "3.3.2",
+    "prettier": "^3.4.2",
     "rollup-plugin-visualizer": "^5.12.0",
     "storybook": "^7.5.3",
     "ts-jest": "^29.1.1",

--- a/src/components/GlobalStyles/GlobalStyles.tsx
+++ b/src/components/GlobalStyles/GlobalStyles.tsx
@@ -9,9 +9,9 @@ export const typography = css`
     font-weight: 400;
     font-display: fallback;
     src: url("/fonts/Barlow-Regular.woff2") format("woff2");
-    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
-      U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212,
-      U+2215, U+FEFF, U+FFFD;
+    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6,
+      U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193,
+      U+2212, U+2215, U+FEFF, U+FFFD;
   }
   @font-face {
     font-family: "Barlow";
@@ -19,9 +19,9 @@ export const typography = css`
     font-weight: 500;
     font-display: fallback;
     src: url("/fonts/Barlow-Medium.woff2") format("woff2");
-    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
-      U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212,
-      U+2215, U+FEFF, U+FFFD;
+    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6,
+      U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193,
+      U+2212, U+2215, U+FEFF, U+FFFD;
   }
   @font-face {
     font-family: "Barlow";
@@ -29,9 +29,9 @@ export const typography = css`
     font-weight: 700;
     font-display: fallback;
     src: url("/fonts/Barlow-Bold.woff2") format("woff2");
-    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
-      U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212,
-      U+2215, U+FEFF, U+FFFD;
+    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6,
+      U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193,
+      U+2212, U+2215, U+FEFF, U+FFFD;
   }
 `;
 const variables = css`

--- a/src/views/Staking/hooks/useStakeFormLogic.ts
+++ b/src/views/Staking/hooks/useStakeFormLogic.ts
@@ -49,11 +49,11 @@ export function useStakeFormLogic(
     amount &&
     isAmountValid &&
     isNumberEthersParseable(amount)
-      ? deriveNewStakingValues(
+      ? (deriveNewStakingValues(
           poolData,
           poolData.lpTokenParser(amount),
           stakingAction
-        ) ?? poolData
+        ) ?? poolData)
       : poolData;
 
   const maximumValue =

--- a/yarn.lock
+++ b/yarn.lock
@@ -18493,15 +18493,15 @@ prettier-plugin-rust@^0.1.9:
     jinx-rust "0.1.6"
     prettier "^2.7.1"
 
-prettier@3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.3.2.tgz#03ff86dc7c835f2d2559ee76876a3914cec4a90a"
-  integrity sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==
-
 prettier@^2.7.1, prettier@^2.8.0:
   version "2.8.8"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
   integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
+
+prettier@^3.4.2:
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.4.2.tgz#a5ce1fb522a588bf2b78ca44c6e6fe5aa5a2b13f"
+  integrity sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==
 
 pretty-format@^27.0.2:
   version "27.5.1"


### PR DESCRIPTION
Some deps should be ignored by dependabot. This could be due to:
- Not using SemVer
- Pinning to a specific version