### PR TITLE
fix: account for message requirement on relayer balance

### DIFF
--- a/src/hooks/useBridgeFees.ts
+++ b/src/hooks/useBridgeFees.ts
@@ -69,9 +69,12 @@ export function useBridgeFees(
     retry: (_, error) => {
       if (
         error instanceof AxiosError &&
-        error.response?.data.includes(
-          "Amount exceeds max. deposit limit for short delay"
-        )
+        (error.response?.data?.message?.includes(
+          "doesn't have enough funds to support this deposit"
+        ) ||
+          error.response?.data.includes(
+            "Amount exceeds max. deposit limit for short delay"
+          ))
       ) {
         return false;
       }


### PR DESCRIPTION
We cannot initiate slow fills for Hyperliquid due to protocol constraints preventing slow fills on messages. Therefore, we need to gracefully handle this in the UI by not showing a quote and not hanging.