### PR TITLE
use token default on initial route

### DIFF
--- a/src/views/Bridge/utils.ts
+++ b/src/views/Bridge/utils.ts
@@ -236,7 +236,9 @@ export function getInitialRoute(filter: RouteFilter = {}) {
     ...enabledRoutes[0],
     type: "bridge",
   };
-  return routeFromUrl ?? routeFromFilter ?? defaultRoute;
+  return getTokenDefaultsForRoute(
+    routeFromUrl ?? routeFromFilter ?? defaultRoute
+  );
 }
 
 export function findEnabledRoute(


### PR DESCRIPTION
We have the ability to set default IN/OUT tokens for a given chain route.
Currently only works when user actively changes route parameters.
This sets the token defaults on INITIAL route also.