### PR TITLE
fix: handle 7702 correctly

### DIFF
--- a/src/hooks/useConnection.ts
+++ b/src/hooks/useConnection.ts
@@ -18,7 +18,11 @@ export function useConnection() {
     didAttemptAutoSelect,
   } = useOnboard();
 
-  const isContractAddress = useIsContractAddress(account?.address, chainId);
+  const isContractAddress = useIsContractAddress(
+    account?.address,
+    chainId,
+    true
+  );
 
   return {
     account: account ? ethers.utils.getAddress(account.address) : undefined,

--- a/src/hooks/useIsContractAddress.ts
+++ b/src/hooks/useIsContractAddress.ts
@@ -1,13 +1,28 @@
 import { useQuery } from "@tanstack/react-query";
+import { isAddress } from "viem";
 import { getCode, noContractCode } from "utils";
 
-export function useIsContractAddress(address?: string, chainId = 1) {
+export function useIsContractAddress(
+  address?: string,
+  chainId = 1,
+  ignore7702 = false
+) {
   const result = useQuery({
-    queryKey: ["isContractAddress", address, chainId],
+    queryKey: ["isContractAddress", address, chainId, ignore7702],
     queryFn: async () => {
       if (!address || !chainId) return false;
       const code = await getCode(address, chainId);
-      return code !== noContractCode;
+
+      if (code === noContractCode) {
+        return false;
+      }
+
+      // Ignore EIP-7702 delegations if ignore7702 was set.
+      if (ignore7702) {
+        return !is7702Delegate(code);
+      }
+
+      return true;
     },
     enabled: Boolean(address && chainId),
     // we don't expect this change for a given address, cache heavily
@@ -19,4 +34,13 @@ export function useIsContractAddress(address?: string, chainId = 1) {
   });
 
   return result.data ?? false;
+}
+
+export function is7702Delegate(code: string): boolean {
+  // Sample 7702 delegation bytecode: 0xef010063c0c19a282a1b52b07dd5a65b58948a07dae32b
+  return (
+    code.length === 48 &&
+    code.startsWith("0xef0100") &&
+    isAddress(`0x${code.slice(8)}`)
+  );
 }

--- a/src/views/Bridge/hooks/useToAccount.ts
+++ b/src/views/Bridge/hooks/useToAccount.ts
@@ -2,6 +2,10 @@ import { useState, useEffect } from "react";
 
 import { useConnection } from "hooks";
 import { getCode } from "utils";
+import {
+  useIsContractAddress,
+  is7702Delegate,
+} from "hooks/useIsContractAddress";
 
 export type ToAccount = {
   address: string;
@@ -12,10 +16,11 @@ export function useToAccount(toChainId?: number) {
   const [customToAddress, setCustomToAddress] = useState<string | undefined>();
   const [toAccount, setToAccount] = useState<ToAccount | undefined>();
 
-  const {
-    account: connectedAccount,
-    isContractAddress: isConnectedAccountContract,
-  } = useConnection();
+  const { account: connectedAccount } = useConnection();
+  const isConnectedAccountContract = useIsContractAddress(
+    connectedAccount,
+    toChainId
+  );
 
   useEffect(() => {
     if (!toChainId) {
@@ -27,16 +32,16 @@ export function useToAccount(toChainId?: number) {
         .then((code) =>
           setToAccount({
             address: customToAddress,
-            isContract: code !== "0x",
+            isContract: code !== "0x" || !is7702Delegate(code),
           })
         )
         .catch((error) => {
-          console.error(error);
+          console.error("Failed to get code", error);
+          setToAccount({
+            address: customToAddress,
+            isContract: false,
+          });
         });
-      setToAccount({
-        address: customToAddress,
-        isContract: false,
-      });
     } else if (connectedAccount) {
       setToAccount({
         address: connectedAccount,

--- a/src/views/DepositStatus/components/DepositStatusLowerCard.tsx
+++ b/src/views/DepositStatus/components/DepositStatusLowerCard.tsx
@@ -60,7 +60,7 @@ export function DepositStatusLowerCard({
   );
 
   const history = useHistory();
-  const isReceiverContract = useIsContractAddress(recipient);
+  const isReceiverContract = useIsContractAddress(recipient, toChainId);
   const programName = chainIdToRewardsProgramName[toChainId];
 
   const FeesTable =


### PR DESCRIPTION
- Suppress the red warning banner when the depositor is a 7702 delegation on the origin chain.
- When the recipient on the destination chain has a 7702 delegation in place, ensure that the outputToken is shown as WETH and not ETH.

Fixes ACX-4114