### PR TITLE
chore: Temporarily disable relayer exclusivity

### DIFF
--- a/api/suggested-fees.ts
+++ b/api/suggested-fees.ts
@@ -26,6 +26,7 @@ import {
   validateChainAndTokenParams,
   getCachedLimits,
   getCachedLatestBlock,
+  getCurrentTime,
 } from "./_utils";
 import { selectExclusiveRelayer } from "./_exclusivity";
 import {

--- a/api/suggested-fees.ts
+++ b/api/suggested-fees.ts
@@ -26,7 +26,6 @@ import {
   validateChainAndTokenParams,
   getCachedLimits,
   getCachedLatestBlock,
-  getCurrentTime,
 } from "./_utils";
 import { selectExclusiveRelayer } from "./_exclusivity";
 import {
@@ -260,7 +259,10 @@ const handler = async (
     let exclusiveRelayer = sdk.constants.ZERO_ADDRESS;
     let exclusivityDeadline = 0;
     // Temporarily disable exclusivity, to be resumed based on timestamp.
-    if (depositMethod === "depositExclusive" && getCurrentTime() < 1738965797) {
+    if (
+      depositMethod === "depositExclusive" &&
+      sdk.utils.getCurrentTime() < 1738965797
+    ) {
       ({ exclusiveRelayer, exclusivityPeriod: exclusivityDeadline } =
         await selectExclusiveRelayer(
           computedOriginChainId,

--- a/api/suggested-fees.ts
+++ b/api/suggested-fees.ts
@@ -261,7 +261,7 @@ const handler = async (
     // Temporarily disable exclusivity, to be resumed based on timestamp.
     if (
       depositMethod === "depositExclusive" &&
-      sdk.utils.getCurrentTime() >1738965797
+      sdk.utils.getCurrentTime() > 1738965797
     ) {
       ({ exclusiveRelayer, exclusivityPeriod: exclusivityDeadline } =
         await selectExclusiveRelayer(

--- a/api/suggested-fees.ts
+++ b/api/suggested-fees.ts
@@ -261,7 +261,7 @@ const handler = async (
     // Temporarily disable exclusivity, to be resumed based on timestamp.
     if (
       depositMethod === "depositExclusive" &&
-      sdk.utils.getCurrentTime() < 1738965797
+      sdk.utils.getCurrentTime() >1738965797
     ) {
       ({ exclusiveRelayer, exclusivityPeriod: exclusivityDeadline } =
         await selectExclusiveRelayer(

--- a/api/suggested-fees.ts
+++ b/api/suggested-fees.ts
@@ -258,7 +258,8 @@ const handler = async (
 
     let exclusiveRelayer = sdk.constants.ZERO_ADDRESS;
     let exclusivityDeadline = 0;
-    if (depositMethod === "depositExclusive") {
+    // Temporarily disable exclusivity, to be resumed based on timestamp.
+    if (depositMethod === "depositExclusive" && getCurrentTime() < 1738965797) {
       ({ exclusiveRelayer, exclusivityPeriod: exclusivityDeadline } =
         await selectExclusiveRelayer(
           computedOriginChainId,


### PR DESCRIPTION
Many relayers are down due to the pending SpokePool upgrade. Disable for ~12 hours and then resume automatically. This is a bodge.