### PR TITLE
fix: minor edit on available-routes API description

### DIFF
--- a/api-docs-openapi.yaml
+++ b/api-docs-openapi.yaml
@@ -263,7 +263,7 @@ paths:
   /available-routes:
     get:
       summary: Retrieve available routes for transfers
-      description: Returns available routes based on specified parameters.
+      description: Returns available routes based on specified parameters. If no parameters are provided, available routes on all chains are returned.
       parameters:
         - name: originChainId
           in: query


### PR DESCRIPTION
Minor edit suggesting that all routes across all chains are returned incase the dev does not provide any parameters while using the available-routes API