### PR TITLE
don't cache user pool value

### DIFF
--- a/api/pools-user.ts
+++ b/api/pools-user.ts
@@ -43,10 +43,6 @@ const handler = async (
       message: "Response data",
       responseJson: poolStateOfUser,
     });
-    response.setHeader(
-      "Cache-Control",
-      "s-maxage=300, stale-while-revalidate=300"
-    );
     response.status(200).json(poolStateOfUser);
   } catch (error: unknown) {
     return handleErrorCondition("pools-user", response, logger, error);

--- a/src/views/LiquidityPool/components/ActionInputBlock.tsx
+++ b/src/views/LiquidityPool/components/ActionInputBlock.tsx
@@ -83,6 +83,7 @@ export function ActionInputBlock({ action, selectedToken }: Props) {
           onSuccess: () => {
             setAmount("");
             maxAmountsQuery.refetch();
+            stakingPoolQuery.refetch();
           },
         }
       );
@@ -97,6 +98,7 @@ export function ActionInputBlock({ action, selectedToken }: Props) {
           onSuccess: () => {
             setAmount("");
             maxAmountsQuery.refetch();
+            stakingPoolQuery.refetch();
           },
         }
       );


### PR DESCRIPTION
closes ACF-21

## Changes
- We no longer cache responses from `/api/user-pools` on the server. This stale data is causing UX issues in the frontend.
- We also explicitly refetch users' LP token balances after a successful withdrawal/deposit into an LP. 