### PR TITLE
fix: add drain call for destination swaps with embedded actions

### DIFF
--- a/api/_dexes/utils.ts
+++ b/api/_dexes/utils.ts
@@ -645,6 +645,20 @@ export function buildDestinationSwapCrossChainMessage({
         ),
         value: "0",
       },
+      // drain remaining swap output tokens from MultiCallHandler contract
+      // (only needed when there's embedded actions, otherwise the drain call is already part of transferActions)
+      ...(embeddedActions.length > 0
+        ? [
+            {
+              target: getMultiCallHandlerAddress(destinationSwapChainId),
+              callData: encodeDrainCalldata(
+                crossSwap.outputToken.address,
+                crossSwap.refundAddress ?? crossSwap.depositor
+              ),
+              value: "0",
+            },
+          ]
+        : []),
     ],
   });
 }


### PR DESCRIPTION
We were missing a drain call to send leftover tokens from the destination swap when embedded actions were included.

For example, in [this transaction](https://explorer.lens.xyz/tx/0xca1f8672a2b8fd732c5073dd27fa509b4431d64ef01cee9827939311594a0680) we received 0.996 WGHO after the swap, we unwrapped only 0.987 GHO (which matches swap.minOutputAmount). Then we execute actions with the 0.987 GHO and the difference was left in the MulticallHandler.

After the fix, this is how the transaction looks like: https://explorer.lens.xyz/tx/0x6389c1eb7360076a4af648e402bef9a15ca2e7611d6341806230ccdf53627a8e
You can see the leftover WGHO tokens are sent to the fallback recipient.