### PR TITLE
fix: disable indexer api cache

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -63,7 +63,7 @@
   ],
   "headers": [
     {
-      "source": "/api/deposit(?:/.*)?",
+      "source": "/api/deposit(.*)",
       "headers": [
         {
           "key": "CDN-Cache-Control",

--- a/vercel.json
+++ b/vercel.json
@@ -63,6 +63,15 @@
   ],
   "headers": [
     {
+      "source": "/api/deposit*",
+      "headers": [
+        {
+          "key": "CDN-Cache-Control",
+          "value": "max-age=0"
+        }
+      ]
+    },
+    {
       "source": "/(.*)",
       "headers": [
         {

--- a/vercel.json
+++ b/vercel.json
@@ -63,7 +63,7 @@
   ],
   "headers": [
     {
-      "source": "/api/deposit.*",
+      "source": /api/deposit(?:/.*)?,
       "headers": [
         {
           "key": "CDN-Cache-Control",

--- a/vercel.json
+++ b/vercel.json
@@ -63,7 +63,7 @@
   ],
   "headers": [
     {
-      "source": /api/deposit(?:/.*)?,
+      "source": "/api/deposit(?:/.*)?",
       "headers": [
         {
           "key": "CDN-Cache-Control",

--- a/vercel.json
+++ b/vercel.json
@@ -63,7 +63,7 @@
   ],
   "headers": [
     {
-      "source": "/api/deposit*",
+      "source": "/api/deposit.*",
       "headers": [
         {
           "key": "CDN-Cache-Control",


### PR DESCRIPTION
PancakeSwap reported delays in reflecting the deposit status correctly in our API. I was able to replicate the issue and what happened was that `https://indexer.api.across.to` had the status updated, but `https://app.across.to` returned `404 Deposit not found`. This led me to think that there's a caching issue, so I am disabling caching for all Indexer API endpoints. 