### PR TITLE
feat: select best quote based on all possible cross swap types

### DIFF
--- a/api/_dexes/cross-swap-service.ts
+++ b/api/_dexes/cross-swap-service.ts
@@ -9,6 +9,7 @@ import {
   Profiler,
   addMarkupToAmount,
   getBridgeQuoteForExactInput,
+  addTimeoutToPromise,
 } from "../_utils";
 import { CrossSwap, CrossSwapQuotes } from "./types";
 import {
@@ -40,7 +41,9 @@ import {
   CrossSwapQuotesRetrievalB2AResult,
 } from "./types";
 
-const indicativeQuoteBuffer = 0.005; // 0.5% buffer for indicative quotes
+const INDICATIVE_QUOTE_BUFFER = 0.005; // 0.5% buffer for indicative quotes
+
+const PROMISE_TIMEOUT_MS = 10000;
 
 export async function getCrossSwapQuotes(
   crossSwap: CrossSwap,
@@ -625,7 +628,7 @@ export async function getCrossSwapQuotesForOutputA2B(
         depositor: crossSwap.depositor,
         amount: addMarkupToAmount(
           prioritizedStrategy.indicativeOriginSwapQuote.maximumAmountIn,
-          indicativeQuoteBuffer
+          INDICATIVE_QUOTE_BUFFER
         ).toString(),
       },
       TradeType.EXACT_INPUT
@@ -973,7 +976,7 @@ export async function getCrossSwapQuotesForOutputByRouteA2A(
       minOutputAmount: addMarkupToAmount(
         prioritizedDestinationStrategy.indicativeDestinationSwapQuote
           .maximumAmountIn,
-        indicativeQuoteBuffer
+        INDICATIVE_QUOTE_BUFFER
       ),
       recipient: getMultiCallHandlerAddress(
         prioritizedDestinationStrategy.result.destinationSwapChainId
@@ -999,7 +1002,7 @@ export async function getCrossSwapQuotesForOutputByRouteA2A(
           depositor: crossSwap.depositor,
           amount: addMarkupToAmount(
             indicativeBridgeQuote.inputAmount,
-            indicativeQuoteBuffer
+            INDICATIVE_QUOTE_BUFFER
           ).toString(),
         },
         TradeType.EXACT_OUTPUT,
@@ -1067,7 +1070,7 @@ export async function getCrossSwapQuotesForOutputByRouteA2A(
             amount: addMarkupToAmount(
               prioritizedOriginStrategy.indicativeOriginSwapQuote
                 .maximumAmountIn,
-              indicativeQuoteBuffer
+              INDICATIVE_QUOTE_BUFFER
             ).toString(),
           },
           TradeType.EXACT_INPUT
@@ -1230,7 +1233,12 @@ async function selectBestCrossSwapQuote(
   crossSwapQuotePromises: Promise<CrossSwapQuotes>[],
   amountType: AmountType
 ): Promise<CrossSwapQuotes> {
-  const crossSwapQuotes = await Promise.allSettled(crossSwapQuotePromises);
+  const crossSwapQuotePromisesWithTimeout = crossSwapQuotePromises.map(
+    (promise) => addTimeoutToPromise(promise, PROMISE_TIMEOUT_MS)
+  );
+  const crossSwapQuotes = await Promise.allSettled(
+    crossSwapQuotePromisesWithTimeout
+  );
 
   const fulfilledQuotes = crossSwapQuotes
     .filter((result) => result.status === "fulfilled")

--- a/api/_dexes/cross-swap-service.ts
+++ b/api/_dexes/cross-swap-service.ts
@@ -12,10 +12,11 @@ import {
 } from "../_utils";
 import { CrossSwap, CrossSwapQuotes } from "./types";
 import {
+  AmountType,
   buildExactInputBridgeTokenMessage,
   buildExactOutputBridgeTokenMessage,
   buildMinOutputBridgeTokenMessage,
-  getCrossSwapType,
+  getCrossSwapTypes,
   getPreferredBridgeTokens,
   getQuoteFetchStrategies,
   QuoteFetchStrategies,
@@ -85,8 +86,8 @@ function getCrossSwapQuoteForAmountType(
       strategies: QuoteFetchStrategies
     ) => Promise<CrossSwapQuotes>
   >
-) {
-  const crossSwapType = getCrossSwapType({
+): Promise<CrossSwapQuotes> {
+  const crossSwapTypes = getCrossSwapTypes({
     inputToken: crossSwap.inputToken.address,
     originChainId: crossSwap.inputToken.chainId,
     outputToken: crossSwap.outputToken.address,
@@ -95,20 +96,23 @@ function getCrossSwapQuoteForAmountType(
     isOutputNative: Boolean(crossSwap.isOutputNative),
   });
 
-  const handler = typeToHandler[crossSwapType];
-  if (!handler) {
-    throw new InvalidParamError({
-      message: `Failed to fetch swap quote: invalid cross swap type '${crossSwapType}'`,
-    });
-  }
+  const crossSwaps = crossSwapTypes.map((crossSwapType) => {
+    const handler = typeToHandler[crossSwapType];
+    if (!handler) {
+      throw new InvalidParamError({
+        message: `Failed to fetch swap quote: invalid cross swap type '${crossSwapType}'`,
+      });
+    }
+    return handler(crossSwap, strategies);
+  });
 
-  return handler(crossSwap, strategies);
+  return selectBestCrossSwapQuote(crossSwaps, crossSwap.type);
 }
 
 export async function getCrossSwapQuotesForExactInputB2B(
   crossSwap: CrossSwap,
   strategies: QuoteFetchStrategies
-) {
+): Promise<CrossSwapQuotes> {
   // Use the first origin strategy since we don't need to fetch multiple origin quotes
   const originStrategy = getQuoteFetchStrategies(
     crossSwap.inputToken.chainId,
@@ -159,7 +163,7 @@ export async function getCrossSwapQuotesForExactInputB2B(
 export async function getCrossSwapQuotesForOutputB2B(
   crossSwap: CrossSwap,
   strategies: QuoteFetchStrategies
-) {
+): Promise<CrossSwapQuotes> {
   // Use the first origin strategy since we don't need to fetch multiple origin quotes
   const originStrategy = getQuoteFetchStrategies(
     crossSwap.inputToken.chainId,
@@ -1215,4 +1219,64 @@ function _prepCrossSwapQuotesRetrievalA2A(
  */
 async function executeStrategies<T>(strategyFetches: Promise<T>[]): Promise<T> {
   return await Promise.any(strategyFetches);
+}
+
+/**
+ * Executes quotes for multiple cross swap types and selects the best one.
+ * For exact input, compare based on destination swap output amount if available, otherwise bridge output amount.
+ * For exact output, compare based on destination swap input amount if available, otherwise bridge input amount.
+ */
+async function selectBestCrossSwapQuote(
+  crossSwapQuotePromises: Promise<CrossSwapQuotes>[],
+  amountType: AmountType
+): Promise<CrossSwapQuotes> {
+  const crossSwapQuotes = await Promise.allSettled(crossSwapQuotePromises);
+
+  const fulfilledQuotes = crossSwapQuotes
+    .filter((result) => result.status === "fulfilled")
+    .map((result) => result.value);
+
+  if (fulfilledQuotes.length === 0) {
+    throw new SwapQuoteUnavailableError({
+      message:
+        "Failed to fetch swap quote: No quotes available from any cross swap type",
+    });
+  }
+
+  if (fulfilledQuotes.length === 1) {
+    return fulfilledQuotes[0];
+  }
+
+  const bestQuote = fulfilledQuotes.reduce((best, current) => {
+    const currentDestinationSwapQuote = current.destinationSwapQuote;
+    const bestDestinationSwapQuote = best.destinationSwapQuote;
+    const currentBridgeQuote = current.bridgeQuote;
+    const bestBridgeQuote = best.bridgeQuote;
+    const isExactInput = amountType === "exactInput";
+
+    const currentAmount = currentDestinationSwapQuote
+      ? isExactInput
+        ? currentDestinationSwapQuote.expectedAmountOut
+        : currentDestinationSwapQuote.expectedAmountIn
+      : isExactInput
+        ? currentBridgeQuote.outputAmount
+        : currentBridgeQuote.inputAmount;
+    const bestAmount = bestDestinationSwapQuote
+      ? isExactInput
+        ? bestDestinationSwapQuote.expectedAmountOut
+        : bestDestinationSwapQuote.expectedAmountIn
+      : isExactInput
+        ? bestBridgeQuote.outputAmount
+        : bestBridgeQuote.inputAmount;
+
+    return isExactInput
+      ? currentAmount.gt(bestAmount)
+        ? current
+        : best
+      : currentAmount.lt(bestAmount)
+        ? current
+        : best;
+  });
+
+  return bestQuote;
 }

--- a/api/_dexes/utils.ts
+++ b/api/_dexes/utils.ts
@@ -108,14 +108,14 @@ export function getPreferredBridgeTokens(
   );
 }
 
-export function getCrossSwapType(params: {
+export function getCrossSwapTypes(params: {
   inputToken: string;
   originChainId: number;
   outputToken: string;
   destinationChainId: number;
   isInputNative: boolean;
   isOutputNative: boolean;
-}): CrossSwapType {
+}): CrossSwapType[] {
   if (
     isRouteEnabled(
       params.originChainId,
@@ -124,7 +124,7 @@ export function getCrossSwapType(params: {
       params.outputToken
     )
   ) {
-    return CROSS_SWAP_TYPE.BRIDGEABLE_TO_BRIDGEABLE;
+    return [CROSS_SWAP_TYPE.BRIDGEABLE_TO_BRIDGEABLE];
   }
 
   const inputBridgeable = isInputTokenBridgeable(
@@ -142,7 +142,7 @@ export function getCrossSwapType(params: {
   // `UniversalSwapAndBridge` does not support native tokens as input.
   if (params.isInputNative) {
     if (inputBridgeable) {
-      return CROSS_SWAP_TYPE.BRIDGEABLE_TO_ANY;
+      return [CROSS_SWAP_TYPE.BRIDGEABLE_TO_ANY];
     }
     // We can't bridge native tokens that are not ETH, e.g. MATIC or AZERO. Therefore
     // throw until we have periphery contract audited so that it can accept native
@@ -152,15 +152,22 @@ export function getCrossSwapType(params: {
     );
   }
 
+  if (inputBridgeable && outputBridgeable) {
+    return [
+      CROSS_SWAP_TYPE.ANY_TO_BRIDGEABLE,
+      CROSS_SWAP_TYPE.BRIDGEABLE_TO_ANY,
+    ];
+  }
+
   if (outputBridgeable) {
-    return CROSS_SWAP_TYPE.ANY_TO_BRIDGEABLE;
+    return [CROSS_SWAP_TYPE.ANY_TO_BRIDGEABLE];
   }
 
   if (inputBridgeable) {
-    return CROSS_SWAP_TYPE.BRIDGEABLE_TO_ANY;
+    return [CROSS_SWAP_TYPE.BRIDGEABLE_TO_ANY];
   }
 
-  return CROSS_SWAP_TYPE.ANY_TO_ANY;
+  return [CROSS_SWAP_TYPE.ANY_TO_ANY];
 }
 
 export function buildExactInputBridgeTokenMessage(

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -2786,3 +2786,15 @@ export const ConvertDecimals = (fromDecimals: number, toDecimals: number) => {
     return amount.mul(BigNumber.from("10").pow(-1 * diff));
   };
 };
+
+export function addTimeoutToPromise<T>(
+  promise: Promise<T>,
+  delay: number
+): Promise<T> {
+  const timeout = new Promise<T>((_, reject) => {
+    setTimeout(() => {
+      reject(new Error("Promise timed out"));
+    }, delay);
+  });
+  return Promise.race([promise, timeout]);
+}

--- a/test/api/_dexes/utils.test.ts
+++ b/test/api/_dexes/utils.test.ts
@@ -1,4 +1,4 @@
-import { getCrossSwapType, CROSS_SWAP_TYPE } from "../../../api/_dexes/utils";
+import { getCrossSwapTypes, CROSS_SWAP_TYPE } from "../../../api/_dexes/utils";
 import { CHAIN_IDs, TOKEN_SYMBOLS_MAP } from "../../../api/_constants";
 
 describe("_dexes/utils", () => {
@@ -12,8 +12,8 @@ describe("_dexes/utils", () => {
         isOutputNative: true,
         isInputNative: false,
       };
-      const crossSwapType = getCrossSwapType(params);
-      expect(crossSwapType).toBe(CROSS_SWAP_TYPE.ANY_TO_BRIDGEABLE);
+      const crossSwapTypes = getCrossSwapTypes(params);
+      expect(crossSwapTypes).toEqual([CROSS_SWAP_TYPE.ANY_TO_BRIDGEABLE]);
     });
 
     test("Lens GHO -> L1 GHO - should return bridgeable-to-any", () => {
@@ -25,8 +25,39 @@ describe("_dexes/utils", () => {
         isOutputNative: false,
         isInputNative: true,
       };
-      const crossSwapType = getCrossSwapType(params);
-      expect(crossSwapType).toBe(CROSS_SWAP_TYPE.BRIDGEABLE_TO_ANY);
+      const crossSwapTypes = getCrossSwapTypes(params);
+      expect(crossSwapTypes).toEqual([CROSS_SWAP_TYPE.BRIDGEABLE_TO_ANY]);
+    });
+
+    test("Optimism USDC -> Arbitrum USDC - should return bridgeable-to-bridgeable", () => {
+      const params = {
+        inputToken: TOKEN_SYMBOLS_MAP.USDC.addresses[CHAIN_IDs.OPTIMISM],
+        originChainId: CHAIN_IDs.OPTIMISM,
+        outputToken: TOKEN_SYMBOLS_MAP.USDC.addresses[CHAIN_IDs.ARBITRUM],
+        destinationChainId: CHAIN_IDs.ARBITRUM,
+        isOutputNative: false,
+        isInputNative: false,
+      };
+      const crossSwapTypes = getCrossSwapTypes(params);
+      expect(crossSwapTypes).toEqual([
+        CROSS_SWAP_TYPE.BRIDGEABLE_TO_BRIDGEABLE,
+      ]);
+    });
+
+    test("Optimism USDC -> Arbitrum ETH - should return any-to-bridgeable and bridgeable-to-any", () => {
+      const params = {
+        inputToken: TOKEN_SYMBOLS_MAP.USDC.addresses[CHAIN_IDs.OPTIMISM],
+        originChainId: CHAIN_IDs.OPTIMISM,
+        outputToken: TOKEN_SYMBOLS_MAP.ETH.addresses[CHAIN_IDs.ARBITRUM],
+        destinationChainId: CHAIN_IDs.ARBITRUM,
+        isOutputNative: false,
+        isInputNative: false,
+      };
+      const crossSwapTypes = getCrossSwapTypes(params);
+      expect(crossSwapTypes).toEqual([
+        CROSS_SWAP_TYPE.ANY_TO_BRIDGEABLE,
+        CROSS_SWAP_TYPE.BRIDGEABLE_TO_ANY,
+      ]);
     });
   });
 });


### PR DESCRIPTION
### Overview
As mentioned in [ACX-4169](https://linear.app/uma/issue/ACX-4169/determine-dynamically-a2b-or-b2a-based-on-lowest-fees):
>Currently if the inputToken AND the outputToken are bridgeable and not the same asset (e.g. OP USDC -> Arb ETH), we prefer origin swaps over destination swaps
>We need to fetch quotes for both possible routes (origin swap + bridge OR bridge + destination swap) and return the cheapest

### Changes

- Make `getCrossSwapTypes` return a list of possible cross swap types.
- **If the input and output tokens are bridgeable AND do not have an enabled route**, return both `CROSS_SWAP_TYPE.ANY_TO_BRIDGEABLE` and `CROSS_SWAP_TYPE.BRIDGEABLE_TO_ANY` as a list.
- Add new function `selectBestCrossSwapQuote` which does the following:
    - Call `await Promise.allSettled` on all the possible cross swap quotes
    - For all the successful quotes, reduce the results to find the "best" one
 - To determine the "best" quote for `EXACT_INPUT`, we can use the following logic:
    - For origin swaps, just take the bridge output amount since that will already be factored in the origin swap quote output
    - For destination swaps, take the destination swap quote expected output amount
 - To determine the "best" quote for `EXACT_OUTPUT`, we can use the following logic:
    - For origin swaps, just take the bridge input amount
    - For destination swaps, take the destination swap quote expected input amount (if this is supported?)
 - Updated test `test/api/_dexes/utils.test.ts` to include new scenarios.

### Testing
I tested USDC on Optimism to ETH on Arbitrum and logged some output.
#### For `EXACT_INPUT`:
```
[
  {
    at: '0x/fetchFn',
    message: 'Swap quote',
    type: 'EXACT_INPUT',
    tokenIn: 'USDC',
    tokenOut: 'ETH',
    chainId: 42161,
    maximumAmountIn: '500000',
    minAmountOut: '162668980712700',
    expectedAmountOut: '164312101733636',
    expectedAmountIn: '500000'
  }
]
[
  {
    at: '0x/fetchFn',
    message: 'Swap quote',
    type: 'EXACT_INPUT',
    tokenIn: 'USDC',
    tokenOut: 'ETH',
    chainId: 42161,
    maximumAmountIn: '464643',
    minAmountOut: '150681543903000',
    expectedAmountOut: '152203579702275',
    expectedAmountIn: '464643'
  }
]
quote 1 destinationSwapQuote undefined
quote 1 bridgeQuote 158901870331078


quote 2 destinationSwapQuote 152203579702275
quote 2 bridgeQuote 464643


Best destination swap quote undefined
Best bridge output quote 158901870331078
```

As you can see, it got quotes for both origin and destination swaps and chose the best one.
Transaction: https://optimistic.etherscan.io/tx/0x256bb7853b0bddcc02408a44a52ee95d3fca7d32f4b0f2ab092a0c657e38300a

#### For `EXACT_OUTPUT`:
```
crossSwapQuotes [
  {
    status: 'fulfilled',
    value: {
      crossSwap: [Object],
      bridgeQuote: [Object],
      destinationSwapQuote: undefined,
      originSwapQuote: [Object],
      contracts: [Object]
    }
  },
  {
    status: 'rejected',
    reason: AcrossApiError: execution reverted
        at getBridgeQuoteForMinOutput (/Users/ashwinswaroop/Repos/frontend/api/_utils.ts:1191:15)
        at processTicksAndRejections (node:internal/process/task_queues:105:5)
        at async Promise.all (index 1) {
      code: 'SIMULATION_ERROR',
      status: 400,
      param: undefined,
      [cause]: [AxiosError]
    }
  }
]
```

As you can see, it got quotes for both origin and destination swaps and chose the only successful one. I think because we don't allow destination swap exact output? If so we can probably skip getting a quote in this scenario.
Transaction: https://optimistic.etherscan.io/tx/0xd698eb0fc95f0307292033fcaca1883df98fd300e6115a54142583bf470b983b
