### PR TITLE
fix: drop lite-chain style deposit limits for ultra-lite chains (BSC)

### DIFF
--- a/api/limits.ts
+++ b/api/limits.ts
@@ -364,10 +364,8 @@ const handler = async (
     }
 
     // Apply chain max values when defined
-    const includeDefaultMaxValues =
-      originChainIsLiteChain || originChainIsUltraLightChain;
-    const includeRelayerBalances =
-      originChainIsLiteChain || originChainIsUltraLightChain;
+    const includeDefaultMaxValues = originChainIsLiteChain;
+    const includeRelayerBalances = originChainIsLiteChain;
     let chainAvailableInputTokenAmountForDeposits: BigNumber | undefined;
     let chainInputTokenMaxDeposit: BigNumber | undefined;
     let chainHasMaxBoundary: boolean = false;


### PR DESCRIPTION
We were treating BSC like a lite chain, where we would stop deposits from that chain once the relayer or spoke balance got too high.

BSC, however, has fast rebalancing on all tokens via Binance, so the relayer origin balance should not be a consideration when determining deposit limits.

This fix _should_ work for now, but we probably need a broader refactor here. Lite chains vs non-lite chains are no longer the determining factor. Rather, it depends on if and how quickly rebalancing is between that chain and mainnet _for that token_. We will need a per-token config that basically rates rebalancing per chain and token as fast, slow, or none. For now, ultra lite chains (BSC) all happen to have fast rebalancing (binance) and all lite chains (LISK, etc) do not, so this should work.