### PR TITLE
fix: add fill tx in transactions table

### DIFF
--- a/src/hooks/useDeposits.ts
+++ b/src/hooks/useDeposits.ts
@@ -141,7 +141,6 @@ export type IndexerDeposit = {
   swapTokenAmount: string;
   relayer: string;
   fillBlockTimestamp: string;
-  fillTransactionHash: string;
   fillTx: string;
   speedups: any[];
 };

--- a/src/views/Transactions/components/PersonalTransactions.tsx
+++ b/src/views/Transactions/components/PersonalTransactions.tsx
@@ -142,9 +142,7 @@ function convertIndexerDepositToDeposit(
     amount: indexerDeposit.inputAmount,
     depositTxHash:
       indexerDeposit.depositTransactionHash || indexerDeposit.depositTxHash,
-    fillTxs: indexerDeposit.fillTransactionHash
-      ? [indexerDeposit.fillTransactionHash || indexerDeposit.fillTx]
-      : [],
+    fillTxs: indexerDeposit.fillTx ? [indexerDeposit.fillTx] : [],
     speedUps: indexerDeposit.speedups,
     depositRelayerFeePct: "0",
     initialRelayerFeePct: "0",


### PR DESCRIPTION
<img width="462" alt="Screenshot 2025-05-12 at 20 28 31" src="https://github.com/user-attachments/assets/8c470085-14ce-4762-8aa7-7425bb29e209" />

Fill transaction hash missing in transactions table