### PR TITLE
feat(api): field `outputAmount` + param `allowUnmatchedDecimals`

### DIFF
--- a/api/suggested-fees.ts
+++ b/api/suggested-fees.ts
@@ -28,6 +28,7 @@ import {
   OPT_IN_CHAINS,
   parseL1TokenConfigSafe,
   getL1TokenConfigCache,
+  ConvertDecimals,
 } from "./_utils";
 import { selectExclusiveRelayer } from "./_exclusivity";
 import {
@@ -279,6 +280,11 @@ const handler = async (
       relayerFeeDetails.relayFeePercent
     ).add(lpFeePct);
 
+    const outputAmount = ConvertDecimals(
+      inputToken.decimals,
+      outputToken.decimals
+    )(amount.sub(totalRelayFee));
+
     const { exclusiveRelayer, exclusivityPeriod: exclusivityDeadline } =
       await selectExclusiveRelayer(
         computedOriginChainId,
@@ -364,6 +370,7 @@ const handler = async (
         recommendedDepositInstant: limits.recommendedDepositInstant,
       },
       fillDeadline: fillDeadline.toString(),
+      outputAmount: outputAmount.toString(),
     };
 
     logger.info({


### PR DESCRIPTION
There might be edge cases where the decimals for the same token do not match on different chains (USDC/USDT on BNB). To handle these cases we add a correctly scaled `outputAmount` response field. We also let consumers opt-in for these routes via the query param `allowUnmatchedDecimals`.