### PR TITLE
tests: rework handler tests

### DIFF
--- a/test/api/handlers/account-balance.test.ts
+++ b/test/api/handlers/account-balance.test.ts
@@ -1,0 +1,95 @@
+import { VercelResponse } from "@vercel/node";
+import { latestBalanceCache } from "../../../api/_utils";
+import handler from "../../../api/account-balance";
+import { TypedVercelRequest } from "../../../api/_types";
+import { createMockRequest, setupTestMocks } from "../helpers/test-helper";
+import { InputError } from "../../../api/_errors";
+
+jest.mock("../../../api/_utils", () => ({
+  ...jest.requireActual("../../../api/_utils"),
+  latestBalanceCache: jest.fn(),
+  getLogger: jest.fn().mockReturnValue({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+describe("Account balance handler tests", () => {
+  let mockResponse: jest.Mocked<VercelResponse>;
+  let mockGet: jest.Mock;
+
+  beforeEach(() => {
+    const mocks = setupTestMocks<VercelResponse>(
+      latestBalanceCache as jest.Mock
+    );
+    mockResponse = mocks.mockResponse;
+    mockGet = mocks.mockGet;
+  });
+
+  it("should return balance for valid request", async () => {
+    const mockBalance = "1000000000000000000";
+    mockGet.mockResolvedValueOnce(mockBalance);
+
+    await handler(
+      createMockRequest<
+        TypedVercelRequest<{ token: string; account: string; chainId: string }>
+      >({
+        token: "0x1234567890123456789012345678901234567890",
+        account: "0x0987654321098765432109876543210987654321",
+        chainId: "1",
+      }),
+      mockResponse
+    );
+
+    expect(mockResponse.json).toHaveBeenCalledWith({
+      balance: mockBalance,
+      account: "0x0987654321098765432109876543210987654321",
+      token: "0x1234567890123456789012345678901234567890",
+    });
+  });
+
+  it("should handle invalid token address", async () => {
+    await handler(
+      createMockRequest({
+        token: "invalid",
+        account: "0x0987654321098765432109876543210987654321",
+        chainId: "1",
+      }),
+      mockResponse
+    );
+
+    expect(mockResponse.status).toHaveBeenCalledWith(400);
+    expect(mockResponse.json.mock.calls[0][0]).toBeInstanceOf(InputError);
+  });
+
+  it("should handle balance cache errors", async () => {
+    mockGet.mockRejectedValueOnce(new Error("Cache error"));
+
+    await handler(
+      createMockRequest({
+        token: "0x1234567890123456789012345678901234567890",
+        account: "0x0987654321098765432109876543210987654321",
+        chainId: "1",
+      }),
+      mockResponse
+    );
+
+    expect(mockResponse.status).toHaveBeenCalledWith(500);
+    expect(mockResponse.json.mock.calls[0][0]).toBeInstanceOf(Error);
+    expect(mockResponse.json.mock.calls[0][0].message).toContain("Cache error");
+  });
+
+  it("should handle missing required parameters", async () => {
+    await handler(
+      createMockRequest({
+        token: "0x1234567890123456789012345678901234567890",
+      }),
+      mockResponse
+    );
+
+    expect(mockResponse.status).toHaveBeenCalledWith(400);
+    expect(mockResponse.json.mock.calls[0][0]).toBeInstanceOf(InputError);
+  });
+});

--- a/test/api/handlers/error-handler.test.ts
+++ b/test/api/handlers/error-handler.test.ts
@@ -1,0 +1,167 @@
+import { StructError } from "superstruct";
+import { AxiosError, AxiosResponse } from "axios";
+import { ethers } from "ethers";
+import { VercelResponse } from "@vercel/node";
+import { relayFeeCalculator } from "@across-protocol/sdk";
+import {
+  handleErrorCondition,
+  AcrossApiError,
+  InputError,
+  SimulationError,
+  AcrossErrorCode,
+  HttpErrorToStatusCode,
+} from "../../../api/_errors";
+
+describe("Error handler tests", () => {
+  let mockResponse: jest.Mocked<VercelResponse>;
+  let mockLogger: jest.Mocked<relayFeeCalculator.Logger>;
+
+  beforeEach(() => {
+    mockResponse = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    } as unknown as jest.Mocked<VercelResponse>;
+
+    mockLogger = {
+      error: jest.fn(),
+      warn: jest.fn(),
+    } as unknown as jest.Mocked<relayFeeCalculator.Logger>;
+  });
+
+  it("should handle Superstruct validation errors", () => {
+    const structError = new StructError(
+      {
+        value: "invalid",
+        type: "string",
+        path: ["user", "name"],
+        branch: [{ user: { name: "invalid" } }],
+        key: "name",
+        refinement: undefined,
+        message: "Expected string",
+      },
+      () => {
+        throw new Error("Expected string");
+      }
+    );
+
+    handleErrorCondition(
+      "test-endpoint",
+      mockResponse,
+      mockLogger,
+      structError
+    );
+
+    expect(mockResponse.status).toHaveBeenCalledWith(
+      HttpErrorToStatusCode.BAD_REQUEST
+    );
+    expect(mockResponse.json).toHaveBeenCalledWith(expect.any(InputError));
+    expect(mockLogger.warn).toHaveBeenCalled();
+  });
+
+  it("should handle Axios errors with upstream AcrossApiError", () => {
+    const axiosError = new AxiosError(
+      "Error message",
+      "ERROR_CODE",
+      undefined,
+      undefined,
+      {
+        data: {
+          type: "AcrossApiError",
+          message: "Upstream error message",
+          status: HttpErrorToStatusCode.BAD_REQUEST,
+          code: AcrossErrorCode.INVALID_PARAM,
+        },
+        status: HttpErrorToStatusCode.BAD_REQUEST,
+      } as AxiosResponse
+    );
+
+    handleErrorCondition("test-endpoint", mockResponse, mockLogger, axiosError);
+
+    expect(mockResponse.status).toHaveBeenCalledWith(
+      HttpErrorToStatusCode.BAD_REQUEST
+    );
+    expect(mockResponse.json).toHaveBeenCalledWith(expect.any(AcrossApiError));
+    expect(mockLogger.warn).toHaveBeenCalled();
+  });
+
+  it("should handle Axios errors", () => {
+    const axiosError = new AxiosError(
+      "Error message",
+      "ERROR_CODE",
+      undefined,
+      undefined,
+      { status: HttpErrorToStatusCode.INTERNAL_SERVER_ERROR } as AxiosResponse
+    );
+
+    handleErrorCondition("test-endpoint", mockResponse, mockLogger, axiosError);
+
+    expect(mockResponse.status).toHaveBeenCalledWith(
+      HttpErrorToStatusCode.BAD_GATEWAY
+    );
+    expect(mockResponse.json).toHaveBeenCalledWith(expect.any(AcrossApiError));
+    expect(mockLogger.error).toHaveBeenCalled();
+  });
+
+  it("should handle Ethers simulation errors", () => {
+    const ethersError = {
+      reason: '{"message":"execution reverted"}',
+      code: ethers.utils.Logger.errors.UNPREDICTABLE_GAS_LIMIT,
+      method: "estimateGas",
+      transaction: {
+        from: "0x123",
+        to: "0x456",
+        data: "test data",
+      },
+    };
+
+    handleErrorCondition(
+      "test-endpoint",
+      mockResponse,
+      mockLogger,
+      ethersError
+    );
+
+    expect(mockResponse.status).toHaveBeenCalledWith(
+      HttpErrorToStatusCode.BAD_REQUEST
+    );
+    expect(mockResponse.json).toHaveBeenCalledWith(expect.any(SimulationError));
+    expect(mockLogger.warn).toHaveBeenCalled();
+  });
+
+  it("should handle AcrossApiError instances", () => {
+    const acrossError = new InputError({
+      message: "Test error",
+      code: AcrossErrorCode.INVALID_PARAM,
+    });
+
+    handleErrorCondition(
+      "test-endpoint",
+      mockResponse,
+      mockLogger,
+      acrossError
+    );
+
+    expect(mockResponse.status).toHaveBeenCalledWith(
+      HttpErrorToStatusCode.BAD_REQUEST
+    );
+    expect(mockResponse.json).toHaveBeenCalledWith(expect.any(InputError));
+    expect(mockLogger.warn).toHaveBeenCalled();
+  });
+
+  it("should handle generic errors", () => {
+    const genericError = new Error("Generic error message");
+
+    handleErrorCondition(
+      "test-endpoint",
+      mockResponse,
+      mockLogger,
+      genericError
+    );
+
+    expect(mockResponse.status).toHaveBeenCalledWith(
+      HttpErrorToStatusCode.INTERNAL_SERVER_ERROR
+    );
+    expect(mockResponse.json).toHaveBeenCalledWith(expect.any(AcrossApiError));
+    expect(mockLogger.error).toHaveBeenCalled();
+  });
+});

--- a/test/api/helpers/test-helper.ts
+++ b/test/api/helpers/test-helper.ts
@@ -1,0 +1,26 @@
+export const createMockResponse = <TResponse>() => {
+  return {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+    setHeader: jest.fn().mockReturnThis(),
+  } as unknown as jest.Mocked<TResponse>;
+};
+
+export const createMockRequest = <TRequest>(query: Record<string, string>) => {
+  return {
+    query,
+  } as unknown as TRequest;
+};
+
+export const setupTestMocks = <TResponse>(mockFn: jest.Mock) => {
+  const mockResponse = createMockResponse<TResponse>();
+  const mockGet = jest.fn();
+
+  jest.clearAllMocks();
+  mockFn.mockReturnValue({ get: mockGet });
+
+  return {
+    mockResponse,
+    mockGet,
+  };
+};


### PR DESCRIPTION
### Summary
This PR aims to rework the way we test our handlers. Each API handler does the following:

1. Processes inbound request and returns a response.
2. Calls `handleErrorCondition` for exception handling.

We should have 2 separate sets of unit tests. One which covers all the branches `handleErrorCondition` and then one which covers the core functionality of each handler in success/fail scenarios.

### Details

- `test-helper.ts` - This contains common functions that every handler test can use to setup mocks. I purposely didn't use any Vercel specific logic here so that the helper can be used with any adapter.
- `account-balance.test.ts` - This contains tests to cover all scenarios which can happen within the core handler logic. We can follow this pattern and add tests for each endpoint in future PRs.
- `error-handler.test.ts` - This aims to test every branch of `handleErrorCondition` in `_errors.ts`. Its execution is standalone and doesn't rely on any specific handler invoking it. This way we can ensure that every execution branch is covered.

### Testing
New tests are passing. The next step is to clean up and refactor old tests.

```
Test Suites: 6 passed, 6 total
Tests:       34 passed, 34 total
```