### PR TITLE
fix: recompute fees when switching arb <-> hl

### DIFF
--- a/src/views/Bridge/hooks/useTransferQuote.ts
+++ b/src/views/Bridge/hooks/useTransferQuote.ts
@@ -74,6 +74,7 @@ export function useTransferQuote(
       amount.toString(),
       swapSlippage,
       toAddress,
+      selectedRoute.externalProjectId,
     ],
     enabled: Boolean(
       feesQuery.fees &&


### PR DESCRIPTION
The fee query when switching from Arbitrum to HL didn't always update. Even though the fees query got recomputed, the quote query did not.