### PR TITLE
fix: relayer gas fees for solana

### DIFF
--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -2117,12 +2117,17 @@ export function getCachedNativeGasCost(
   // Set this longer than the secondsPerUpdate value in the cron cache gas prices job.
   const ttlPerChain = {
     default: 120,
+    [CHAIN_IDs.SOLANA]: 1,
   };
-  const cacheKey = buildInternalCacheKey(
+  const cacheKeyArgs = [
     "nativeGasCost",
     deposit.destinationChainId,
-    deposit.outputToken
-  );
+    deposit.outputToken,
+    sdk.utils.chainIsSvm(deposit.destinationChainId)
+      ? deposit.recipientAddress
+      : [],
+  ].flat();
+  const cacheKey = buildInternalCacheKey(...cacheKeyArgs);
   const fetchFn = async () => {
     const relayerAddress =
       overrides?.relayerAddress ??

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -735,10 +735,16 @@ export const getRelayerFeeCalculator = (
   }> = {}
 ) => {
   const queries = getRelayerFeeCalculatorQueries(destinationChainId, overrides);
+  const destinationChainInfo = getChainInfo(destinationChainId);
+  const destinationChainNativeTokenDecimals =
+    TOKEN_SYMBOLS_MAP[
+      destinationChainInfo.nativeToken as keyof typeof TOKEN_SYMBOLS_MAP
+    ]?.decimals ?? 18;
   const relayerFeeCalculatorConfig = {
     feeLimitPercent: maxRelayFeePct * 100,
     queries,
     capitalCostsConfig: relayerFeeCapitalCostConfig,
+    nativeTokenDecimals: destinationChainNativeTokenDecimals,
   };
   if (relayerFeeCalculatorConfig.feeLimitPercent < 1)
     throw new Error(

--- a/api/limits.ts
+++ b/api/limits.ts
@@ -215,7 +215,7 @@ const handler = async (
           relayerAddress: relayer.toBytes32(),
         }
       ).get(),
-      isMessageDefined || sdk.utils.chainIsSvm(destinationChainId)
+      isMessageDefined
         ? undefined // Only use cached gas units if message is not defined, i.e. standard for standard bridges
         : getCachedNativeGasCost(simulationDepositArgs, {
             relayerAddress: relayer.toBytes32(),

--- a/api/limits.ts
+++ b/api/limits.ts
@@ -215,7 +215,7 @@ const handler = async (
           relayerAddress: relayer.toBytes32(),
         }
       ).get(),
-      isMessageDefined
+      isMessageDefined || sdk.utils.chainIsSvm(destinationChainId)
         ? undefined // Only use cached gas units if message is not defined, i.e. standard for standard bridges
         : getCachedNativeGasCost(simulationDepositArgs, {
             relayerAddress: relayer.toBytes32(),

--- a/api/suggested-fees.ts
+++ b/api/suggested-fees.ts
@@ -110,6 +110,7 @@ const handler = async (
       _relayer || getDefaultRelayerAddress(destinationChainId, l1Token.symbol)
     );
     const depositWithMessage = sdk.utils.isDefined(message);
+    const isDestinationSvm = sdk.utils.chainIsSvm(destinationChainId);
 
     // If the destination or origin chain is an opt-in chain, we need to check if the role is OPT_IN_CHAINS.
     const isDestinationOptInChain = OPT_IN_CHAINS.includes(
@@ -228,10 +229,16 @@ const handler = async (
         amountInput,
         // Only pass in the following parameters if message is defined, otherwise leave them undefined so we are more
         // likely to hit the /limits cache using the above parameters that are not specific to this deposit.
-        depositWithMessage || sdk.utils.chainIsSvm(destinationChainId)
-          ? recipient.toBytes32()
+        depositWithMessage || isDestinationSvm
+          ? isDestinationSvm
+            ? recipient.toBase58()
+            : recipient.toEvmAddress()
           : undefined,
-        depositWithMessage ? relayer.toBytes32() : undefined,
+        depositWithMessage
+          ? isDestinationSvm
+            ? relayer.toBase58()
+            : relayer.toEvmAddress()
+          : undefined,
         depositWithMessage ? message : undefined,
         allowUnmatchedDecimals
       ),

--- a/api/suggested-fees.ts
+++ b/api/suggested-fees.ts
@@ -228,7 +228,9 @@ const handler = async (
         amountInput,
         // Only pass in the following parameters if message is defined, otherwise leave them undefined so we are more
         // likely to hit the /limits cache using the above parameters that are not specific to this deposit.
-        depositWithMessage ? recipient.toBytes32() : undefined,
+        depositWithMessage || sdk.utils.chainIsSvm(destinationChainId)
+          ? recipient.toBytes32()
+          : undefined,
         depositWithMessage ? relayer.toBytes32() : undefined,
         depositWithMessage ? message : undefined,
         allowUnmatchedDecimals


### PR DESCRIPTION
### Summary
This PR fixes the relayer gas fees that the API would compute:
- Consider the `recipient` address always when dest. chain is Solana
  - This is required because the recipient might need a PDA or ATA set up if not existent
- Use correct native token decimals for `RelayFeeCalculator`

### Examples
- [Correct `/limits` response](https://app-frontend-v3-git-fix-recipient-address-gas-costs-uma.vercel.app/api/limits?inputToken=0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913&outputToken=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v&originChainId=8453&destinationChainId=34268394551451&allowUnmatchedDecimals=true&amount=2000000&recipient=B9mvTvYZuoEjLtxtNun2r2jmcmYCCJp2uwt1o8tpFfm7)
- [Wrong `/limits` response](https://app-frontend-v3-git-epic-solana-v1-uma.vercel.app/api/limits?inputToken=0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913&outputToken=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v&originChainId=8453&destinationChainId=34268394551451&allowUnmatchedDecimals=true&amount=2000000)
