### PR TITLE
feat: use `sellEntireBalance` for A2A swaps

### DIFF
--- a/api/_dexes/0x/allowance-holder.ts
+++ b/api/_dexes/0x/allowance-holder.ts
@@ -96,6 +96,7 @@ export function get0xStrategy(
             sellAmount: swapAmount,
             taker: swap.recipient,
             slippageBps: Math.floor(swap.slippageTolerance * 100),
+            sellEntireBalance: opts?.sellEntireBalance,
             ...sourcesParams,
           },
         }

--- a/api/_dexes/types.ts
+++ b/api/_dexes/types.ts
@@ -164,6 +164,7 @@ export type QuoteFetchFn = (
 export type QuoteFetchOpts = Partial<{
   useIndicativeQuote: boolean;
   sources?: ReturnType<GetSourcesFn>;
+  sellEntireBalance?: boolean;
 }>;
 
 export type OriginEntryPointContractName =


### PR DESCRIPTION
This PR adds support for 0x `sellEntireBalance` flag when origin + destination swaps are required.
Closes ACX-4244

#### Test txns for USDC.e -> AAVE
MIN_OUTPUT with `3000000000000000`
- [deposit](https://optimistic.etherscan.io/tx/0x08b36ccedd40298fe4ebb9b24e89ad3350338639de1457a9f705b2dbf05e0fbd)
- [fill](https://arbiscan.io/tx/0x168c8d84835594712d3db48fd57a3b6a681ea603a1c39cbfbc0418e83f6b4425)

EXACT_INPUT with `1000000`
- [deposit](https://optimistic.etherscan.io/tx/0x026fa6a5313bb2c5ef9be87d9b1b99c0e1bddaeb68dfdf9ffc0d3b726ee1c854)
- [fill](https://arbiscan.io/tx/0x0b4d3dcaf2d39b2f1d39896e8b81683f6d26e0c91b01105953b61fd64852d128)