### PR TITLE
feat: more robust swap fees resolving

### DIFF
--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -955,7 +955,8 @@ export const getCachedTokenPrice = async (
   l1Token: string,
   baseCurrency: string = "eth",
   historicalDateISO?: string,
-  chainId?: number
+  chainId?: number,
+  fallbackResolver?: string
 ): Promise<number> => {
   return Number(
     (
@@ -965,6 +966,7 @@ export const getCachedTokenPrice = async (
           chainId,
           baseCurrency,
           date: historicalDateISO,
+          fallbackResolver,
         },
         headers: getVercelHeaders(),
       })

--- a/api/coingecko.ts
+++ b/api/coingecko.ts
@@ -1,6 +1,9 @@
 import { VercelResponse } from "@vercel/node";
 import { ethers } from "ethers";
-import { Infer, optional, string, pattern, type } from "superstruct";
+import { Infer, optional, string, pattern, type, enums } from "superstruct";
+import { coingecko, utils } from "@across-protocol/sdk";
+import axios from "axios";
+
 import { TypedVercelRequest } from "./_types";
 import {
   getLogger,
@@ -18,14 +21,13 @@ import {
   TOKEN_SYMBOLS_MAP,
   coinGeckoAssetPlatformLookup,
 } from "./_constants";
-import { InvalidParamError } from "./_errors";
+import { compactAxiosError, InvalidParamError } from "./_errors";
 import { isEvmAddress } from "./_address";
-
-import { coingecko, utils } from "@across-protocol/sdk";
+import { sendResponse } from "./_response_utils";
+import { getEnvs } from "./_env";
 
 const { Coingecko } = coingecko;
 
-import { getEnvs } from "./_env";
 const {
   REACT_APP_COINGECKO_PRO_API_KEY,
   REDIRECTED_TOKEN_PRICE_LOOKUP_ADDRESSES,
@@ -38,6 +40,7 @@ const CoingeckoQueryParamsSchema = type({
   chainId: optional(positiveInt),
   baseCurrency: optional(string()),
   date: optional(pattern(string(), /\d{2}-\d{2}-\d{4}/)),
+  fallbackResolver: optional(enums(["lifi"])),
 });
 
 type CoingeckoQueryParams = Infer<typeof CoingeckoQueryParamsSchema>;
@@ -59,6 +62,7 @@ const handler = async (
       chainId: _chainId,
       baseCurrency: _baseCurrency,
       date: dateStr,
+      fallbackResolver,
     } = parseQuery(query, CoingeckoQueryParamsSchema);
 
     let address = l1Token ?? tokenAddress;
@@ -76,6 +80,15 @@ const handler = async (
         baseCurrency: _baseCurrency,
         dateStr,
       });
+
+    // If coingecko can't resolve price we use a fallback resolver
+    if (price === 0 && fallbackResolver && baseCurrency === "usd" && !dateStr) {
+      price = await resolveUsdPriceViaFallbackResolver({
+        address,
+        chainId,
+        fallbackResolver,
+      });
+    }
 
     // If the base currency is a derived currency, we just need to grab
     // the price of the quote currency in USD and perform the conversion.
@@ -103,31 +116,19 @@ const handler = async (
     }
     price = Number((price / quotePrice).toFixed(quotePrecision));
 
-    // Two different explanations for how `stale-while-revalidate` works:
-
-    // https://vercel.com/docs/concepts/edge-network/caching#stale-while-revalidate
-    // This tells our CDN the value is fresh for 10 seconds. If a request is repeated within the next 10 seconds,
-    // the previously cached value is still fresh. The header x-vercel-cache present in the response will show the
-    // value HIT. If the request is repeated between 1 and 20 seconds later, the cached value will be stale but
-    // still render. In the background, a revalidation request will be made to populate the cache with a fresh value.
-    // x-vercel-cache will have the value STALE until the cache is refreshed.
-
-    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
-    // The response is fresh for 150s. After 150s it becomes stale, but the cache is allowed to reuse it
-    // for any requests that are made in the following 150s, provided that they revalidate the response in the background.
-    // Revalidation will make the cache be fresh again, so it appears to clients that it was always fresh during
-    // that period — effectively hiding the latency penalty of revalidation from them.
-    // If no request happened during that period, the cache became stale and the next request will revalidate normally.
     logger.debug({
       at: "Coingecko",
       message: "Response data",
       responseJson: { price },
     });
-    response.setHeader(
-      "Cache-Control",
-      "s-maxage=150, stale-while-revalidate=150"
-    );
-    response.status(200).json({ price });
+
+    sendResponse({
+      response,
+      body: { price },
+      statusCode: 200,
+      cacheSeconds: 150,
+      staleWhileRevalidateSeconds: 150,
+    });
   } catch (error: unknown) {
     return handleErrorCondition("coingecko", response, logger, error);
   }
@@ -238,6 +239,39 @@ async function resolvePrice(params: {
     }
   }
   return { price, baseCurrency, isDerivedCurrency, chainId };
+}
+
+async function resolveUsdPriceViaFallbackResolver(params: {
+  address: string;
+  chainId: number;
+  fallbackResolver: string;
+}) {
+  if (params.fallbackResolver === "lifi") {
+    try {
+      const { data } = await axios.get<{ priceUSD: string }>(
+        `https://li.quest/v1/token`,
+        {
+          params: {
+            chainId: params.chainId,
+            token: params.address,
+          },
+        }
+      );
+      return parseFloat(data.priceUSD);
+    } catch (error) {
+      getLogger().debug({
+        at: "Coingecko/resolveUsdPriceViaFallbackResolver",
+        message: "Failed to resolve price via fallback resolver",
+        error: compactAxiosError(error as Error),
+      });
+      return 0;
+    }
+  }
+
+  throw new InvalidParamError({
+    message: "Invalid fallback resolver",
+    param: "fallbackResolver",
+  });
 }
 
 export default handler;

