### PR TITLE
fix: limits failures and decimal inconsistency

### DIFF
--- a/api/limits.ts
+++ b/api/limits.ts
@@ -107,7 +107,8 @@ const handler = async (
       ? ethers.utils.getAddress(relayer)
       : getDefaultRelayerAddress(destinationChainId, l1Token.symbol);
     const amount = BigNumber.from(
-      _amount ?? ethers.BigNumber.from("10").pow(inputToken.decimals)
+      // 0.0001 tokens so we don't expect to have less than this on any chain, even for the most valuable tokens (BTC).
+      _amount ?? ethers.BigNumber.from("10").pow(inputToken.decimals - 4)
     );
 
     const isMessageDefined = sdk.utils.isDefined(message);

--- a/api/suggested-fees.ts
+++ b/api/suggested-fees.ts
@@ -267,7 +267,13 @@ const handler = async (
       currentUt,
       nextUt
     );
-    const lpFeeTotal = amount.mul(lpFeePct).div(ethers.constants.WeiPerEther);
+    const convertInputToOutputDecimals = ConvertDecimals(
+      inputToken.decimals,
+      outputToken.decimals
+    );
+    const lpFeeTotal = convertInputToOutputDecimals(
+      amount.mul(lpFeePct).div(ethers.constants.WeiPerEther)
+    );
 
     const isAmountTooLow = BigNumber.from(amountInput).lt(minDeposit);
 
@@ -286,10 +292,9 @@ const handler = async (
       relayerFeeDetails.relayFeePercent
     ).add(lpFeePct);
 
-    const outputAmount = ConvertDecimals(
-      inputToken.decimals,
-      outputToken.decimals
-    )(amount.sub(totalRelayFee));
+    const outputAmount = convertInputToOutputDecimals(
+      amount.sub(totalRelayFee)
+    );
 
     const { exclusiveRelayer, exclusivityPeriod: exclusivityDeadline } =
       await selectExclusiveRelayer(

--- a/api/suggested-fees.ts
+++ b/api/suggested-fees.ts
@@ -267,13 +267,7 @@ const handler = async (
       currentUt,
       nextUt
     );
-    const convertInputToOutputDecimals = ConvertDecimals(
-      inputToken.decimals,
-      outputToken.decimals
-    );
-    const lpFeeTotal = convertInputToOutputDecimals(
-      amount.mul(lpFeePct).div(ethers.constants.WeiPerEther)
-    );
+    const lpFeeTotal = amount.mul(lpFeePct).div(ethers.constants.WeiPerEther);
 
     const isAmountTooLow = BigNumber.from(amountInput).lt(minDeposit);
 
@@ -292,9 +286,10 @@ const handler = async (
       relayerFeeDetails.relayFeePercent
     ).add(lpFeePct);
 
-    const outputAmount = convertInputToOutputDecimals(
-      amount.sub(totalRelayFee)
-    );
+    const outputAmount = ConvertDecimals(
+      inputToken.decimals,
+      outputToken.decimals
+    )(amount.sub(totalRelayFee));
 
     const { exclusiveRelayer, exclusivityPeriod: exclusivityDeadline } =
       await selectExclusiveRelayer(

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@across-protocol/constants": "^3.1.66",
     "@across-protocol/contracts": "^4.0.9",
-    "@across-protocol/sdk": "4.1.65-alpha.0",
+    "@across-protocol/sdk": "4.1.65-alpha.1",
     "@amplitude/analytics-browser": "^2.3.5",
     "@balancer-labs/sdk": "1.1.6-beta.16",
     "@emotion/react": "^11.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -64,10 +64,10 @@
     yargs "^17.7.2"
     zksync-web3 "^0.14.3"
 
-"@across-protocol/sdk@4.1.65-alpha.0":
-  version "4.1.65-alpha.0"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.1.65-alpha.0.tgz#cab1be2aa80fde66c7e19b9053ee98660501a22f"
-  integrity sha512-i/x/CjoCcCzqa+/xIuaBWUhyxKRN68ILARkEATaZwYQao16GeCD5+wpbsq8Z8BgVd6K4ssTuhMd6Xv6ObuiLbA==
+"@across-protocol/sdk@4.1.65-alpha.1":
+  version "4.1.65-alpha.1"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.1.65-alpha.1.tgz#12bda8d3bafb38361550cd5109ea39a8e669c40c"
+  integrity sha512-4MhNQNeW7Rg1UwwGuY/ClqNwSF6PNyBLG7PXQ6wZMhK5tJMuxKCPhOJQdKabjmFmeICzl4+eMdgBSr4vWD1BLg==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/constants" "^3.1.66"


### PR DESCRIPTION
This [PR](https://github.com/across-protocol/frontend/pull/1610) was rolled back due to some remaining issues when `allowUnmatchedDecimals=true`.

During my investigation, I found that after this was merged, error rates on BTC transfers to linea would spike. This is because [this line](https://github.com/across-protocol/frontend/blob/cb9c47cf149d8ecba7dab0542f17b62c1943be91/api/limits.ts#L110) is being activated, causing the limits API to assume that at least one unit of the currency is held on the destination chain by the simulated relayer. This is a problem for BTC.

I also found another issue in how the response is being constructed when testing. In `/suggested-fees`, the `relayerCapitalFee.total` and `relayerGasFee.total` were being scaled to the output token's decimals, but the lpFee.total was being scaled to the input token's decimals. This inconsistency also caused the totalRelayFee.total to be a sum of units with different decimals, meaning for large differences in decimals, either the LP fee would be ignored in the final total or the other two components would be ignored.

Example query showing the issue:
```
curl 'http://localhost:3000/api/suggested-fees?originChainId=56&destinationChainId=8453&inputToken=0x55d398326f99059fF775485246999027B3197955&outputToken=0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2&amount=147184171098622492637&message=0x0000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000004000000000000000000000000060ac95ec1153aa8199751917ede25d0ca49a36e20000000000000000000000000000000000000000000000000000000000000000&recipient=0x60Ac95eC1153aA8199751917edE25D0Ca49a36e2&allowUnmatchedDecimals=true' | json_pp
```

Output:
```json
{
   "capitalFeePct" : "99997166135480",
   "capitalFeeTotal" : "14717",
   "destinationSpokePoolAddress" : "0x09aea4b2242abC8bb4BB78D537A67a245A7bEC64",
   "estimatedFillTimeSec" : 3,
   "exclusiveRelayer" : "0x0000000000000000000000000000000000000000",
   "exclusivityDeadline" : 0,
   "fillDeadline" : "1748762341",
   "inputToken" : {
      "address" : "0x55d398326f99059fF775485246999027B3197955",
      "chainId" : 56,
      "decimals" : 18,
      "symbol" : "USDT-BNB"
   },
   "isAmountTooLow" : false,
   "limits" : {
      "maxDeposit" : "20000000000000000000000",
      "maxDepositInstant" : "20000000000000000000000",
      "maxDepositShortDelay" : "20000000000000000000000",
      "minDeposit" : "500000000000000000",
      "recommendedDepositInstant" : "20000000000000000000000"
   },
   "lpFee" : {
      "pct" : "286360464366013",
      "total" : "42147727583128246"
   },
   "lpFeePct" : "0",
   "outputAmount" : "147142023",
   "outputToken" : {
      "address" : "0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2",
      "chainId" : 8453,
      "decimals" : 6,
      "symbol" : "USDT"
   },
   "quoteBlock" : "22607340",
   "relayFeePct" : "388382304744486",
   "relayFeeTotal" : "42147727583143260",
   "relayGasFeePct" : "2024674242993",
   "relayGasFeeTotal" : "297",
   "relayerCapitalFee" : {
      "pct" : "99997166135480",
      "total" : "14717"
   },
   "relayerGasFee" : {
      "pct" : "2024674242993",
      "total" : "297"
   },
   "spokePoolAddress" : "0x4e8E101924eDE233C13e2D8622DC8aED2872d505",
   "timestamp" : "1748750507",
   "totalRelayFee" : {
      "pct" : "388382304744486",
      "total" : "42147727583143260"
   }
}
```

This PR makes two changes to address the issues identified above:
1. Simulate with 1e-4 units of each token on a supported chain, which would equate to 0.0001 BTC (the most expensive asset supported), which is about $10 rather than $100k. I don't think there is any downside to setting this value low, and no tokens have fewer than 4 decimals of precision AFAIK.
2. Convert the decimals of the LP fee amount to those of the output token before adding to the other fees or returning to the user.

Open question: should we quote fee values in the output decimals? Seems much more natural for the caller for the fees to be quoted in the same units as `amount` that they provided. `allowUnmatchedDecimals=true` is still undocumented, so we probably have a chance to change before callers begin relying on the behavior.

EDIT: we've decided to change the fee decimals to the input decimals and update the SDK upstream. Alpha release branch is here: https://github.com/across-protocol/sdk/pull/1069.