### PR TITLE
fix(hotfix): fix status cell for slow fill requested deposits

### DIFF
--- a/src/components/DepositsTable/cells/StatusCell.tsx
+++ b/src/components/DepositsTable/cells/StatusCell.tsx
@@ -19,15 +19,19 @@ type Props = {
 };
 
 export function StatusCell({ deposit, width }: Props) {
-  if (deposit.status === "pending" || deposit.status === "expired") {
-    return <PendingStatusCell deposit={deposit} width={width} />;
+  if (deposit.status === "filled") {
+    return <FilledStatusCell deposit={deposit} width={width} />;
   }
 
   if (deposit.status === "refunded") {
     return <RefundedStatusCell deposit={deposit} width={width} />;
   }
 
-  return <FilledStatusCell deposit={deposit} width={width} />;
+  if (deposit.status === "slowFillRequested") {
+    return <SlowFillRequestedStatusCell deposit={deposit} width={width} />;
+  }
+
+  return <PendingStatusCell deposit={deposit} width={width} />;
 }
 
 function FilledStatusCell({ deposit, width }: Props) {
@@ -113,6 +117,14 @@ function RefundedStatusCell({ width }: Props) {
   return (
     <StyledPendingStatusCell width={width}>
       <Text color={"light-200"}>Refunded</Text>
+    </StyledPendingStatusCell>
+  );
+}
+
+function SlowFillRequestedStatusCell({ width }: Props) {
+  return (
+    <StyledPendingStatusCell width={width}>
+      <Text color={"light-200"}>Slow Fill Requested</Text>
     </StyledPendingStatusCell>
   );
 }

--- a/src/hooks/useDeposits.ts
+++ b/src/hooks/useDeposits.ts
@@ -13,7 +13,12 @@ import {
 } from "../utils/local-deposits";
 import { DepositStatusFilter } from "views/Transactions/types";
 
-export type DepositStatus = "pending" | "filled" | "refunded" | "expired";
+export type DepositStatus =
+  | "pending"
+  | "filled"
+  | "refunded"
+  | "expired"
+  | "slowFillRequested";
 
 export type SpeedUpDepositTx = {
   hash: string;


### PR DESCRIPTION
**Issue**

We are not handling correctly the `StatusCell` for deposits with slow fill requests and the dApp fallbacks to show them as `filled`