### PR TITLE
feat: add support `prioritizationMode` in strategies config

### DIFF
--- a/api/_dexes/cross-swap-service.ts
+++ b/api/_dexes/cross-swap-service.ts
@@ -879,7 +879,7 @@ export async function getCrossSwapQuotesForExactInputByRouteA2A(
     assertSources(originSources);
 
     const destinationSources = result.destinationStrategy.getSources(
-      destinationSwap.chainId,
+      result.destinationSwap.chainId,
       {
         excludeSources: crossSwap.excludeSources,
         includeSources: crossSwap.includeSources,

--- a/api/_dexes/utils.ts
+++ b/api/_dexes/utils.ts
@@ -44,6 +44,15 @@ export type CrossSwapType =
 
 export type AmountType = (typeof AMOUNT_TYPE)[keyof typeof AMOUNT_TYPE];
 
+export type QuoteFetchPrioritizationMode =
+  | {
+      mode: "equal-speed";
+    }
+  | {
+      mode: "priority-speed";
+      priorityChunkSize: number;
+    };
+
 /**
  * Describes which quote fetch strategies to use for a given chain,
  *
@@ -54,6 +63,7 @@ export type AmountType = (typeof AMOUNT_TYPE)[keyof typeof AMOUNT_TYPE];
  * }
  */
 export type QuoteFetchStrategies = Partial<{
+  prioritizationMode: QuoteFetchPrioritizationMode;
   default: QuoteFetchStrategy[];
   chains: {
     [chainId: number]: QuoteFetchStrategy[];
@@ -95,9 +105,13 @@ export const PREFERRED_BRIDGE_TOKENS: {
   },
 };
 
-export const defaultQuoteFetchStrategies: QuoteFetchStrategy[] =
-  // These will be our default strategies until the periphery contract is audited
-  [getSwapRouter02Strategy("UniversalSwapAndBridge")];
+export const defaultQuoteFetchStrategies: QuoteFetchStrategies = {
+  prioritizationMode: {
+    mode: "priority-speed",
+    priorityChunkSize: 1,
+  },
+  default: [getSwapRouter02Strategy("UniversalSwapAndBridge")],
+};
 
 export function getPreferredBridgeTokens(
   fromChainId: number,
@@ -418,7 +432,7 @@ export function getQuoteFetchStrategies(
     strategies.swapPairs?.[chainId]?.[tokenInSymbol]?.[tokenOutSymbol] ??
     strategies.chains?.[chainId] ??
     strategies.default ??
-    defaultQuoteFetchStrategies
+    defaultQuoteFetchStrategies.default!
   );
 }
 

--- a/api/_dexes/utils.ts
+++ b/api/_dexes/utils.ts
@@ -30,6 +30,7 @@ import {
   isOutputTokenBridgeable,
   getSpokePool,
   getSpokePoolAddress,
+  addMarkupToAmount,
 } from "../_utils";
 import {
   getSpokePoolPeripheryAddress,
@@ -680,8 +681,14 @@ export async function estimateInputForExactOutput(
     .mul(inputUnit)
     .div(inputUnitOutputAmount);
 
-  // Add 1% buffer for slippage and rounding
-  return requiredInputAmount.mul(101).div(100).toString();
+  // Consider slippage and add fixed buffer for price discrepancies between the input
+  // unit and the desired output amount
+  const buffer = 0.05; // 5%
+  const adjustedInputAmount = addMarkupToAmount(
+    requiredInputAmount,
+    swap.slippageTolerance / 100 + buffer
+  );
+  return adjustedInputAmount.toString();
 }
 
 export function isValidSource(

--- a/api/swap/_configs.ts
+++ b/api/swap/_configs.ts
@@ -1,0 +1,47 @@
+import { CHAIN_IDs } from "../_constants";
+import { getWrappedGhoStrategy } from "../_dexes/gho/wrapped-gho";
+import { getWghoMulticallStrategy } from "../_dexes/gho/multicall";
+import { getSwapRouter02Strategy } from "../_dexes/uniswap/swap-router-02";
+import { get0xStrategy } from "../_dexes/0x/allowance-holder";
+import { getLifiStrategy } from "../_dexes/lifi/lifi-router";
+
+import { QuoteFetchStrategies } from "../_dexes/utils";
+
+export const quoteFetchStrategies: QuoteFetchStrategies = {
+  prioritizationMode: {
+    mode: "priority-speed",
+    priorityChunkSize: 1,
+  },
+  default: [
+    get0xStrategy("SpokePoolPeriphery"),
+    getLifiStrategy("SpokePoolPeriphery"),
+    getSwapRouter02Strategy("UniversalSwapAndBridge", "trading-api"),
+  ],
+  chains: {
+    [CHAIN_IDs.LENS]: [
+      getSwapRouter02Strategy("UniversalSwapAndBridge", "sdk-swap-quoter"),
+    ],
+  },
+  swapPairs: {
+    [CHAIN_IDs.MAINNET]: {
+      GHO: {
+        WGHO: [getWrappedGhoStrategy()],
+      },
+      WGHO: {
+        GHO: [getWrappedGhoStrategy()],
+        USDC: [getWrappedGhoStrategy()],
+        USDT: [getWrappedGhoStrategy()],
+        DAI: [getWrappedGhoStrategy()],
+      },
+      USDC: {
+        WGHO: [getWghoMulticallStrategy()],
+      },
+      USDT: {
+        WGHO: [getWghoMulticallStrategy()],
+      },
+      DAI: {
+        WGHO: [getWghoMulticallStrategy()],
+      },
+    },
+  },
+};

--- a/api/swap/approval/_service.ts
+++ b/api/swap/approval/_service.ts
@@ -18,46 +18,12 @@ import {
 } from "../_utils";
 import { getBalanceAndAllowance } from "../../_erc20";
 import { getCrossSwapQuotes } from "../../_dexes/cross-swap-service";
-import { inferCrossSwapType, QuoteFetchStrategies } from "../../_dexes/utils";
+import { inferCrossSwapType } from "../../_dexes/utils";
+import { quoteFetchStrategies } from "../_configs";
 import { TypedVercelRequest } from "../../_types";
-import { getSwapRouter02Strategy } from "../../_dexes/uniswap/swap-router-02";
-import { CHAIN_IDs } from "../../_constants";
-import { getWrappedGhoStrategy } from "../../_dexes/gho/wrapped-gho";
-import { getWghoMulticallStrategy } from "../../_dexes/gho/multicall";
 import { AcrossErrorCode } from "../../_errors";
 
 const logger = getLogger();
-
-const quoteFetchStrategies: QuoteFetchStrategies = {
-  default: [getSwapRouter02Strategy("UniversalSwapAndBridge", "trading-api")],
-  chains: {
-    [CHAIN_IDs.LENS]: [
-      getSwapRouter02Strategy("UniversalSwapAndBridge", "sdk-swap-quoter"),
-    ],
-  },
-  swapPairs: {
-    [CHAIN_IDs.MAINNET]: {
-      GHO: {
-        WGHO: [getWrappedGhoStrategy()],
-      },
-      WGHO: {
-        GHO: [getWrappedGhoStrategy()],
-        USDC: [getWrappedGhoStrategy()],
-        USDT: [getWrappedGhoStrategy()],
-        DAI: [getWrappedGhoStrategy()],
-      },
-      USDC: {
-        WGHO: [getWghoMulticallStrategy()],
-      },
-      USDT: {
-        WGHO: [getWghoMulticallStrategy()],
-      },
-      DAI: {
-        WGHO: [getWghoMulticallStrategy()],
-      },
-    },
-  },
-};
 
 export async function handleApprovalSwap(
   request: TypedVercelRequest<BaseSwapQueryParams, SwapBody>,

--- a/test/api/_dexes/cross-swap-service.test.ts
+++ b/test/api/_dexes/cross-swap-service.test.ts
@@ -54,15 +54,18 @@ describe("#executeStrategies()", () => {
 
     it("should return the first successful result when all promises succeed", async () => {
       const results = [
-        new Promise((resolve) =>
-          setTimeout(() => resolve({ id: 1, data: "first" }), 10)
-        ),
-        new Promise((resolve) =>
-          setTimeout(() => resolve({ id: 2, data: "second" }), 20)
-        ),
-        new Promise((resolve) =>
-          setTimeout(() => resolve({ id: 3, data: "third" }), 30)
-        ),
+        () =>
+          new Promise((resolve) =>
+            setTimeout(() => resolve({ id: 1, data: "first" }), 10)
+          ),
+        () =>
+          new Promise((resolve) =>
+            setTimeout(() => resolve({ id: 2, data: "second" }), 20)
+          ),
+        () =>
+          new Promise((resolve) =>
+            setTimeout(() => resolve({ id: 3, data: "third" }), 30)
+          ),
       ];
 
       const result = await executeStrategies(results, equalSpeedMode);
@@ -78,9 +81,9 @@ describe("#executeStrategies()", () => {
 
     it("should return first successful result when some promises fail", async () => {
       const results = [
-        Promise.reject(new Error("First failed")),
-        Promise.resolve({ id: 2, data: "success" }),
-        Promise.reject(new Error("Third failed")),
+        () => Promise.reject(new Error("First failed")),
+        () => Promise.resolve({ id: 2, data: "success" }),
+        () => Promise.reject(new Error("Third failed")),
       ];
 
       const result = await executeStrategies(results, equalSpeedMode);
@@ -89,14 +92,16 @@ describe("#executeStrategies()", () => {
 
     it("should throw SwapQuoteUnavailableError when all promises fail with it", async () => {
       const results = [
-        Promise.reject(
-          new SwapQuoteUnavailableError({
-            message: "No quotes available",
-          })
-        ),
-        Promise.reject(
-          new SwapQuoteUnavailableError({ message: "Also no quotes" })
-        ),
+        () =>
+          Promise.reject(
+            new SwapQuoteUnavailableError({
+              message: "No quotes available",
+            })
+          ),
+        () =>
+          Promise.reject(
+            new SwapQuoteUnavailableError({ message: "Also no quotes" })
+          ),
       ];
 
       await expect(executeStrategies(results, equalSpeedMode)).rejects.toThrow(
@@ -115,8 +120,8 @@ describe("#executeStrategies()", () => {
       });
 
       const results = [
-        Promise.reject(invalidParamError1),
-        Promise.reject(invalidParamError2),
+        () => Promise.reject(invalidParamError1),
+        () => Promise.reject(invalidParamError2),
       ];
 
       await expect(executeStrategies(results, equalSpeedMode)).rejects.toThrow(
@@ -126,13 +131,14 @@ describe("#executeStrategies()", () => {
 
     it("should prioritize SwapQuoteUnavailableError over other errors", async () => {
       const results = [
-        Promise.reject(
-          new SwapQuoteUnavailableError({
-            message: "No quotes available",
-          })
-        ),
-        Promise.reject(new Error("Some other error")),
-        Promise.reject(new Error("Another error")),
+        () =>
+          Promise.reject(
+            new SwapQuoteUnavailableError({
+              message: "No quotes available",
+            })
+          ),
+        () => Promise.reject(new Error("Some other error")),
+        () => Promise.reject(new Error("Another error")),
       ];
 
       await expect(executeStrategies(results, equalSpeedMode)).rejects.toThrow(
@@ -142,8 +148,8 @@ describe("#executeStrategies()", () => {
 
     it("should throw generic error when no specific error patterns match", async () => {
       const results = [
-        Promise.reject(new Error("Generic error")),
-        Promise.reject(new Error("Another generic error")),
+        () => Promise.reject(new Error("Generic error")),
+        () => Promise.reject(new Error("Another generic error")),
       ];
 
       await expect(
@@ -160,15 +166,18 @@ describe("#executeStrategies()", () => {
       };
 
       const results = [
-        new Promise((resolve) =>
-          setTimeout(() => resolve({ id: 1, data: "first-chunk-1" }), 10)
-        ),
-        new Promise((resolve) =>
-          setTimeout(() => resolve({ id: 2, data: "first-chunk-2" }), 20)
-        ),
-        new Promise((resolve) =>
-          setTimeout(() => resolve({ id: 3, data: "second-chunk-1" }), 30)
-        ),
+        () =>
+          new Promise((resolve) =>
+            setTimeout(() => resolve({ id: 1, data: "first-chunk-1" }), 10)
+          ),
+        () =>
+          new Promise((resolve) =>
+            setTimeout(() => resolve({ id: 2, data: "first-chunk-2" }), 20)
+          ),
+        () =>
+          new Promise((resolve) =>
+            setTimeout(() => resolve({ id: 3, data: "second-chunk-1" }), 30)
+          ),
       ];
 
       const result = await executeStrategies(results, priorityMode);
@@ -184,17 +193,22 @@ describe("#executeStrategies()", () => {
       };
 
       const results = [
-        Promise.reject(new Error("First chunk failed 1")),
-        Promise.reject(new Error("First chunk failed 2")),
-        new Promise((resolve) =>
-          setTimeout(() => resolve({ id: 3, data: "second-chunk-success" }), 10)
-        ),
-        new Promise((resolve) =>
-          setTimeout(
-            () => resolve({ id: 4, data: "second-chunk-success-2" }),
-            20
-          )
-        ),
+        () => Promise.reject(new Error("First chunk failed 1")),
+        () => Promise.reject(new Error("First chunk failed 2")),
+        () =>
+          new Promise((resolve) =>
+            setTimeout(
+              () => resolve({ id: 3, data: "second-chunk-success" }),
+              10
+            )
+          ),
+        () =>
+          new Promise((resolve) =>
+            setTimeout(
+              () => resolve({ id: 4, data: "second-chunk-success-2" }),
+              20
+            )
+          ),
       ];
 
       const result = await executeStrategies(results, priorityMode);
@@ -208,8 +222,8 @@ describe("#executeStrategies()", () => {
       };
 
       const results = [
-        Promise.resolve({ id: 1, data: "success" }),
-        Promise.resolve({ id: 2, data: "success2" }),
+        () => Promise.resolve({ id: 1, data: "success" }),
+        () => Promise.resolve({ id: 2, data: "success2" }),
       ];
 
       const result = await executeStrategies(results, priorityMode);
@@ -223,9 +237,9 @@ describe("#executeStrategies()", () => {
       };
 
       const results = [
-        Promise.reject(new Error("Chunk 1 failed")),
-        Promise.reject(new Error("Chunk 2 failed")),
-        Promise.resolve({ id: 3, data: "chunk-3-success" }),
+        () => Promise.reject(new Error("Chunk 1 failed")),
+        () => Promise.reject(new Error("Chunk 2 failed")),
+        () => Promise.resolve({ id: 3, data: "chunk-3-success" }),
       ];
 
       const result = await executeStrategies(results, priorityMode);
@@ -239,13 +253,14 @@ describe("#executeStrategies()", () => {
       };
 
       const results = [
-        Promise.reject(new Error("First error")),
-        Promise.reject(
-          new SwapQuoteUnavailableError({
-            message: "No quotes available",
-          })
-        ),
-        Promise.reject(new Error("Third error")),
+        () => Promise.reject(new Error("First error")),
+        () =>
+          Promise.reject(
+            new SwapQuoteUnavailableError({
+              message: "No quotes available",
+            })
+          ),
+        () => Promise.reject(new Error("Third error")),
       ];
 
       await expect(executeStrategies(results, priorityMode)).rejects.toThrow(
@@ -260,15 +275,20 @@ describe("#executeStrategies()", () => {
       };
 
       const results = [
-        Promise.reject(
-          new InvalidParamError({
-            message: "Invalid sources",
-            param: "excludeSources",
-          })
-        ),
-        Promise.reject(
-          new InvalidParamError({ message: "Invalid", param: "includeSources" })
-        ),
+        () =>
+          Promise.reject(
+            new InvalidParamError({
+              message: "Invalid sources",
+              param: "excludeSources",
+            })
+          ),
+        () =>
+          Promise.reject(
+            new InvalidParamError({
+              message: "Invalid",
+              param: "includeSources",
+            })
+          ),
       ];
 
       await expect(executeStrategies(results, priorityMode)).rejects.toThrow(

--- a/test/api/_dexes/cross-swap-service.test.ts
+++ b/test/api/_dexes/cross-swap-service.test.ts
@@ -1,0 +1,279 @@
+import { executeStrategies } from "../../../api/_dexes/cross-swap-service";
+import {
+  SwapQuoteUnavailableError,
+  InvalidParamError,
+} from "../../../api/_errors";
+
+// format the following
+jest.mock("../../../api/_utils", () => ({
+  getBridgeQuoteForMinOutput: jest.fn(),
+  getRouteByInputTokenAndDestinationChain: jest.fn(),
+  getRouteByOutputTokenAndOriginChain: jest.fn(),
+  getRoutesByChainIds: jest.fn(),
+  getTokenByAddress: jest.fn(),
+  getBridgeQuoteForExactInput: jest.fn(),
+  addTimeoutToPromise: jest.fn(),
+  getRejectedReasons: jest.fn(),
+  getLogger: jest.fn(() => ({ debug: jest.fn() })),
+}));
+
+jest.mock("../../../api/_dexes/utils", () => ({
+  buildExactInputBridgeTokenMessage: jest.fn(),
+  buildExactOutputBridgeTokenMessage: jest.fn(),
+  buildMinOutputBridgeTokenMessage: jest.fn(),
+  getCrossSwapTypes: jest.fn(),
+  getPreferredBridgeTokens: jest.fn(),
+  getQuoteFetchStrategies: jest.fn(),
+  defaultQuoteFetchStrategies: {},
+  AMOUNT_TYPE: {
+    EXACT_INPUT: "exactInput",
+    EXACT_OUTPUT: "exactOutput",
+    MIN_OUTPUT: "minOutput",
+  },
+  CROSS_SWAP_TYPE: {
+    BRIDGEABLE_TO_BRIDGEABLE: "bridgeableTobridgeable",
+    BRIDGEABLE_TO_ANY: "bridgeableToAny",
+    ANY_TO_BRIDGEABLE: "anyToBridgeable",
+    ANY_TO_ANY: "anyToAny",
+  },
+  buildDestinationSwapCrossChainMessage: jest.fn(),
+  assertMinOutputAmount: jest.fn(),
+}));
+
+jest.mock("../../../api/_multicall-handler", () => ({
+  getMultiCallHandlerAddress: jest.fn(),
+}));
+
+describe("#executeStrategies()", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("equal-speed mode", () => {
+    const equalSpeedMode = { mode: "equal-speed" as const };
+
+    it("should return the first successful result when all promises succeed", async () => {
+      const results = [
+        new Promise((resolve) =>
+          setTimeout(() => resolve({ id: 1, data: "first" }), 10)
+        ),
+        new Promise((resolve) =>
+          setTimeout(() => resolve({ id: 2, data: "second" }), 20)
+        ),
+        new Promise((resolve) =>
+          setTimeout(() => resolve({ id: 3, data: "third" }), 30)
+        ),
+      ];
+
+      const result = await executeStrategies(results, equalSpeedMode);
+
+      // Should return one of the results (first to resolve)
+      expect(result).toEqual(
+        expect.objectContaining({
+          id: 1,
+          data: "first",
+        })
+      );
+    });
+
+    it("should return first successful result when some promises fail", async () => {
+      const results = [
+        Promise.reject(new Error("First failed")),
+        Promise.resolve({ id: 2, data: "success" }),
+        Promise.reject(new Error("Third failed")),
+      ];
+
+      const result = await executeStrategies(results, equalSpeedMode);
+      expect(result).toEqual({ id: 2, data: "success" });
+    });
+
+    it("should throw SwapQuoteUnavailableError when all promises fail with it", async () => {
+      const results = [
+        Promise.reject(
+          new SwapQuoteUnavailableError({
+            message: "No quotes available",
+          })
+        ),
+        Promise.reject(
+          new SwapQuoteUnavailableError({ message: "Also no quotes" })
+        ),
+      ];
+
+      await expect(executeStrategies(results, equalSpeedMode)).rejects.toThrow(
+        SwapQuoteUnavailableError
+      );
+    });
+
+    it("should throw InvalidParamError when all promises fail with excludeSources/includeSources errors", async () => {
+      const invalidParamError1 = new InvalidParamError({
+        message: "Invalid excludeSources",
+        param: "excludeSources",
+      });
+      const invalidParamError2 = new InvalidParamError({
+        message: "Invalid includeSources",
+        param: "includeSources",
+      });
+
+      const results = [
+        Promise.reject(invalidParamError1),
+        Promise.reject(invalidParamError2),
+      ];
+
+      await expect(executeStrategies(results, equalSpeedMode)).rejects.toThrow(
+        InvalidParamError
+      );
+    });
+
+    it("should prioritize SwapQuoteUnavailableError over other errors", async () => {
+      const results = [
+        Promise.reject(
+          new SwapQuoteUnavailableError({
+            message: "No quotes available",
+          })
+        ),
+        Promise.reject(new Error("Some other error")),
+        Promise.reject(new Error("Another error")),
+      ];
+
+      await expect(executeStrategies(results, equalSpeedMode)).rejects.toThrow(
+        SwapQuoteUnavailableError
+      );
+    });
+
+    it("should throw generic error when no specific error patterns match", async () => {
+      const results = [
+        Promise.reject(new Error("Generic error")),
+        Promise.reject(new Error("Another generic error")),
+      ];
+
+      await expect(
+        executeStrategies(results, equalSpeedMode)
+      ).rejects.toThrow();
+    });
+  });
+
+  describe("priority-speed mode", () => {
+    it("should return result from first chunk when it succeeds", async () => {
+      const priorityMode = {
+        mode: "priority-speed" as const,
+        priorityChunkSize: 2,
+      };
+
+      const results = [
+        new Promise((resolve) =>
+          setTimeout(() => resolve({ id: 1, data: "first-chunk-1" }), 10)
+        ),
+        new Promise((resolve) =>
+          setTimeout(() => resolve({ id: 2, data: "first-chunk-2" }), 20)
+        ),
+        new Promise((resolve) =>
+          setTimeout(() => resolve({ id: 3, data: "second-chunk-1" }), 30)
+        ),
+      ];
+
+      const result = await executeStrategies(results, priorityMode);
+
+      // Should return result from first chunk
+      expect(result).toEqual({ id: 1, data: "first-chunk-1" });
+    });
+
+    it("should move to next chunk when first chunk fails completely", async () => {
+      const priorityMode = {
+        mode: "priority-speed" as const,
+        priorityChunkSize: 2,
+      };
+
+      const results = [
+        Promise.reject(new Error("First chunk failed 1")),
+        Promise.reject(new Error("First chunk failed 2")),
+        new Promise((resolve) =>
+          setTimeout(() => resolve({ id: 3, data: "second-chunk-success" }), 10)
+        ),
+        new Promise((resolve) =>
+          setTimeout(
+            () => resolve({ id: 4, data: "second-chunk-success-2" }),
+            20
+          )
+        ),
+      ];
+
+      const result = await executeStrategies(results, priorityMode);
+      expect(result).toEqual({ id: 3, data: "second-chunk-success" });
+    });
+
+    it("should handle chunks correctly when priority chunk size is larger than array", async () => {
+      const priorityMode = {
+        mode: "priority-speed" as const,
+        priorityChunkSize: 10,
+      };
+
+      const results = [
+        Promise.resolve({ id: 1, data: "success" }),
+        Promise.resolve({ id: 2, data: "success2" }),
+      ];
+
+      const result = await executeStrategies(results, priorityMode);
+      expect([1, 2]).toContain(result.id);
+    });
+
+    it("should process multiple chunks in sequence", async () => {
+      const priorityMode = {
+        mode: "priority-speed" as const,
+        priorityChunkSize: 1,
+      };
+
+      const results = [
+        Promise.reject(new Error("Chunk 1 failed")),
+        Promise.reject(new Error("Chunk 2 failed")),
+        Promise.resolve({ id: 3, data: "chunk-3-success" }),
+      ];
+
+      const result = await executeStrategies(results, priorityMode);
+      expect(result).toEqual({ id: 3, data: "chunk-3-success" });
+    });
+
+    it("should aggregate errors correctly when all chunks fail", async () => {
+      const priorityMode = {
+        mode: "priority-speed" as const,
+        priorityChunkSize: 1,
+      };
+
+      const results = [
+        Promise.reject(new Error("First error")),
+        Promise.reject(
+          new SwapQuoteUnavailableError({
+            message: "No quotes available",
+          })
+        ),
+        Promise.reject(new Error("Third error")),
+      ];
+
+      await expect(executeStrategies(results, priorityMode)).rejects.toThrow(
+        SwapQuoteUnavailableError
+      );
+    });
+
+    it("should handle mixed error types in priority mode", async () => {
+      const priorityMode = {
+        mode: "priority-speed" as const,
+        priorityChunkSize: 2,
+      };
+
+      const results = [
+        Promise.reject(
+          new InvalidParamError({
+            message: "Invalid sources",
+            param: "excludeSources",
+          })
+        ),
+        Promise.reject(
+          new InvalidParamError({ message: "Invalid", param: "includeSources" })
+        ),
+      ];
+
+      await expect(executeStrategies(results, priorityMode)).rejects.toThrow(
+        InvalidParamError
+      );
+    });
+  });
+});


### PR DESCRIPTION
Closes ACX-4236

We can now configure a `prioritizationMode` which is used to determine the prioritized strategy. Currently it supports
- `equal-speed` - Executes all strategy fetches in parallel and returns the first one that completes.
- `priority-speed` - Executes the first `priorityChunkSize` strategy fetches in parallel and returns the first one that completes. If all of the first `priorityChunkSize` strategy fetches fail, the remaining strategy fetches are executed in parallel, and the first one that completes is returned.
