### PR TITLE
fix: use address instead of depositor when querying deposits

### DIFF
--- a/src/hooks/useDeposits.ts
+++ b/src/hooks/useDeposits.ts
@@ -221,7 +221,7 @@ async function getDeposits(
         status: params.status === "pending" ? "unfilled" : params.status,
         limit: params.limit,
         skip: params.offset,
-        depositor: params.address,
+        address: params.address,
       },
     }
   );


### PR DESCRIPTION
This PR updates the `/deposits` query to use `address` instead of `depositor`, this way the indexer returns deposits where the address is either the depositor or the recipient, rather than just the recipient.

Note: this is the way it used to work with the scraper.