### PR TITLE
Fix SVM Wallet selector 

### DIFF
--- a/src/hooks/useWalletSorted.ts
+++ b/src/hooks/useWalletSorted.ts
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
-import { useDetectBrowserWallets } from "./useDetectBrowserWallets";
 import { useLatestWallets } from "./useLatestSvmWallet";
 import { Wallet, useWallet } from "@solana/wallet-adapter-react";
+import { WalletReadyState } from "@solana/wallet-adapter-base";
 
 export type WalletWithInstalled = Wallet & {
   installed: boolean;
@@ -9,14 +9,14 @@ export type WalletWithInstalled = Wallet & {
 
 export function useWalletsSorted() {
   const wallet = useWallet();
-  const installedWallets = useDetectBrowserWallets();
+
   const { svm: latestWalletName } = useLatestWallets();
 
   const sortedWallets: WalletWithInstalled[] = useMemo(() => {
     return wallet.wallets
       .map((wallet) => ({
         ...wallet,
-        installed: installedWallets.includes(wallet.adapter.name.toLowerCase()),
+        installed: wallet.readyState === WalletReadyState.Installed,
       }))
       .sort((a, b) => {
         // latest first
@@ -38,7 +38,7 @@ export function useWalletsSorted() {
         // fallback
         return a.adapter.name.localeCompare(b.adapter.name);
       });
-  }, [installedWallets, latestWalletName, wallet.wallets]);
+  }, [latestWalletName, wallet.wallets]);
 
   return { sortedWallets, ...wallet };
 }


### PR DESCRIPTION
closes ACX-4186

We were using evm standard of detecting which wallets are installed in the browser leading , so wallets other than those which are compatible on BOTH evm and svm, were not shown as installed.

Use Solana's baked-in wallet adapter logic to detect if wallets are installed.

##Note
 the 2 Metamask options are technically 2 separate wallets. 
One is the Solflare plugin within Metamask.
The other is Metamask's own native SVM wallet.
This is intentional and Metamask "Emits" both wallets as being available options to the dapp. 