### PR TITLE
fix: set arbitrum as the default destination chain

### DIFF
--- a/src/views/Bridge/utils.ts
+++ b/src/views/Bridge/utils.ts
@@ -223,14 +223,22 @@ export function getTokenDefaultsForRoute(route: SelectedRoute): SelectedRoute {
   return route;
 }
 
+const defaultFilter = {
+  fromChain: hubPoolChainId,
+  toChain: CHAIN_IDs.ARBITRUM,
+};
+
 export function getInitialRoute(filter: RouteFilter = {}) {
-  const routeFromUrl = getRouteFromUrl(filter);
+  const routeFromUrl = getRouteFromUrl({
+    fromChain: filter.fromChain || defaultFilter.fromChain,
+    toChain: filter.toChain || defaultFilter.toChain,
+  });
   const routeFromFilter = findEnabledRoute({
     inputTokenSymbol:
       filter.inputTokenSymbol ??
       (isNonEthChain(filter?.fromChain) ? "WETH" : "ETH"),
-    fromChain: filter.fromChain || hubPoolChainId,
-    toChain: filter.toChain,
+    fromChain: filter.fromChain || defaultFilter.fromChain,
+    toChain: filter.toChain || defaultFilter.toChain,
   });
   const defaultRoute = findEnabledRoute(defaultRouteFilter) ?? {
     ...enabledRoutes[0],


### PR DESCRIPTION
If a user is connected to mainnet, the app finds the next best enabled route where mainnet is origin chain. 
Currently this is TO Lens. 
This PR sets Arbitrum as the default destination chain


closes ACX-4054