### PR TITLE
fix: local sdk patch for gas price

### DIFF
--- a/patches/@across-protocol+sdk+4.2.9.patch
+++ b/patches/@across-protocol+sdk+4.2.9.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@across-protocol/sdk/dist/cjs/gasPriceOracle/adapters/ethereum.js b/node_modules/@across-protocol/sdk/dist/cjs/gasPriceOracle/adapters/ethereum.js
+index a3861ca..562b04e 100644
+--- a/node_modules/@across-protocol/sdk/dist/cjs/gasPriceOracle/adapters/ethereum.js
++++ b/node_modules/@across-protocol/sdk/dist/cjs/gasPriceOracle/adapters/ethereum.js
+@@ -15,7 +15,7 @@ function eip1559Raw(provider, chainId, baseFeeMultiplier, priorityFeeMultiplier)
+         return tslib_1.__generator(this, function (_b) {
+             switch (_b.label) {
+                 case 0: return [4, Promise.all([
+-                        provider.getBlock("pending"),
++                        provider.getBlock("latest"),
+                         provider.send("eth_maxPriorityFeePerGas", []),
+                     ])];
+                 case 1:


### PR DESCRIPTION
Local patch until https://github.com/across-protocol/frontend/pull/1643 get merged so we can upgrade to https://github.com/across-protocol/sdk/releases/tag/v4.3.16 which introduces this change