### PR TITLE
fix: fix indexer deposit fields

### DIFF
--- a/src/hooks/useDeposits.ts
+++ b/src/hooks/useDeposits.ts
@@ -122,6 +122,7 @@ export type IndexerDeposit = {
   fillDeadline: string;
   quoteTimestamp: string;
   depositTransactionHash: string;
+  depositTxHash: string;
   depositBlockNumber: number;
   depositBlockTimestamp: string;
   status: "unfilled" | "filled";
@@ -140,6 +141,7 @@ export type IndexerDeposit = {
   relayer: string;
   fillBlockTimestamp: string;
   fillTransactionHash: string;
+  fillTx: string;
   speedups: any[];
 };
 

--- a/src/views/Transactions/components/PersonalTransactions.tsx
+++ b/src/views/Transactions/components/PersonalTransactions.tsx
@@ -140,9 +140,10 @@ function convertIndexerDepositToDeposit(
     recipientAddr: indexerDeposit.recipient,
     message: indexerDeposit.message,
     amount: indexerDeposit.inputAmount,
-    depositTxHash: indexerDeposit.depositTransactionHash,
+    depositTxHash:
+      indexerDeposit.depositTransactionHash || indexerDeposit.depositTxHash,
     fillTxs: indexerDeposit.fillTransactionHash
-      ? [indexerDeposit.fillTransactionHash]
+      ? [indexerDeposit.fillTransactionHash || indexerDeposit.fillTx]
       : [],
     speedUps: indexerDeposit.speedups,
     depositRelayerFeePct: "0",


### PR DESCRIPTION
`depositTransactionHash` and  `fillTransactionHash` are being renamed in the `/deposits` indexer endpoint