### PR TITLE
feat: support destination chain relayer fee calculator config overrides

### DIFF
--- a/api/_constants.ts
+++ b/api/_constants.ts
@@ -161,6 +161,18 @@ export const coinGeckoAssetPlatformLookup: Record<string, number> = {
 
 export const graphAPIKey = GRAPH_API_KEY;
 
+// {
+//   "TOKEN_SYMBOL": {
+//     "ORIGIN_CHAIN_ID": {
+//       "DESTINATION_CHAIN_ID": {
+//         "lowerBound": "1000000000000000",
+//         "upperBound": "5000000000000000",
+//         "cutoff": "10000000000000000000000",
+//         "decimals": 18
+//       }
+//     }
+//   }
+// }
 const relayerFeeCapitalCostRouteOverrides: Record<
   string,
   Record<string, Record<string, relayFeeCalculator.CapitalCostConfig>>
@@ -168,6 +180,16 @@ const relayerFeeCapitalCostRouteOverrides: Record<
   ? JSON.parse(RELAYER_FEE_CAPITAL_COST_ROUTE_OVERRIDES)
   : {};
 
+// {
+//   "TOKEN_SYMBOL": {
+//     "DESTINATION_CHAIN_ID": {
+//       "lowerBound": "1000000000000000",
+//       "upperBound": "5000000000000000",
+//       "cutoff": "10000000000000000000000",
+//       "decimals": 18
+//     }
+//   }
+// }
 const relayerFeeCapitalCostDestinationChainOverrides: Record<
   string,
   Record<string, relayFeeCalculator.CapitalCostConfig>

--- a/api/_constants.ts
+++ b/api/_constants.ts
@@ -7,7 +7,11 @@ import {
 import * as constants from "@across-protocol/constants";
 import { getEnvs } from "./_env";
 
-const { GRAPH_API_KEY, RELAYER_FEE_CAPITAL_COST_OVERRIDES } = getEnvs();
+const {
+  GRAPH_API_KEY,
+  RELAYER_FEE_CAPITAL_COST_ROUTE_OVERRIDES,
+  RELAYER_FEE_CAPITAL_COST_DESTINATION_CHAIN_OVERRIDES,
+} = getEnvs();
 
 export const CHAIN_IDs = constants.CHAIN_IDs;
 export const TOKEN_SYMBOLS_MAP = constants.TOKEN_SYMBOLS_MAP;
@@ -157,11 +161,18 @@ export const coinGeckoAssetPlatformLookup: Record<string, number> = {
 
 export const graphAPIKey = GRAPH_API_KEY;
 
-const relayerFeeCapitalCostOverrides: Record<
+const relayerFeeCapitalCostRouteOverrides: Record<
   string,
   Record<string, Record<string, relayFeeCalculator.CapitalCostConfig>>
-> = RELAYER_FEE_CAPITAL_COST_OVERRIDES
-  ? JSON.parse(RELAYER_FEE_CAPITAL_COST_OVERRIDES)
+> = RELAYER_FEE_CAPITAL_COST_ROUTE_OVERRIDES
+  ? JSON.parse(RELAYER_FEE_CAPITAL_COST_ROUTE_OVERRIDES)
+  : {};
+
+const relayerFeeCapitalCostDestinationChainOverrides: Record<
+  string,
+  Record<string, relayFeeCalculator.CapitalCostConfig>
+> = RELAYER_FEE_CAPITAL_COST_DESTINATION_CHAIN_OVERRIDES
+  ? JSON.parse(RELAYER_FEE_CAPITAL_COST_DESTINATION_CHAIN_OVERRIDES)
   : {};
 
 export const relayerFeeCapitalCostConfig: {
@@ -173,7 +184,9 @@ export const relayerFeeCapitalCostConfig: {
         token,
         {
           default: defaultRelayerFeeCapitalCostConfig[token],
-          routeOverrides: relayerFeeCapitalCostOverrides[token] || {},
+          routeOverrides: relayerFeeCapitalCostRouteOverrides[token] || {},
+          destinationChainOverrides:
+            relayerFeeCapitalCostDestinationChainOverrides[token] || {},
         },
       ];
     }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@across-protocol/constants": "^3.1.51",
     "@across-protocol/contracts": "^4.0.5",
-    "@across-protocol/sdk": "^4.1.44",
+    "@across-protocol/sdk": "^4.1.47",
     "@amplitude/analytics-browser": "^2.3.5",
     "@balancer-labs/sdk": "1.1.6-beta.16",
     "@emotion/react": "^11.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,10 +60,10 @@
     yargs "^17.7.2"
     zksync-web3 "^0.14.3"
 
-"@across-protocol/sdk@^4.1.44":
-  version "4.1.44"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.1.44.tgz#5ab120c8d93e87b9b8ca9f71291fb3f1369abb42"
-  integrity sha512-hH94JUYDCQV6rEcSmqPgqf0iOQSa547j8ykZZePUOC574aYuJ6KMGWvDevYdakA1q/DKQBqoilFUADSejI7eHQ==
+"@across-protocol/sdk@^4.1.47":
+  version "4.1.47"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.1.47.tgz#d67f120800c4959cba491337b2184acaa08245ed"
+  integrity sha512-3vuKp7M6EjE00ukp82/ludXVJ9LwKFW7MyvAHtJRHPGlb6JoLkT1scMEjoJ9NAarSBUyFM7r1mrThg9gWffidA==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/constants" "^3.1.51"
@@ -21110,7 +21110,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -21144,15 +21144,6 @@ string-width@^3.0.0, string-width@^3.1.0:
     emoji-regex "^7.0.1"
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
-
-string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.0, string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -21241,7 +21232,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -21268,13 +21259,6 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.0.1"
@@ -23953,7 +23937,7 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -23983,15 +23967,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Part of https://github.com/across-protocol/sdk/pull/997
Adds support for env var `RELAYER_FEE_CAPITAL_COST_DESTINATION_CHAIN_OVERRIDES`
renames ~~`RELAYER_FEE_CAPITAL_COST_OVERRIDES`~~ => `RELAYER_FEE_CAPITAL_COST_ROUTE_OVERRIDES`