### PR TITLE
improve: use generic speed up txn

### DIFF
--- a/src/utils/sdk.ts
+++ b/src/utils/sdk.ts
@@ -14,6 +14,7 @@ export { getCurrentTime } from "@across-protocol/sdk/dist/esm/utils/TimeUtils";
 export { isBridgedUsdc } from "@across-protocol/sdk/dist/esm/utils/TokenUtils";
 export { BRIDGED_USDC_SYMBOLS } from "@across-protocol/sdk/dist/esm/constants";
 export {
+  toBytes32,
   compareAddressesSimple,
   toAddress,
 } from "@across-protocol/sdk/dist/esm/utils/AddressUtils";

--- a/src/views/Transactions/hooks/useSpeedUp.tsx
+++ b/src/views/Transactions/hooks/useSpeedUp.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { BigNumber } from "ethers";
+import { BigNumber, ethers } from "ethers";
 import { useMutation } from "@tanstack/react-query";
 
 import { useConnection, useBridgeFees, useIsWrongNetwork } from "hooks";
@@ -86,9 +86,14 @@ export function useSpeedUp(transfer: Deposit, token: Token) {
       );
 
       const depositor = await signer.getAddress();
+      // Scale the depositor address to 32 bytes
+      const paddedDepositor = ethers.utils.hexZeroPad(
+        ethers.utils.hexlify(depositor),
+        32
+      );
       const spokePool = config.getSpokePool(transfer.sourceChainId, signer);
       const txResponse = await spokePool.speedUpDeposit(
-        depositor,
+        paddedDepositor,
         BigNumber.from(transfer.depositId),
         updatedOutputAmount,
         newRecipient,

--- a/src/views/Transactions/hooks/useSpeedUp.tsx
+++ b/src/views/Transactions/hooks/useSpeedUp.tsx
@@ -87,7 +87,7 @@ export function useSpeedUp(transfer: Deposit, token: Token) {
 
       const depositor = await signer.getAddress();
       const spokePool = config.getSpokePool(transfer.sourceChainId, signer);
-      const txResponse = await spokePool.speedUpV3Deposit(
+      const txResponse = await spokePool.speedUpDeposit(
         depositor,
         BigNumber.from(transfer.depositId),
         updatedOutputAmount,

--- a/src/views/Transactions/hooks/useSpeedUp.tsx
+++ b/src/views/Transactions/hooks/useSpeedUp.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { BigNumber, ethers } from "ethers";
+import { BigNumber } from "ethers";
 import { useMutation } from "@tanstack/react-query";
 
 import { useConnection, useBridgeFees, useIsWrongNetwork } from "hooks";
@@ -10,6 +10,7 @@ import {
   waitOnTransaction,
   fixedPointAdjustment,
   getUpdateV3DepositTypedData,
+  toBytes32,
 } from "utils";
 
 import type { Deposit } from "hooks/useDeposits";
@@ -86,17 +87,12 @@ export function useSpeedUp(transfer: Deposit, token: Token) {
       );
 
       const depositor = await signer.getAddress();
-      // Scale the depositor address to 32 bytes
-      const paddedDepositor = ethers.utils.hexZeroPad(
-        ethers.utils.hexlify(depositor),
-        32
-      );
       const spokePool = config.getSpokePool(transfer.sourceChainId, signer);
       const txResponse = await spokePool.speedUpDeposit(
-        paddedDepositor,
+        toBytes32(depositor),
         BigNumber.from(transfer.depositId),
         updatedOutputAmount,
-        newRecipient,
+        toBytes32(newRecipient),
         newMessage,
         depositorSignature
       );


### PR DESCRIPTION
We are moving to version-generic event names. We should move forward with using the generic speed-up deposit fn.

Note: this is an opinionated change