### PR TITLE
feat: resubmission of PR #1661

### DIFF
--- a/api/_dexes/utils.ts
+++ b/api/_dexes/utils.ts
@@ -109,14 +109,14 @@ export function getPreferredBridgeTokens(
   );
 }
 
-export function getCrossSwapType(params: {
+export function getCrossSwapTypes(params: {
   inputToken: string;
   originChainId: number;
   outputToken: string;
   destinationChainId: number;
   isInputNative: boolean;
   isOutputNative: boolean;
-}): CrossSwapType {
+}): CrossSwapType[] {
   if (
     isRouteEnabled(
       params.originChainId,
@@ -125,7 +125,7 @@ export function getCrossSwapType(params: {
       params.outputToken
     )
   ) {
-    return CROSS_SWAP_TYPE.BRIDGEABLE_TO_BRIDGEABLE;
+    return [CROSS_SWAP_TYPE.BRIDGEABLE_TO_BRIDGEABLE];
   }
 
   const inputBridgeable = isInputTokenBridgeable(
@@ -143,7 +143,7 @@ export function getCrossSwapType(params: {
   // `UniversalSwapAndBridge` does not support native tokens as input.
   if (params.isInputNative) {
     if (inputBridgeable) {
-      return CROSS_SWAP_TYPE.BRIDGEABLE_TO_ANY;
+      return [CROSS_SWAP_TYPE.BRIDGEABLE_TO_ANY];
     }
     // We can't bridge native tokens that are not ETH, e.g. MATIC or AZERO. Therefore
     // throw until we have periphery contract audited so that it can accept native
@@ -153,15 +153,22 @@ export function getCrossSwapType(params: {
     );
   }
 
+  if (inputBridgeable && outputBridgeable) {
+    return [
+      CROSS_SWAP_TYPE.ANY_TO_BRIDGEABLE,
+      CROSS_SWAP_TYPE.BRIDGEABLE_TO_ANY,
+    ];
+  }
+
   if (outputBridgeable) {
-    return CROSS_SWAP_TYPE.ANY_TO_BRIDGEABLE;
+    return [CROSS_SWAP_TYPE.ANY_TO_BRIDGEABLE];
   }
 
   if (inputBridgeable) {
-    return CROSS_SWAP_TYPE.BRIDGEABLE_TO_ANY;
+    return [CROSS_SWAP_TYPE.BRIDGEABLE_TO_ANY];
   }
 
-  return CROSS_SWAP_TYPE.ANY_TO_ANY;
+  return [CROSS_SWAP_TYPE.ANY_TO_ANY];
 }
 
 export function buildExactInputBridgeTokenMessage(

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -2850,3 +2850,43 @@ export function addTimeoutToPromise<T>(
   });
   return Promise.race([promise, timeout]);
 }
+
+export function flattenErrors(reason: any, depth: number = 0): string[] {
+  if (
+    reason instanceof AggregateError &&
+    Array.isArray(reason.errors) &&
+    depth < 1
+  ) {
+    return reason.errors.flatMap((error) => flattenErrors(error, depth + 1));
+  }
+  const response = reason.response;
+  if (reason.isAxiosError && response) {
+    const responseData = response.data;
+    const responseMessage =
+      responseData.message ||
+      responseData.detail ||
+      JSON.stringify(responseData);
+    return [
+      `AxiosError: status: ${response.status}, details: ${responseMessage}`,
+    ];
+  }
+  return [`Error: ${JSON.stringify(reason)}`];
+}
+
+export function getRejectedReasons(
+  settledResults: PromiseSettledResult<any>[]
+): string[] {
+  try {
+    return settledResults
+      .map((result, idx) => {
+        if (result.status === "rejected") {
+          const reason = (result as PromiseRejectedResult).reason;
+          return flattenErrors(reason).map((msg) => `Quote ${idx + 1}: ${msg}`);
+        }
+        return [];
+      })
+      .flat();
+  } catch (err) {
+    return [];
+  }
+}

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -2838,3 +2838,15 @@ export const ConvertDecimals = (fromDecimals: number, toDecimals: number) => {
     return amount.mul(BigNumber.from("10").pow(-1 * diff));
   };
 };
+
+export function addTimeoutToPromise<T>(
+  promise: Promise<T>,
+  delay: number
+): Promise<T> {
+  const timeout = new Promise<T>((_, reject) => {
+    setTimeout(() => {
+      reject(new Error("Promise timed out"));
+    }, delay);
+  });
+  return Promise.race([promise, timeout]);
+}

--- a/test/api/_dexes/utils.test.ts
+++ b/test/api/_dexes/utils.test.ts
@@ -1,4 +1,4 @@
-import { getCrossSwapType, CROSS_SWAP_TYPE } from "../../../api/_dexes/utils";
+import { getCrossSwapTypes, CROSS_SWAP_TYPE } from "../../../api/_dexes/utils";
 import { CHAIN_IDs, TOKEN_SYMBOLS_MAP } from "../../../api/_constants";
 
 describe("_dexes/utils", () => {
@@ -12,8 +12,8 @@ describe("_dexes/utils", () => {
         isOutputNative: true,
         isInputNative: false,
       };
-      const crossSwapType = getCrossSwapType(params);
-      expect(crossSwapType).toBe(CROSS_SWAP_TYPE.ANY_TO_BRIDGEABLE);
+      const crossSwapTypes = getCrossSwapTypes(params);
+      expect(crossSwapTypes).toEqual([CROSS_SWAP_TYPE.ANY_TO_BRIDGEABLE]);
     });
 
     test("Lens GHO -> L1 GHO - should return bridgeable-to-any", () => {
@@ -25,8 +25,39 @@ describe("_dexes/utils", () => {
         isOutputNative: false,
         isInputNative: true,
       };
-      const crossSwapType = getCrossSwapType(params);
-      expect(crossSwapType).toBe(CROSS_SWAP_TYPE.BRIDGEABLE_TO_ANY);
+      const crossSwapTypes = getCrossSwapTypes(params);
+      expect(crossSwapTypes).toEqual([CROSS_SWAP_TYPE.BRIDGEABLE_TO_ANY]);
+    });
+
+    test("Optimism USDC -> Arbitrum USDC - should return bridgeable-to-bridgeable", () => {
+      const params = {
+        inputToken: TOKEN_SYMBOLS_MAP.USDC.addresses[CHAIN_IDs.OPTIMISM],
+        originChainId: CHAIN_IDs.OPTIMISM,
+        outputToken: TOKEN_SYMBOLS_MAP.USDC.addresses[CHAIN_IDs.ARBITRUM],
+        destinationChainId: CHAIN_IDs.ARBITRUM,
+        isOutputNative: false,
+        isInputNative: false,
+      };
+      const crossSwapTypes = getCrossSwapTypes(params);
+      expect(crossSwapTypes).toEqual([
+        CROSS_SWAP_TYPE.BRIDGEABLE_TO_BRIDGEABLE,
+      ]);
+    });
+
+    test("Optimism USDC -> Arbitrum ETH - should return any-to-bridgeable and bridgeable-to-any", () => {
+      const params = {
+        inputToken: TOKEN_SYMBOLS_MAP.USDC.addresses[CHAIN_IDs.OPTIMISM],
+        originChainId: CHAIN_IDs.OPTIMISM,
+        outputToken: TOKEN_SYMBOLS_MAP.ETH.addresses[CHAIN_IDs.ARBITRUM],
+        destinationChainId: CHAIN_IDs.ARBITRUM,
+        isOutputNative: false,
+        isInputNative: false,
+      };
+      const crossSwapTypes = getCrossSwapTypes(params);
+      expect(crossSwapTypes).toEqual([
+        CROSS_SWAP_TYPE.ANY_TO_BRIDGEABLE,
+        CROSS_SWAP_TYPE.BRIDGEABLE_TO_ANY,
+      ]);
     });
   });
 });


### PR DESCRIPTION
I had to revert #1661 because of a false alarm. When executing cross swap quotes concurrently using `Promise.all`, the inner exceptions of individual promises are returned as an array of `AggregateError` objects. Also, we were swallowing these exceptions and returning a generic `SwapQuoteUnavailableError` without any cause. Seeing these generic errors without the underlying exception made me think there was a problem with my changes while using the Uniswap strategy. But looking further locally, I was able to successfully reproduce the error and it was actually expected.

The error was that the user was trying to swap too large of an amount from Mainnet USDC to Lens WGHO: `inputToken=0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48&outputToken=0x88F08E304EC4f90D644Cec3Fb69b8aD414acf884&originChainId=1&destinationChainId=232&skipAmountLimit=true&recipient=0xc5939F59b3c9662377DdA53A08D5085b2d52b719&amount=12829237738206715000000000000000000`

In this PR, I resubmitted the original contents but added a function to unwrap the errors from individual promises and return the errors as a formatted string that will get logged in the `cause` field.

For testing, I retried the exact call and now we return some more details in the error and also internally log the inner exceptions in the `cause` field. I also tried some valid scenarios and it looks good.

### What the user sees:
```
{
      type: 'AcrossApiError',
      code: 'SWAP_QUOTE_UNAVAILABLE',
      status: 400,
      message: 'Failed to fetch swap quote: No quotes available for exactInput USDC to WGHO from 1 to 232 for amount 12829237738206715000000000000000000'
}
```

### What we see in the logs:
```
{
    at: 'swap/approval',
    code: 'SWAP_QUOTE_UNAVAILABLE',
    message: 'Status 400 - Failed to fetch swap quote: No quotes available for exactInput USDC to WGHO from 1 to 232 for amount 12829237738206715000000000000000000',
    cause: "Quote 1: AxiosError: status: 404, details: No quotes available, Quote 2: AxiosError: status: 400, details: Relayer Address (0x07aE8551Be970cB1cCa11Dd7a11F47Ae82e70E67) doesn't have enough funds to support this deposit; for help, please reach out to https://discord.across.to"
}
```