### PR TITLE
chore: add app fee options to swap quote script

### DIFF
--- a/scripts/tests/swap-quotes.ts
+++ b/scripts/tests/swap-quotes.ts
@@ -34,6 +34,8 @@ type SwapQuoteResult = {
   outputTokenSymbol: string;
   amount: string;
   tradeType: string;
+  appFeeRecipient?: string;
+  appFeePercent?: string;
   success: boolean;
   data?: any;
   error?: any;
@@ -101,7 +103,18 @@ const argsFromCli = yargs(hideBin(process.argv))
     default: "exactInput",
     type: "string",
   })
+  .option("appFeeRecipient", {
+    alias: "afr",
+    description: "App fee recipient address",
+    type: "string",
+  })
+  .option("appFeePercent", {
+    alias: "afp",
+    description: "App fee percentage (0-1, e.g., 0.01 for 1%)",
+    type: "string",
+  })
   .help()
+  .strict()
   .parseSync();
 
 async function fetchSupportedChains(baseUrl: string): Promise<Chain[]> {
@@ -126,6 +139,8 @@ async function fetchSwapQuote(
     amount: string;
     depositor: string;
     tradeType: string;
+    appFeeRecipient?: string;
+    appFeePercent?: string;
   }
 ): Promise<any> {
   const response = await axios.get(`${baseUrl}/api/swap/approval`, {
@@ -190,6 +205,8 @@ async function main() {
     amount,
     depositor,
     tradeType,
+    appFeeRecipient,
+    appFeePercent,
   } = argsFromCli;
 
   console.log(`Starting swap quotes test with host: ${host}`);
@@ -202,6 +219,8 @@ async function main() {
   console.log(`Max tokens: ${maxTokens}`);
   console.log(`Amount: ${amount}`);
   console.log(`Trade type: ${tradeType}`);
+  console.log(`App fee recipient: ${appFeeRecipient || "none"}`);
+  console.log(`App fee percent: ${appFeePercent || "none"}`);
   console.log("\n");
 
   try {
@@ -314,6 +333,11 @@ async function main() {
                 amount: normalizedAmount,
                 depositor,
                 tradeType,
+                ...(appFeeRecipient &&
+                  appFeePercent && {
+                    appFeeRecipient,
+                    appFeePercent,
+                  }),
               };
 
               const quoteData = await fetchSwapQuote(host, quoteParams);
@@ -327,6 +351,8 @@ async function main() {
                 outputTokenSymbol: outputToken.symbol,
                 amount: normalizedAmount,
                 tradeType,
+                appFeeRecipient,
+                appFeePercent,
                 success: true,
                 data: quoteData,
               });
@@ -345,6 +371,8 @@ async function main() {
                 outputTokenSymbol: outputToken.symbol,
                 amount: normalizedAmount,
                 tradeType,
+                appFeeRecipient,
+                appFeePercent,
                 success: false,
                 error: {
                   message: error.message || "Unknown error",


### PR DESCRIPTION
It will be useful to have app fees be a part of the new swap quote script for easier testing:

- Add new options and append them to params
- Make `yargs` use strict mode so typos/mistakes in arguments and options will be caught