### PR TITLE
feat: l1 token config fallback

### DIFF
--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -2204,9 +2204,10 @@ export function paramToArray<T extends undefined | string | string[]>(
 
 export function parseL1TokenConfigSafe(jsonString: string) {
   try {
-    return sdk.contracts.acrossConfigStore.Client.parseL1TokenConfig(
-      jsonString
-    );
+    return null;
+    // return sdk.contracts.acrossConfigStore.Client.parseL1TokenConfig(
+    //   jsonString
+    // );
   } catch (error) {
     getLogger().error({
       at: "parseL1TokenConfigSafe",

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -2204,10 +2204,9 @@ export function paramToArray<T extends undefined | string | string[]>(
 
 export function parseL1TokenConfigSafe(jsonString: string) {
   try {
-    return null;
-    // return sdk.contracts.acrossConfigStore.Client.parseL1TokenConfig(
-    //   jsonString
-    // );
+    return sdk.contracts.acrossConfigStore.Client.parseL1TokenConfig(
+      jsonString
+    );
   } catch (error) {
     getLogger().error({
       at: "parseL1TokenConfigSafe",

--- a/api/cron-cache-l1-token-configs.ts
+++ b/api/cron-cache-l1-token-configs.ts
@@ -1,0 +1,73 @@
+import { VercelResponse } from "@vercel/node";
+import { TypedVercelRequest } from "./_types";
+
+import {
+  HUB_POOL_CHAIN_ID,
+  getLogger,
+  handleErrorCondition,
+  getL1TokenConfigCache,
+} from "./_utils";
+import { UnauthorizedError } from "./_errors";
+
+import mainnetChains from "../src/data/chains_1.json";
+
+const handler = async (
+  request: TypedVercelRequest<Record<string, never>>,
+  response: VercelResponse
+) => {
+  const logger = getLogger();
+  logger.debug({
+    at: "CronCacheL1TokenConfigs",
+    message: "Starting cron job...",
+  });
+  try {
+    const authHeader = request.headers?.["authorization"];
+    if (
+      !process.env.CRON_SECRET ||
+      authHeader !== `Bearer ${process.env.CRON_SECRET}`
+    ) {
+      throw new UnauthorizedError();
+    }
+
+    // Skip cron job on testnet
+    if (HUB_POOL_CHAIN_ID !== 1) {
+      return;
+    }
+
+    const mainnetChain = mainnetChains.find((chain) => chain.chainId === 1);
+
+    if (!mainnetChain) {
+      throw new Error("Mainnet chain not found");
+    }
+
+    const l1TokenAddresses = mainnetChain.inputTokens.map(
+      (token) => token.address
+    );
+
+    for (const l1TokenAddress of l1TokenAddresses) {
+      const l1TokenConfigCache = getL1TokenConfigCache(l1TokenAddress);
+
+      logger.info({
+        at: "CronCacheL1TokenConfigs",
+        message: `Caching L1 token config for ${l1TokenAddress}`,
+      });
+      await l1TokenConfigCache.set();
+    }
+
+    logger.debug({
+      at: "CronCacheL1TokenConfigs",
+      message: "Finished",
+    });
+    response.status(200);
+    response.send("OK");
+  } catch (error: unknown) {
+    return handleErrorCondition(
+      "cron-cache-l1-token-configs",
+      response,
+      logger,
+      error
+    );
+  }
+};
+
+export default handler;

--- a/api/cron-cache-l1-token-configs.ts
+++ b/api/cron-cache-l1-token-configs.ts
@@ -43,16 +43,24 @@ const handler = async (
     const l1TokenAddresses = mainnetChain.inputTokens.map(
       (token) => token.address
     );
-
-    for (const l1TokenAddress of l1TokenAddresses) {
-      const l1TokenConfigCache = getL1TokenConfigCache(l1TokenAddress);
-
-      logger.info({
-        at: "CronCacheL1TokenConfigs",
-        message: `Caching L1 token config for ${l1TokenAddress}`,
-      });
-      await l1TokenConfigCache.set();
-    }
+    const setL1TokenConfigTasks = l1TokenAddresses.map((l1TokenAddress) => {
+      try {
+        const l1TokenConfigCache = getL1TokenConfigCache(l1TokenAddress);
+        logger.info({
+          at: "CronCacheL1TokenConfigs",
+          message: `Caching L1 token config for ${l1TokenAddress}`,
+        });
+        return l1TokenConfigCache.set();
+      } catch (e) {
+        logger.error({
+          at: "CronCacheL1TokenConfigs",
+          message: `Error caching L1 token config for ${l1TokenAddress}`,
+          error: e,
+        });
+        throw e;
+      }
+    });
+    await Promise.all(setL1TokenConfigTasks);
 
     logger.debug({
       at: "CronCacheL1TokenConfigs",

--- a/api/suggested-fees.ts
+++ b/api/suggested-fees.ts
@@ -27,6 +27,8 @@ import {
   getCachedLimits,
   getCachedLatestBlock,
   OPT_IN_CHAINS,
+  parseL1TokenConfigSafe,
+  getL1TokenConfigCache,
 } from "./_utils";
 import { selectExclusiveRelayer } from "./_exclusivity";
 import {
@@ -243,14 +245,16 @@ const handler = async (
       });
     }
 
-    const parsedL1TokenConfig =
-      sdk.contracts.acrossConfigStore.Client.parseL1TokenConfig(
-        String(rawL1TokenConfig)
-      );
+    const parsedL1TokenConfig = parseL1TokenConfigSafe(
+      String(rawL1TokenConfig)
+    );
+    const validL1TokenConfig =
+      parsedL1TokenConfig ||
+      (await getL1TokenConfigCache(l1Token.address).get());
     const routeRateModelKey = `${computedOriginChainId}-${destinationChainId}`;
     const rateModel =
-      parsedL1TokenConfig.routeRateModel?.[routeRateModelKey] ||
-      parsedL1TokenConfig.rateModel;
+      validL1TokenConfig.routeRateModel?.[routeRateModelKey] ||
+      validL1TokenConfig.rateModel;
     const lpFeePct = sdk.lpFeeCalculator.calculateRealizedLpFeePct(
       rateModel,
       currentUt,

--- a/vercel.json
+++ b/vercel.json
@@ -20,6 +20,10 @@
     {
       "path": "/api/cron-ping-endpoints",
       "schedule": "* * * * *"
+    },
+    {
+      "path": "/api/cron-cache-l1-token-configs",
+      "schedule": "0 * * * *"
     }
   ],
   "functions": {


### PR DESCRIPTION
This adds some fallback logic to the API in case of an un-parsable JSON. We have a CRON job which runs every hour to cache parseable L1 token configs. If we fail to parse the string directly fetched from the ConfigStore, we use the cached one.