### PR TITLE
fix: default separate cache namespace for preview/prod

### DIFF
--- a/api/_cache.ts
+++ b/api/_cache.ts
@@ -10,6 +10,7 @@ const {
   UPSTASH_REDIS_REST_TOKEN,
   UPSTASH_REDIS_READ_ONLY_TOKEN,
   CACHE_PREFIX,
+  VERCEL_ENV,
 } = getEnvs();
 
 const isRedisCacheEnabled =
@@ -83,10 +84,11 @@ export function buildCacheKey(
 }
 
 export function buildInternalCacheKey(...args: (string | number)[]): string {
-  return buildCacheKey(
-    `${CACHE_PREFIX ? CACHE_PREFIX + "-" : ""}QUOTES_API`,
-    ...args
-  );
+  const defaultCachePrefix =
+    VERCEL_ENV === "production" ? "" : `${VERCEL_ENV}_`;
+  const cachePrefix = CACHE_PREFIX ? CACHE_PREFIX + "_" : defaultCachePrefix;
+
+  return buildCacheKey(`${cachePrefix}QUOTES_API`, ...args);
 }
 
 export async function getCachedValue<T>(

--- a/api/_cache.ts
+++ b/api/_cache.ts
@@ -11,6 +11,7 @@ const {
   UPSTASH_REDIS_READ_ONLY_TOKEN,
   CACHE_PREFIX,
   VERCEL_ENV,
+  VERCEL_URL,
 } = getEnvs();
 
 const isRedisCacheEnabled =
@@ -85,7 +86,7 @@ export function buildCacheKey(
 
 export function buildInternalCacheKey(...args: (string | number)[]): string {
   const defaultCachePrefix =
-    VERCEL_ENV === "production" ? "" : `${VERCEL_ENV}_`;
+    VERCEL_ENV === "production" ? "" : `${VERCEL_URL}_`;
   const cachePrefix = CACHE_PREFIX ? CACHE_PREFIX + "_" : defaultCachePrefix;
 
   return buildCacheKey(`${cachePrefix}QUOTES_API`, ...args);


### PR DESCRIPTION
This PR creates a separate cache namespace for all `preview` deployments by default, which can still be overridden by setting the environment variable `CACHE_PREFIX` for a specific branch or deployment.

Alternatively, the default for previews could be the deployment URL. Not 100% which makes more sense