### PR TITLE
feat(swap): Set body schema and validations for embedded actions

### DIFF
--- a/api/_errors.ts
+++ b/api/_errors.ts
@@ -36,6 +36,7 @@ export const AcrossErrorCode = {
   AMOUNT_TOO_LOW: "AMOUNT_TOO_LOW",
   AMOUNT_TOO_HIGH: "AMOUNT_TOO_HIGH",
   ROUTE_NOT_ENABLED: "ROUTE_NOT_ENABLED",
+  ABI_ENCODING_ERROR: "ABI_ENCODING_ERROR",
 
   // Status: 50X
   UPSTREAM_RPC_ERROR: "UPSTREAM_RPC_ERROR",
@@ -136,6 +137,18 @@ export class MissingParamError extends InputError {
       code: AcrossErrorCode.MISSING_PARAM,
       param: args.param,
     });
+  }
+}
+
+export class AbiEncodingError extends InputError {
+  constructor(args: { message: string }, opts?: ErrorOptions) {
+    super(
+      {
+        message: args.message,
+        code: AcrossErrorCode.ABI_ENCODING_ERROR,
+      },
+      opts
+    );
   }
 }
 

--- a/api/_errors.ts
+++ b/api/_errors.ts
@@ -31,6 +31,7 @@ export const HttpErrorToStatusCode = {
 export const AcrossErrorCode = {
   // Status: 40X
   INVALID_PARAM: "INVALID_PARAM",
+  INVALID_METHOD: "INVALID_METHOD",
   MISSING_PARAM: "MISSING_PARAM",
   SIMULATION_ERROR: "SIMULATION_ERROR",
   AMOUNT_TOO_LOW: "AMOUNT_TOO_LOW",

--- a/api/_types/generic.types.ts
+++ b/api/_types/generic.types.ts
@@ -1,5 +1,9 @@
 import { VercelRequest } from "@vercel/node";
 
-export type TypedVercelRequest<T> = VercelRequest & {
-  query: Partial<T>;
+export type TypedVercelRequest<TQuery, TBody = undefined> = Omit<
+  VercelRequest,
+  "body"
+> & {
+  query: Partial<TQuery>;
+  body: TBody;
 };

--- a/api/swap/_utils.ts
+++ b/api/swap/_utils.ts
@@ -193,16 +193,20 @@ export function handleSwapBody(body: SwapBody) {
   assert(body, SwapBody);
 
   // Helper function to recursively extract only the .value fields from args array
-  const flattenArgs = (args: any[]): any[] =>
-    args.map((arg) => {
+  const flattenArgs = (args: any[], depth: number = 0): any[] => {
+    if (depth > 10) {
+      throw new Error("Arguments array is too deeply nested");
+    }
+    return args.map((arg) => {
       if (Array.isArray(arg)) {
-        return flattenArgs(arg);
+        return flattenArgs(arg, depth + 1);
       } else if (arg && typeof arg === "object" && "value" in arg) {
         return arg.value;
       } else {
         return arg;
       }
     });
+  };
 
   body.actions.forEach((action) => {
     const methodAbi = action.functionSignature;

--- a/api/swap/_utils.ts
+++ b/api/swap/_utils.ts
@@ -171,7 +171,6 @@ const RecursiveArgumentArray: any = lazy(() =>
 // Instructions for a single function call
 const Action = type({
   target: validEvmAddress(),
-  functionName: string(),
   functionSignature: string(), // Will be validated at runtime
   args: array(RecursiveArgumentArray),
   value: positiveIntStr(),
@@ -208,15 +207,14 @@ export function handleSwapBody(body: SwapBody) {
   body.actions.map((action) => {
     const methodAbi = action.functionSignature;
     const positionalArgs = flattenArgs(action.args);
-
     const iface = new utils.Interface([methodAbi]);
-
+    const functionName = iface.fragments[0].name;
     try {
-      iface.encodeFunctionData(action.functionName, positionalArgs);
+      iface.encodeFunctionData(functionName, positionalArgs);
     } catch (err) {
       throw new AbiEncodingError(
         {
-          message: `Failed to encode function data for ${action.functionName}. Arguments may be invalid or mismatched.`,
+          message: `Failed to encode function data for ${functionName}. Arguments may be invalid or mismatched.`,
         },
         {
           cause: `${err instanceof Error ? err.message : String(err)}`,

--- a/api/swap/_utils.ts
+++ b/api/swap/_utils.ts
@@ -1,4 +1,18 @@
-import { assert, Infer, type, string, optional, enums } from "superstruct";
+import {
+  assert,
+  Infer,
+  type,
+  string,
+  optional,
+  enums,
+  array,
+  object,
+  boolean,
+  lazy,
+  union,
+  unknown,
+  refine,
+} from "superstruct";
 import { BigNumber, constants, utils } from "ethers";
 
 import { TypedVercelRequest } from "../_types";
@@ -6,12 +20,13 @@ import {
   positiveFloatStr,
   positiveIntStr,
   validAddress,
+  validEvmAddress,
   boolStr,
   getCachedTokenInfo,
   getWrappedNativeTokenAddress,
   getCachedTokenPrice,
 } from "../_utils";
-import { InvalidParamError } from "../_errors";
+import { AbiEncodingError, InvalidParamError } from "../_errors";
 import { isValidIntegratorId } from "../_integrator-id";
 import {
   CrossSwapFees,
@@ -128,6 +143,87 @@ export async function handleBaseSwapQueryParams(
     slippageTolerance,
     refundToken,
   };
+}
+
+// Schema definitions for embedded actions
+// Input param for a function call
+const ActionArg = refine(
+  object({
+    value: unknown(), // Will be validated at runtime
+    populateDynamically: boolean(),
+    balanceSource: optional(validEvmAddress()),
+  }),
+  "balanceSource",
+  (argument) => {
+    if (argument.populateDynamically && !argument.balanceSource) {
+      return "balanceSource is required when populateDynamically is true";
+    }
+    return true;
+  }
+);
+
+// Recursive array type that can have nested arrays at any depth
+// Needed to support arguments of type tuple and array
+const RecursiveArgumentArray: any = lazy(() =>
+  union([ActionArg, array(RecursiveArgumentArray)])
+);
+
+// Instructions for a single function call
+const Action = type({
+  target: validEvmAddress(),
+  functionName: string(),
+  functionSignature: string(), // Will be validated at runtime
+  args: array(RecursiveArgumentArray),
+  value: positiveIntStr(),
+});
+
+const SwapBody = type({
+  actions: array(Action),
+});
+
+export type SwapBody = Infer<typeof SwapBody>;
+
+/**
+ * Validates that all actions in the swap body can be properly encoded.
+ * Recursively extracts argument values and validates they match the function signature.
+ *
+ * @param body - The request body containing an array of actions to validate
+ * @throws {AbiEncodingError} When function encoding fails due to invalid arguments or mismatched signatures
+ */
+export function handleSwapBody(body: SwapBody) {
+  assert(body, SwapBody);
+
+  // Helper function to recursively extract only the .value fields from args array
+  const flattenArgs = (args: any[]): any[] =>
+    args.map((arg) => {
+      if (Array.isArray(arg)) {
+        return flattenArgs(arg);
+      } else if (arg && typeof arg === "object" && "value" in arg) {
+        return arg.value;
+      } else {
+        return arg;
+      }
+    });
+
+  body.actions.map((action) => {
+    const methodAbi = action.functionSignature;
+    const positionalArgs = flattenArgs(action.args);
+
+    const iface = new utils.Interface([methodAbi]);
+
+    try {
+      iface.encodeFunctionData(action.functionName, positionalArgs);
+    } catch (err) {
+      throw new AbiEncodingError(
+        {
+          message: `Failed to encode function data for ${action.functionName}. Arguments may be invalid or mismatched.`,
+        },
+        {
+          cause: `${err instanceof Error ? err.message : String(err)}`,
+        }
+      );
+    }
+  });
 }
 
 export function getApprovalTxns(params: {

--- a/api/swap/_utils.ts
+++ b/api/swap/_utils.ts
@@ -204,7 +204,7 @@ export function handleSwapBody(body: SwapBody) {
       }
     });
 
-  body.actions.map((action) => {
+  body.actions.forEach((action) => {
     const methodAbi = action.functionSignature;
     const positionalArgs = flattenArgs(action.args);
     const iface = new utils.Interface([methodAbi]);

--- a/api/swap/approval/_service.ts
+++ b/api/swap/approval/_service.ts
@@ -7,6 +7,8 @@ import {
   BaseSwapQueryParams,
   getApprovalTxns,
   buildBaseSwapResponseJson,
+  handleSwapBody,
+  SwapBody,
 } from "../_utils";
 import { getBalanceAndAllowance } from "../../_erc20";
 import { getCrossSwapQuotes } from "../../_dexes/cross-swap-service";
@@ -50,7 +52,7 @@ const quoteFetchStrategies: QuoteFetchStrategies = {
 };
 
 export async function handleApprovalSwap(
-  request: TypedVercelRequest<BaseSwapQueryParams>
+  request: TypedVercelRequest<BaseSwapQueryParams, SwapBody>
 ) {
   const {
     integratorId,
@@ -68,6 +70,10 @@ export async function handleApprovalSwap(
     slippageTolerance,
     refundToken,
   } = await handleBaseSwapQueryParams(request.query);
+
+  if (request.body) {
+    handleSwapBody(request.body);
+  }
 
   const crossSwapQuotes = await getCrossSwapQuotes(
     {

--- a/api/swap/approval/index.ts
+++ b/api/swap/approval/index.ts
@@ -3,12 +3,12 @@ import { SpanStatusCode } from "@opentelemetry/api";
 
 import { TypedVercelRequest } from "../../_types";
 import { getLogger, handleErrorCondition } from "../../_utils";
-import { BaseSwapQueryParams } from "../_utils";
+import { BaseSwapQueryParams, SwapBody } from "../_utils";
 import { handleApprovalSwap } from "./_service";
 import { tracer } from "../../../instrumentation";
 
 const handler = async (
-  request: TypedVercelRequest<BaseSwapQueryParams>,
+  request: TypedVercelRequest<BaseSwapQueryParams, SwapBody>,
   response: VercelResponse
 ) => {
   const logger = getLogger();
@@ -19,6 +19,14 @@ const handler = async (
   });
   return tracer.startActiveSpan("swap/approval", async (span) => {
     try {
+      // This handler supports both GET and POST requests.
+      // For GET requests, we expect the body to be empty.
+      // TODO: Allow only POST requests
+      if (request.method !== "POST" && request.body) {
+        throw new Error(
+          "Only POST requests are supported." // Improve wording
+        );
+      }
       const responseJson = await handleApprovalSwap(request);
 
       logger.debug({

--- a/api/swap/approval/index.ts
+++ b/api/swap/approval/index.ts
@@ -2,7 +2,8 @@ import { VercelResponse } from "@vercel/node";
 import { SpanStatusCode } from "@opentelemetry/api";
 
 import { TypedVercelRequest } from "../../_types";
-import { getLogger, handleErrorCondition } from "../../_utils";
+import { getLogger, handleErrorCondition, InputError } from "../../_utils";
+import { AcrossErrorCode } from "../../_errors";
 import { BaseSwapQueryParams, SwapBody } from "../_utils";
 import { handleApprovalSwap } from "./_service";
 import { tracer } from "../../../instrumentation";
@@ -23,9 +24,10 @@ const handler = async (
       // For GET requests, we expect the body to be empty.
       // TODO: Allow only POST requests
       if (request.method !== "POST" && request.body) {
-        throw new Error(
-          "Only POST requests are supported." // Improve wording
-        );
+        throw new InputError({
+          message: "POST method required when request.body is provided",
+          code: AcrossErrorCode.INVALID_METHOD,
+        });
       }
       const responseJson = await handleApprovalSwap(request);
 

--- a/api/swap/index.ts
+++ b/api/swap/index.ts
@@ -1,7 +1,8 @@
 import { VercelResponse } from "@vercel/node";
 
 import { TypedVercelRequest } from "../_types";
-import { getLogger, handleErrorCondition } from "../_utils";
+import { getLogger, handleErrorCondition, InputError } from "../_utils";
+import { AcrossErrorCode } from "../_errors";
 import {
   handleBaseSwapQueryParams,
   BaseSwapQueryParams,
@@ -31,9 +32,10 @@ export default async function handler(
     // For GET requests, we expect the body to be empty.
     // TODO: Allow only POST requests
     if (request.method !== "POST" && request.body) {
-      throw new Error(
-        "Only POST requests are supported." // Improve wording
-      );
+      throw new InputError({
+        message: "POST method required when request.body is provided",
+        code: AcrossErrorCode.INVALID_METHOD,
+      });
     }
 
     // `/swap` only validate shared base params


### PR DESCRIPTION
This PR introduces the schema for the body of /swap* requests. It defines a structured format for describing destination actions, including the contract to call, the function signature, and a list of positional arguments to populate the call with. Each argument is represented as a structured object, allowing callers to indicate whether the value should be populated dynamically at execution time using the balance of a specified token.

The basic structure looks as follows:
```json
{
  "actions": [
    {
      "target": "0x...", // Contract address to call
      "functionSignature": "function transfer(address to, uint256 amount)", // Full function signature
      "args": [ // Positional inputs for the function
        {
          "value": "0x...", // The argument value
          "populateDynamically": false, // Whether to populate this value dynamically at execution
          "balanceSource": "0x..." // Optional: token to use balance of as dynamic input (required if populateDynamically is true)
        }
        // ... more arguments
      ],
      "value": "0" // ETH value to send with the transaction
    }
    // ... more actions
  ]
}
```

By using positional arguments, this schema also supports complex input types such as tuples, nested tuples, etc.

At runtime, arguments are validated by attempting to ABI-encode them using the provided functionSignature. If encoding fails due to a type mismatch or structural inconsistency, an `AbiEncodingError` is thrown.

This ensures accurate mapping between arguments and Solidity types, strong typing for dynamic and nested structures, and early failure for invalid inputs prior to execution.