### PR TITLE
match wildcards for max deposits env var

### DIFF
--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -33,7 +33,6 @@ import {
   string,
   Struct,
 } from "superstruct";
-
 import enabledMainnetRoutesAsJson from "../src/data/routes_1_0xc186fA914353c44b2E33eBE05f21846F1048bEda.json";
 import enabledSepoliaRoutesAsJson from "../src/data/routes_11155111_0x14224e63716afAcE30C9a417E0542281869f7d9e.json";
 import rpcProvidersJson from "../src/data/rpc-providers.json";
@@ -1939,7 +1938,13 @@ export function getChainInputTokenMaxDepositInUsd(
   const defaultValue = includeDefault
     ? DEFAULT_LITE_CHAIN_USD_MAX_DEPOSIT
     : undefined;
-  return maxDeposits[chainId.toString()]?.[symbol] || defaultValue;
+
+  return (
+    maxDeposits[chainId.toString()]?.[symbol] ?? // specific chain => specific token
+    maxDeposits["*"]?.[symbol] ?? // all chains for specific token
+    maxDeposits["*"]?.["*"] ?? // all tokens for all chains
+    defaultValue // default
+  );
 }
 
 export function getCachedLatestBlock(chainId: number) {


### PR DESCRIPTION
## motivation
We need to be able to set max balances for a set of tokens on ALL chains per environment, testnet 
We can do this with env var `CHAIN_USD_MAX_DEPOSITS`

this will set a $10 max deposit for all chains for USDC,WETH,ETH 
`CHAIN_USD_MAX_DEPOSITS="{"*":{"USDC":"10","ETH":"10","WETH":"10"}}"`