### PR TITLE
fix: remove swapQuotes local definition

### DIFF
--- a/scripts/tests/_swap-utils.ts
+++ b/scripts/tests/_swap-utils.ts
@@ -189,7 +189,6 @@ export async function fetchSwapQuotes() {
       throw new Error("No test cases found");
     }
 
-    const swapQuotes: BaseSwapResponse[] = [];
     for (const testCase of filteredTestCases) {
       console.log("Test case:", testCase.labels.join(" "));
       console.log("Params:", testCase.params);


### PR DESCRIPTION
A local definition of `swapQuotes` in the else branch was causing the `.push` to apply only locally. When we return it at the end of the function, it's returning the global definition.

```
    const swapQuotes: BaseSwapResponse[] = [];
    for (const testCase of filteredTestCases) {
      console.log("Test case:", testCase.labels.join(" "));
      console.log("Params:", testCase.params);
      const response = await axios.get(
        `${SWAP_API_BASE_URL}/api/swap${slug ? `/${slug}` : ""}`,
        {
          params: testCase.params,
        }
      );
      swapQuotes.push(response.data as BaseSwapResponse);
    }
  }


  return swapQuotes;
```

https://github.com/across-protocol/frontend/blob/master/scripts/tests/_swap-utils.ts#L192-L206