### PR TITLE
chore: update OP ceiling to end rewards program

### DIFF
--- a/src/hooks/useAvailableRemainingRewards.ts
+++ b/src/hooks/useAvailableRemainingRewards.ts
@@ -32,7 +32,7 @@ async function resolveCurrentDispensedOpRewards() {
   }>(`${rewardsApiUrl}/rewards/op-rebates/stats`);
   const opToken = getToken("OP");
   const existingTokens = BigNumber.from(data.totalTokenAmount);
-  const tokenCeiling = parseUnits("750000", opToken.decimals); // 750K tokens
+  const tokenCeiling = parseUnits("749000", opToken.decimals); // 749K tokens
 
   return {
     totalTokensDispensed: existingTokens,


### PR DESCRIPTION
We want to end the program at 749K OP so we have 1K OP available in case we need them for deposits that didn't get the expected rewards.