### PR TITLE
feat: support native balance injection for embedded actions

### DIFF
--- a/api/swap/_utils.ts
+++ b/api/swap/_utils.ts
@@ -178,7 +178,7 @@ export async function handleBaseSwapQueryParams(
 const ActionArg = refine(
   object({
     value: unknown(), // Will be validated at runtime
-    populateDynamically: boolean(),
+    populateDynamically: optional(boolean()),
     balanceSource: optional(validEvmAddress()),
   }),
   "balanceSource",

--- a/scripts/tests/_swap-utils.ts
+++ b/scripts/tests/_swap-utils.ts
@@ -229,7 +229,7 @@ export async function fetchSwapQuotes() {
         : undefined;
       console.log("Test case:", testCase.labels.join(" "));
       console.log("Params:", testCase.params);
-      console.log("Body:", body);
+      console.log("Body:", JSON.stringify(body, null, 2));
       const response = await axios.post(
         `${SWAP_API_BASE_URL}/api/swap${slug ? `/${slug}` : ""}`,
         body,
@@ -362,8 +362,8 @@ export async function getNativeDestinationAction(testCase: {
             { value: 0, populateDynamically: false },
           ],
           value: "0", // Will be populated dynamically
-          isNativeTransfer: "false",
-          populateCallValueDynamically: "true",
+          isNativeTransfer: false,
+          populateCallValueDynamically: true,
         },
       ],
     };
@@ -376,9 +376,8 @@ export async function getNativeDestinationAction(testCase: {
           target: ACROSS_DEV_WALLET_2,
           functionSignature: "",
           args: [],
-          value: "0",
-          populateCallValueDynamically: "true",
-          isNativeTransfer: "true",
+          populateCallValueDynamically: true,
+          isNativeTransfer: true,
         },
       ],
     };

--- a/scripts/tests/_swap-utils.ts
+++ b/scripts/tests/_swap-utils.ts
@@ -357,12 +357,10 @@ export async function getNativeDestinationAction(testCase: {
           functionSignature:
             "function depositETH(address, address onBehalfOf, uint16 referralCode)",
           args: [
-            { value: ethers.constants.AddressZero, populateDynamically: false },
-            { value: ACROSS_DEV_WALLET_2, populateDynamically: false },
-            { value: 0, populateDynamically: false },
+            { value: ethers.constants.AddressZero },
+            { value: ACROSS_DEV_WALLET_2 },
+            { value: 0 },
           ],
-          value: "0", // Will be populated dynamically
-          isNativeTransfer: false,
           populateCallValueDynamically: true,
         },
       ],
@@ -397,7 +395,7 @@ export async function getERC20DestinationAction(testCase: {
         target: testCase.params.outputToken,
         functionSignature: "function transfer(address to, uint256 value)",
         args: [
-          { value: ACROSS_DEV_WALLET_2, populateDynamically: false },
+          { value: ACROSS_DEV_WALLET_2 },
           {
             value: testCase.params.amount,
             populateDynamically: true,


### PR DESCRIPTION
This PR adds support for injecting native token balances when executing destination actions.

(All examples below are A2B transactions with tradeType = EXACT_INPUT)

The following scenarios are supported:

1. **Contract call requiring both msg.value and a dynamically populated argument:**
 This case works exactly the same as ERC20 balance injection. Callers must use the zero address as the `balanceSource` to indicate that the native balance should be used. That will replace both the msg.value and the specified argument.
 
     Example: Providing liquidity to our HubPool (requires both msg.value and balance as argument):
Deposit: [0x92d5272b021769f342366dc88b26b7fbee8ecdc5abc8a454a8d85584a32be55c](https://optimistic.etherscan.io/tx/0x92d5272b021769f342366dc88b26b7fbee8ecdc5abc8a454a8d85584a32be55c)
Fill: [0x1e3c35689fe327d1741c34dd1297461a904d93d8043d963748fc7c48571eb718](https://etherscan.io/tx/0x1e3c35689fe327d1741c34dd1297461a904d93d8043d963748fc7c48571eb718)

     Request body:

```
{
  "actions": [
        {
           target: "0xc186fA914353c44b2E33eBE05f21846F1048bEda",
           functionSignature: "function addLiquidity(address l1Token, uint256 l1TokenAmount)",
           args: [
             { value: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", populateDynamically: false },
             { value: "0", populateDynamically: true, balanceSource: ethers.constants.AddressZero },
           ],
           value: "0",
           isNativeTransfer: "false",
           populateCallValueDynamically: "false",
         }
       ]
}
```


2. **Contract call requiring only msg.value to be populated dynamically:**
 Since the current version of the MulticallHandler always overwrites part of the calldata, we use a workaround:
we append 32 zeroed bytes to the end of the calldata to execute and set the replacement instruction to target those bytes. The replacement uses the zero address as the balance source, which both injects the native balance and sets msg.value.
Because the extra bytes lie beyond the actual arguments, they are ignored during execution, preserving expected behavior in the target contract.

    Example: Providing ETH liquidity into Aave (requires only msg.value):
Deposit: [0xedd9e3c7e637930af7d89678aa6bd37f26b8e35d595178052fde4c6ce35608d2](https://optimistic.etherscan.io/tx/0xedd9e3c7e637930af7d89678aa6bd37f26b8e35d595178052fde4c6ce35608d2)
Fill: [0xbe43068d91b2576203632e188503d14e8754a011d608d1fd21dc210cd3154291](https://arbiscan.io/tx/0xbe43068d91b2576203632e188503d14e8754a011d608d1fd21dc210cd3154291)

     Request body:
```
{
  "actions": [
    {
      "target": "0x5283BEcEd7ADF6D003225C13896E536f2D4264FF",
      "functionSignature": "function depositETH(address, address onBehalfOf, uint16 referralCode)",
      "args": [
        {
          "value": "0x0000000000000000000000000000000000000000",
          "populateDynamically": false
        },
        {
          "value": "0x718648C8c531F91b528A7757dD2bE813c3940608",
          "populateDynamically": false
        },
        {
          "value": 0,
          "populateDynamically": false
        }
      ],
      "value": "0",
      "isNativeTransfer": "false",
      "populateCallValueDynamically": "true"
    }
  ]
}
```

3. **Simple native transfer with dynamically populated msg.value:**
We use `drainLeftoverTokens` call to transfer full native balance to the target address.

    Example:
     Deposit: [0x3242aece2979c2d14ccc45e8990632fa80b7fe3e550d7d50d5fbda28d454e1e2](https://optimistic.etherscan.io/tx/0x3242aece2979c2d14ccc45e8990632fa80b7fe3e550d7d50d5fbda28d454e1e2)
     Fill: [0x3d4cd31e628a4aa28d00c9000a596f066e1e28dac055b67e60c5cf7e38b71bfa](https://arbiscan.io/tx/0x3d4cd31e628a4aa28d00c9000a596f066e1e28dac055b67e60c5cf7e38b71bfa)

    Request body:
```
  {
      actions: [
        {
          target: "0x718648C8c531F91b528A7757dD2bE813c3940608",
          functionSignature: "",
          args: [],
          value: "0",
          populateCallValueDynamically: "true",
          isNativeTransfer: "true",
        },
      ],
    }
```






