### PR TITLE
feat: allow setting transfer restricted relayer per chain and token

### DIFF
--- a/api/_constants.ts
+++ b/api/_constants.ts
@@ -3,11 +3,7 @@ import { relayFeeCalculator, utils } from "@across-protocol/sdk";
 import * as constants from "@across-protocol/constants";
 import { getEnvs } from "./_env";
 
-const {
-  RELAYER_ADDRESS_OVERRIDES,
-  GRAPH_API_KEY,
-  RELAYER_FEE_CAPITAL_COST_OVERRIDES,
-} = getEnvs();
+const { GRAPH_API_KEY, RELAYER_FEE_CAPITAL_COST_OVERRIDES } = getEnvs();
 
 export const CHAIN_IDs = constants.CHAIN_IDs;
 export const TOKEN_SYMBOLS_MAP = constants.TOKEN_SYMBOLS_MAP;
@@ -132,16 +128,6 @@ defaultRelayerFeeCapitalCostConfig["USDB"] = {
 export const coinGeckoAssetPlatformLookup: Record<string, number> = {
   "0x4200000000000000000000000000000000000042": CHAIN_IDs.OPTIMISM,
 };
-
-export const defaultRelayerAddressOverride: {
-  defaultAddr?: string;
-  symbols?: {
-    [symbol: string]: {
-      defaultAddr?: string;
-      chains?: { [chainId: string]: string };
-    };
-  };
-} = JSON.parse(RELAYER_ADDRESS_OVERRIDES || "{}");
 
 export const graphAPIKey = GRAPH_API_KEY;
 

--- a/api/_relayer-address.ts
+++ b/api/_relayer-address.ts
@@ -1,0 +1,76 @@
+import { constants } from "@across-protocol/sdk";
+import { getEnvs } from "./_env";
+import { ethers } from "ethers";
+
+const {
+  RELAYER_ADDRESS_OVERRIDES,
+  REACT_APP_FULL_RELAYERS,
+  TRANSFER_RESTRICTED_RELAYERS,
+} = getEnvs();
+
+export const defaultRelayerAddressOverride: {
+  defaultAddr?: string;
+  symbols?: {
+    [symbol: string]: {
+      defaultAddr?: string;
+      chains?: { [chainId: string]: string };
+    };
+  };
+} = JSON.parse(RELAYER_ADDRESS_OVERRIDES || "{}");
+
+const transferRestrictedRelayers: {
+  [destinationChainId: string]: {
+    [symbol: string]: string[];
+  };
+} = JSON.parse(TRANSFER_RESTRICTED_RELAYERS || "{}");
+
+/**
+ * Returns the EOA that will serve as the default relayer address for simulated deposits.
+ * @param destinationChainId The destination chain that a bridge operation will transfer to
+ * @param symbol A valid token symbol
+ * @returns A valid EOA address
+ */
+export function getDefaultRelayerAddress(
+  destinationChainId: number,
+  symbol?: string
+) {
+  const symbolOverride = symbol
+    ? defaultRelayerAddressOverride?.symbols?.[symbol]
+    : undefined;
+  return (
+    symbolOverride?.chains?.[destinationChainId] ?? // Specific Symbol/Chain override
+    symbolOverride?.defaultAddr ?? // Specific Symbol override
+    defaultRelayerAddressOverride?.defaultAddr ?? // Default override
+    constants.DEFAULT_SIMULATED_RELAYER_ADDRESS // Default hardcoded value
+  );
+}
+
+/**
+ * Returns a list of relayers that run a full auto-rebalancing strategy.
+ * @returns A list of relayer addresses
+ */
+export function getFullRelayers() {
+  if (!REACT_APP_FULL_RELAYERS) {
+    return [];
+  }
+  return (JSON.parse(REACT_APP_FULL_RELAYERS) as string[]).map((relayer) => {
+    return ethers.utils.getAddress(relayer);
+  });
+}
+
+/**
+ * Returns a list of relayers that do not run a full auto-rebalancing strategy.
+ * @param destinationChainId The destination chain that a bridge operation will transfer to
+ * @param symbol A valid token symbol
+ * @returns A list of relayer addresses
+ */
+export function getTransferRestrictedRelayers(
+  destinationChainId: number,
+  symbol: string
+) {
+  const restrictedRelayers =
+    transferRestrictedRelayers[destinationChainId]?.[symbol] ?? [];
+  return restrictedRelayers.map((relayer) => {
+    return ethers.utils.getAddress(relayer);
+  });
+}

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -74,10 +74,6 @@ import {
   InvalidParamError,
   RouteNotEnabledError,
 } from "./_errors";
-import {
-  defaultRelayerAddressOverride,
-  getTransferRestrictedRelayers,
-} from "./_relayer-address";
 
 export { InputError, handleErrorCondition } from "./_errors";
 

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -58,7 +58,6 @@ import {
   MULTICALL3_ADDRESS_OVERRIDES,
   SECONDS_PER_YEAR,
   TOKEN_SYMBOLS_MAP,
-  defaultRelayerAddressOverride,
   disabledL1Tokens,
   graphAPIKey,
   maxRelayFeePct,
@@ -75,6 +74,10 @@ import {
   InvalidParamError,
   RouteNotEnabledError,
 } from "./_errors";
+import {
+  defaultRelayerAddressOverride,
+  getTransferRestrictedRelayers,
+} from "./_relayer-address";
 
 export { InputError, handleErrorCondition } from "./_errors";
 
@@ -1826,27 +1829,6 @@ export async function getBalancerV2TokenPrice(
   );
 
   return Number((totalValue / floatTotalSupply).toFixed(18));
-}
-
-/**
- * Returns the EOA that will serve as the default relayer address
- * @param destinationChainId The destination chain that a bridge operation will transfer to
- * @param symbol A valid token symbol
- * @returns A valid EOA address
- */
-export function getDefaultRelayerAddress(
-  destinationChainId: number,
-  symbol?: string
-) {
-  const symbolOverride = symbol
-    ? defaultRelayerAddressOverride?.symbols?.[symbol]
-    : undefined;
-  return (
-    symbolOverride?.chains?.[destinationChainId] ?? // Specific Symbol/Chain override
-    symbolOverride?.defaultAddr ?? // Specific Symbol override
-    defaultRelayerAddressOverride?.defaultAddr ?? // Default override
-    sdk.constants.DEFAULT_SIMULATED_RELAYER_ADDRESS // Default hardcoded value
-  );
 }
 
 /**

--- a/api/suggested-fees.ts
+++ b/api/suggested-fees.ts
@@ -20,7 +20,6 @@ import {
   HUB_POOL_CHAIN_ID,
   ENABLED_ROUTES,
   getSpokePoolAddress,
-  getDefaultRelayerAddress,
   getHubPool,
   callViaMulticall3,
   validateChainAndTokenParams,
@@ -45,7 +44,7 @@ import {
 import { getFillDeadline } from "./_fill-deadline";
 import { parseRole, Role } from "./_auth";
 import { getEnvs } from "./_env";
-
+import { getDefaultRelayerAddress } from "./_relayer-address";
 const { BigNumber } = ethers;
 
 const SuggestedFeesQueryParamsSchema = type({


### PR DESCRIPTION
Closes ACX-3891

Allows to set new env var `TRANSFER_RESTRICTED_RELAYERS` in the format
```
{
  "1135": {
    "LSK": "0x..."
  }
}
```