### PR TITLE
hotfix(hyperliquid): quote on unconnected wallet

### DIFF
--- a/src/utils/bridge.ts
+++ b/src/utils/bridge.ts
@@ -104,7 +104,7 @@ export async function getBridgeFeesWithExternalProjectId(
               value: 0,
             },
           ],
-          fallbackRecipient: args.recipientAddress!,
+          fallbackRecipient: recipient,
         },
       ]
     );


### PR DESCRIPTION
The logic change is in an area that simulates a suggested fees message payload. In an unconnected state the fallback recipient is undefined and this causes a failure.