### PR TITLE
ci: add job for API tests

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -33,3 +33,11 @@ jobs:
           REACT_APP_CHAIN_42161_PROVIDER_URL: ${{ secrets.CYPRESS_CHAIN_42161_PROVIDER_URL }}
           REACT_APP_MOCK_SERVERLESS: true
         run: yarn test
+
+  api-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+      - name: API tests
+        run: yarn test-api

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -15,9 +15,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
-      - run: yarn format
-      - run: yarn lint
-      - run: yarn format
+      - name: Format and lint
+        run: |
+          yarn format
+          yarn lint
 
   unit-tests:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "analyze": "yarn build && rollup-plugin-visualizer --open ./bundle-size-analysis.json",
     "test": "export REACT_APP_GIT_COMMIT_HASH=$(git rev-parse HEAD) && jest --env jsdom src",
     "serve": "vite preview --port 3000",
-    "test-api": "jest test/api",
+    "test-api": "yarn remote-config && jest test/api",
     "pretest:e2e": "npm pkg set 'type'='module'",
     "test:e2e:headful": "yarn pretest:e2e && playwright test",
     "test:e2e:headless": "yarn pretest:e2e && HEADLESS=true playwright test",


### PR DESCRIPTION
This PR makes 3 small changes to our `lint-test` workflow.

1. Adds a new job: `api-tests` which runs `yarn test-api`. I added this because the current configuration only runs frontend unit tests and skips the API tests.
2. Combines `yarn format` and `yarn lint` into a single run step.
3. Removed unnecessary second `yarn format`. Since linting will not change any file contents, I don't believe we need a second format.

To verify that adding `yarn test-api` to our workflow won't break anything, I ran it locally and the current tests passed. The next step is to add more coverage.