--- a/api/coingecko.ts
+++ b/api/coingecko.ts
@@ -252,7 +252,7 @@ async function resolveUsdPriceViaFallbackResolver(params: {
         `https://li.quest/v1/token`,
         {
           params: {
-            chainId: params.chainId,
+            chain: params.chainId,
             token: params.address,
           },
         }

--- a/api/swap/approval/_service.ts
+++ b/api/swap/approval/_service.ts
@@ -1,4 +1,4 @@
-import { BigNumber, ethers } from "ethers";
+import { ethers } from "ethers";
 import { Span } from "@opentelemetry/api";
 
 import {

--- a/api/swap/approval/_service.ts
+++ b/api/swap/approval/_service.ts
@@ -8,6 +8,8 @@ import {
   latestGasPriceCache,
   getLogger,
   getWrappedNativeTokenAddress,
+  getTokenByAddress,
+  HUB_POOL_CHAIN_ID,
 } from "../../_utils";
 import { buildCrossSwapTxForAllowanceHolder } from "./_utils";
 import {
@@ -128,109 +130,69 @@ export async function handleApprovalSwap(
     !skipOriginTxEstimation &&
     allowance.gte(inputAmount) &&
     balance.gte(inputAmount);
+  const provider = getProvider(originChainId);
+  const originChainGasToken = getTokenByAddress(
+    getWrappedNativeTokenAddress(originChainId),
+    originChainId
+  );
+  const destinationChainGasToken = getTokenByAddress(
+    getWrappedNativeTokenAddress(destinationChainId),
+    destinationChainId
+  );
+  const bridgeQuoteInputToken = getTokenByAddress(
+    bridgeQuote.inputToken.address,
+    bridgeQuote.inputToken.chainId
+  );
 
-  let originTxGas: BigNumber | undefined;
-  let originTxGasPrice:
-    | {
-        maxFeePerGas: BigNumber;
-        maxPriorityFeePerGas: BigNumber;
-      }
-    | undefined;
-  let inputTokenPriceUsd: number;
-  let outputTokenPriceUsd: number;
-  let originNativePriceUsd: number;
-  let destinationNativePriceUsd: number;
-  let bridgeQuoteInputTokenPriceUsd: number;
-
-  if (isSwapTxEstimationPossible) {
-    const provider = getProvider(originChainId);
-    [
-      originTxGas,
-      originTxGasPrice,
-      inputTokenPriceUsd,
-      outputTokenPriceUsd,
-      originNativePriceUsd,
-      destinationNativePriceUsd,
-      bridgeQuoteInputTokenPriceUsd,
-    ] = await Promise.all([
-      provider.estimateGas({
-        ...crossSwapTx,
-        from: crossSwap.depositor,
-      }),
-      latestGasPriceCache(originChainId).get(),
-      getCachedTokenPrice(
-        inputToken.address,
-        "usd",
-        undefined,
-        inputToken.chainId
-      ),
-      getCachedTokenPrice(
-        outputToken.address,
-        "usd",
-        undefined,
-        outputToken.chainId
-      ),
-      getCachedTokenPrice(
-        getWrappedNativeTokenAddress(inputToken.chainId),
-        "usd",
-        undefined,
-        inputToken.chainId
-      ),
-      getCachedTokenPrice(
-        getWrappedNativeTokenAddress(outputToken.chainId),
-        "usd",
-        undefined,
-        outputToken.chainId
-      ),
-      getCachedTokenPrice(
-        bridgeQuote.inputToken.address,
-        "usd",
-        undefined,
-        bridgeQuote.inputToken.chainId
-      ),
-    ]);
-  } else {
-    [
-      originTxGasPrice,
-      inputTokenPriceUsd,
-      outputTokenPriceUsd,
-      originNativePriceUsd,
-      destinationNativePriceUsd,
-      bridgeQuoteInputTokenPriceUsd,
-    ] = await Promise.all([
-      latestGasPriceCache(originChainId).get(),
-      getCachedTokenPrice(
-        inputToken.address,
-        "usd",
-        undefined,
-        inputToken.chainId
-      ),
-      getCachedTokenPrice(
-        outputToken.address,
-        "usd",
-        undefined,
-        outputToken.chainId
-      ),
-      getCachedTokenPrice(
-        getWrappedNativeTokenAddress(inputToken.chainId),
-        "usd",
-        undefined,
-        inputToken.chainId
-      ),
-      getCachedTokenPrice(
-        getWrappedNativeTokenAddress(outputToken.chainId),
-        "usd",
-        undefined,
-        outputToken.chainId
-      ),
-      getCachedTokenPrice(
-        bridgeQuote.inputToken.address,
-        "usd",
-        undefined,
-        bridgeQuote.inputToken.chainId
-      ),
-    ]);
-  }
+  const [
+    originTxGas,
+    originTxGasPrice,
+    inputTokenPriceUsd,
+    outputTokenPriceUsd,
+    originNativePriceUsd,
+    destinationNativePriceUsd,
+    bridgeQuoteInputTokenPriceUsd,
+  ] = await Promise.all([
+    isSwapTxEstimationPossible
+      ? provider.estimateGas({
+          ...crossSwapTx,
+          from: crossSwap.depositor,
+        })
+      : undefined,
+    latestGasPriceCache(originChainId).get(),
+    getCachedTokenPrice(
+      inputToken.address,
+      "usd",
+      undefined,
+      inputToken.chainId,
+      "lifi"
+    ),
+    getCachedTokenPrice(
+      outputToken.address,
+      "usd",
+      undefined,
+      outputToken.chainId,
+      "lifi"
+    ),
+    originChainGasToken
+      ? getCachedTokenPrice(
+          originChainGasToken.addresses[HUB_POOL_CHAIN_ID],
+          "usd"
+        )
+      : 0,
+    destinationChainGasToken
+      ? getCachedTokenPrice(
+          destinationChainGasToken.addresses[HUB_POOL_CHAIN_ID],
+          "usd"
+        )
+      : 0,
+    bridgeQuoteInputToken
+      ? getCachedTokenPrice(
+          bridgeQuoteInputToken.addresses[HUB_POOL_CHAIN_ID],
+          "usd"
+        )
+      : 0,
+  ]);
 
   let approvalTxns:
     | {
@@ -250,7 +212,7 @@ export async function handleApprovalSwap(
     });
   }
 
-  const responseJson = await buildBaseSwapResponseJson({
+  const responseJson = buildBaseSwapResponseJson({
     amountType,
     amount,
     originChainId,


### PR DESCRIPTION
Attempt to make swap fees resolving more robust by:

- Adding a `fallbackResolver` param to the coingecko/price endpoint
  - For tokens where we theoretically are able to resolve a price for (e.g. via LiFi) but Coingecko doesn't know of, we can now specify a fallback resolver
- Remove redundant async appFeePriceUsd fetching