### PR TITLE
fix: blocked address uni trading api + loop detected error

### DIFF
--- a/api/_dexes/uniswap/utils/trading-api.ts
+++ b/api/_dexes/uniswap/utils/trading-api.ts
@@ -3,6 +3,8 @@ import axios, { AxiosError } from "axios";
 
 import { Swap } from "../../types";
 import { V2PoolInRoute, V3PoolInRoute } from "./adapter";
+import { getMulticall3Address } from "../../../_utils";
+import { CHAIN_IDs } from "../../../_constants";
 
 export type UniswapClassicQuoteFromApi = {
   chainId: number;
@@ -45,6 +47,15 @@ export async function getUniswapClassicQuoteFromApi(
   swap: UniswapParamForApi,
   tradeType: TradeType
 ) {
+  // NOTE: Temporary fix Stablecoin Mainnet -> Lens. The Multicall3 address is currently blocked
+  // by the Uniswap API. We use a dummy address for just fetching the quote.
+  // TODO: Remove this once the Uniswap API is updated.
+  if (
+    swap.tokenIn.chainId === CHAIN_IDs.MAINNET &&
+    swap.swapper === getMulticall3Address(swap.tokenIn.chainId)
+  ) {
+    swap.swapper = "0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D";
+  }
   const response = await axios.post<{
     requestId: string;
     routing: "CLASSIC";

--- a/api/_dexes/uniswap/utils/trading-api.ts
+++ b/api/_dexes/uniswap/utils/trading-api.ts
@@ -86,6 +86,13 @@ export async function getUniswapClassicQuoteFromApi(
     ...response.data,
     quote: {
       ...quote,
+      output: {
+        ...quote.output,
+        // Revert the dummy recipient address to the original recipient address.
+        recipient: shouldUseDummySwapper
+          ? swap.recipient
+          : quote.output.recipient,
+      },
       // Revert the dummy swapper address to the original swapper address.
       swapper: shouldUseDummySwapper ? swap.swapper : quote.swapper,
     },

--- a/api/_dexes/uniswap/utils/trading-api.ts
+++ b/api/_dexes/uniswap/utils/trading-api.ts
@@ -47,6 +47,7 @@ export async function getUniswapClassicQuoteFromApi(
   swap: UniswapParamForApi,
   tradeType: TradeType
 ) {
+  let swapperAddress = swap.swapper;
   // NOTE: Temporary fix Stablecoin Mainnet -> Lens. The Multicall3 address is currently blocked
   // by the Uniswap API. We use a dummy address for just fetching the quote.
   // TODO: Remove this once the Uniswap API is updated.
@@ -54,7 +55,7 @@ export async function getUniswapClassicQuoteFromApi(
     swap.tokenIn.chainId === CHAIN_IDs.MAINNET &&
     swap.swapper === getMulticall3Address(swap.tokenIn.chainId)
   ) {
-    swap.swapper = "0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D";
+    swapperAddress = "0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D";
   }
   const response = await axios.post<{
     requestId: string;
@@ -69,7 +70,7 @@ export async function getUniswapClassicQuoteFromApi(
       tokenOutChainId: swap.tokenOut.chainId,
       tokenIn: swap.tokenIn.address,
       tokenOut: swap.tokenOut.address,
-      swapper: swap.swapper,
+      swapper: swapperAddress,
       slippageTolerance: swap.slippageTolerance,
       autoSlippage: swap.slippageTolerance ? undefined : "DEFAULT",
       amount: swap.amount,

--- a/api/coingecko.ts
+++ b/api/coingecko.ts
@@ -7,7 +7,6 @@ import {
   handleErrorCondition,
   validAddress,
   getBalancerV2TokenPrice,
-  getCachedTokenPrice,
   parseQuery,
   positiveInt,
 } from "./_utils";
@@ -58,7 +57,7 @@ const handler = async (
       l1Token,
       tokenAddress,
       chainId: _chainId,
-      baseCurrency,
+      baseCurrency: _baseCurrency,
       date: dateStr,
     } = parseQuery(query, CoingeckoQueryParamsSchema);
 
@@ -70,102 +69,13 @@ const handler = async (
       });
     }
 
-    const fallbackChainId =
-      _chainId ??
-      (isEvmAddress(address) ? CHAIN_IDs.MAINNET : CHAIN_IDs.SOLANA);
-    const chainId = coinGeckoAssetPlatformLookup[address] ?? fallbackChainId;
-
-    address = utils.chainIsSvm(chainId)
-      ? utils.toAddressType(address).toBase58()
-      : utils.toAddressType(address).toEvmAddress();
-
-    baseCurrency = (
-      baseCurrency ?? (utils.chainIsSvm(chainId) ? "sol" : "eth")
-    ).toLowerCase();
-
-    // Confirm that the base Currency is supported by Coingecko
-    const isDerivedCurrency = SUPPORTED_CG_DERIVED_CURRENCIES.has(baseCurrency);
-    if (!SUPPORTED_CG_BASE_CURRENCIES.has(baseCurrency) && !isDerivedCurrency) {
-      throw new InvalidParamError({
-        message: `Base currency supplied is not supported by this endpoint. Supported currencies: [${Array.from(
-          SUPPORTED_CG_BASE_CURRENCIES
-        ).join(", ")}].`,
-        param: "baseCurrency",
+    let { price, baseCurrency, isDerivedCurrency, chainId } =
+      await resolvePrice({
+        address,
+        chainId: _chainId,
+        baseCurrency: _baseCurrency,
+        dateStr,
       });
-    }
-
-    // Resolve the optional address lookup that maps one token's
-    // contract address to another.
-    const redirectLookupAddresses: Record<string, string> =
-      REDIRECTED_TOKEN_PRICE_LOOKUP_ADDRESSES !== undefined
-        ? JSON.parse(REDIRECTED_TOKEN_PRICE_LOOKUP_ADDRESSES)
-        : {};
-
-    // Perform a 1-deep lookup to see if the provided l1Token is
-    // to be "redirected" to another provided token contract address
-    if (redirectLookupAddresses[address]) {
-      address = redirectLookupAddresses[address];
-    }
-
-    const coingeckoClient = Coingecko.get(
-      logger,
-      REACT_APP_COINGECKO_PRO_API_KEY,
-      {
-        [CHAIN_IDs.SOLANA]: "solana",
-        [CHAIN_IDs.SOLANA_DEVNET]: "solana",
-      }
-    );
-
-    // We want to compute price and return to caller.
-    let price: number;
-
-    const balancerV2PoolTokens: string[] = JSON.parse(
-      BALANCER_V2_TOKENS ?? "[]"
-    ).map(ethers.utils.getAddress);
-
-    if (balancerV2PoolTokens.includes(address)) {
-      if (dateStr) {
-        throw new InvalidParamError({
-          message: "Historical price not supported for BalancerV2 tokens",
-          param: "date",
-        });
-      }
-      if (baseCurrency === "usd") {
-        price = await getBalancerV2TokenPrice(address);
-      } else {
-        throw new InvalidParamError({
-          message: "Only CG base currency allowed for BalancerV2 tokens is usd",
-          param: "baseCurrency",
-        });
-      }
-    }
-    // Fetch price dynamically from Coingecko API. If a historical
-    // date is provided, fetch historical price. Otherwise, fetch
-    // current price.
-    else {
-      // // If derived, we need to convert to USD first.
-      const modifiedBaseCurrency = isDerivedCurrency ? "usd" : baseCurrency;
-      if (dateStr) {
-        price = await coingeckoClient.getContractHistoricDayPrice(
-          address,
-          dateStr,
-          modifiedBaseCurrency,
-          chainId
-        );
-      } else {
-        [, price] = CG_CONTRACTS_DEFERRED_TO_ID.has(address)
-          ? await coingeckoClient.getCurrentPriceById(
-              address,
-              modifiedBaseCurrency,
-              chainId
-            )
-          : await coingeckoClient.getCurrentPriceByContract(
-              address,
-              modifiedBaseCurrency,
-              chainId
-            );
-      }
-    }
 
     // If the base currency is a derived currency, we just need to grab
     // the price of the quote currency in USD and perform the conversion.
@@ -182,12 +92,13 @@ const handler = async (
         baseTokenAddress = baseToken.addresses[CHAIN_IDs.SOLANA];
         baseTokenChainId = CHAIN_IDs.SOLANA;
       }
-      quotePrice = await getCachedTokenPrice(
-        baseTokenAddress,
-        "usd",
-        undefined,
-        baseTokenChainId
-      );
+      const { price: baseTokenPrice } = await resolvePrice({
+        address: baseTokenAddress,
+        chainId: baseTokenChainId,
+        baseCurrency: "usd",
+        dateStr,
+      });
+      quotePrice = baseTokenPrice;
       quotePrecision = baseToken.decimals;
     }
     price = Number((price / quotePrice).toFixed(quotePrecision));
@@ -221,5 +132,115 @@ const handler = async (
     return handleErrorCondition("coingecko", response, logger, error);
   }
 };
+
+// Wrapping the price resolution in a separate function to avoid 508 LOOP_DETECTED errors for
+// derived currency price resolution.
+async function resolvePrice(params: {
+  address: string;
+  chainId?: number;
+  baseCurrency?: string;
+  dateStr?: string;
+}) {
+  const logger = getLogger();
+
+  const fallbackChainId =
+    params.chainId ??
+    (isEvmAddress(params.address) ? CHAIN_IDs.MAINNET : CHAIN_IDs.SOLANA);
+  const chainId =
+    coinGeckoAssetPlatformLookup[params.address] ?? fallbackChainId;
+
+  let address = utils.chainIsSvm(chainId)
+    ? utils.toAddressType(params.address).toBase58()
+    : utils.toAddressType(params.address).toEvmAddress();
+
+  const baseCurrency = (
+    params.baseCurrency ?? (utils.chainIsSvm(chainId) ? "sol" : "eth")
+  ).toLowerCase();
+
+  // Confirm that the base Currency is supported by Coingecko
+  const isDerivedCurrency = SUPPORTED_CG_DERIVED_CURRENCIES.has(baseCurrency);
+  if (!SUPPORTED_CG_BASE_CURRENCIES.has(baseCurrency) && !isDerivedCurrency) {
+    throw new InvalidParamError({
+      message: `Base currency supplied is not supported by this endpoint. Supported currencies: [${Array.from(
+        SUPPORTED_CG_BASE_CURRENCIES
+      ).join(", ")}].`,
+      param: "baseCurrency",
+    });
+  }
+
+  // Resolve the optional address lookup that maps one token's
+  // contract address to another.
+  const redirectLookupAddresses: Record<string, string> =
+    REDIRECTED_TOKEN_PRICE_LOOKUP_ADDRESSES !== undefined
+      ? JSON.parse(REDIRECTED_TOKEN_PRICE_LOOKUP_ADDRESSES)
+      : {};
+
+  // Perform a 1-deep lookup to see if the provided l1Token is
+  // to be "redirected" to another provided token contract address
+  if (redirectLookupAddresses[address]) {
+    address = redirectLookupAddresses[address];
+  }
+
+  const coingeckoClient = Coingecko.get(
+    logger,
+    REACT_APP_COINGECKO_PRO_API_KEY,
+    {
+      [CHAIN_IDs.SOLANA]: "solana",
+      [CHAIN_IDs.SOLANA_DEVNET]: "solana",
+    }
+  );
+
+  // We want to compute price and return to caller.
+  let price: number;
+
+  const balancerV2PoolTokens: string[] = JSON.parse(
+    BALANCER_V2_TOKENS ?? "[]"
+  ).map(ethers.utils.getAddress);
+
+  if (balancerV2PoolTokens.includes(address)) {
+    if (params.dateStr) {
+      throw new InvalidParamError({
+        message: "Historical price not supported for BalancerV2 tokens",
+        param: "date",
+      });
+    }
+    if (baseCurrency === "usd") {
+      price = await getBalancerV2TokenPrice(address);
+    } else {
+      throw new InvalidParamError({
+        message: "Only CG base currency allowed for BalancerV2 tokens is usd",
+        param: "baseCurrency",
+      });
+    }
+  }
+  // Fetch price dynamically from Coingecko API. If a historical
+  // date is provided, fetch historical price. Otherwise, fetch
+  // current price.
+  else {
+    // // If derived, we need to convert to USD first.
+    const modifiedBaseCurrency = isDerivedCurrency ? "usd" : baseCurrency;
+    if (params.dateStr) {
+      price = await coingeckoClient.getContractHistoricDayPrice(
+        address,
+        params.dateStr,
+        modifiedBaseCurrency,
+        chainId
+      );
+    } else {
+      [, price] = CG_CONTRACTS_DEFERRED_TO_ID.has(address)
+        ? await coingeckoClient.getCurrentPriceById(
+            address,
+            modifiedBaseCurrency,
+            chainId
+          )
+        : await coingeckoClient.getCurrentPriceByContract(
+            address,
+            modifiedBaseCurrency,
+            chainId
+          );
+    }
+  }
+  return { price, baseCurrency, isDerivedCurrency, chainId };
+}
 
 export default handler;


### PR DESCRIPTION
There were two issues in the /swap endpoint that would lead to 502s returned:
1. The Multicall3 address is blocked by Uniswap's Trading API. We circumvent this by using a dummy address to retrieve a quote but when constructing the swap tx, we use the correct address.
2. For some requests, the coingecko endpoint would throw 508 LOOP_DETECTED errors. I could narrow it down to cases where we would self-call the coingecko endpoint for derived currencies. We fix this by factoring the logic into a separate function. This might have a slightly negative performance impact.