### PR TITLE
fix: filter out unsupported strategies when prepping b2a/a2b/a2a

### DIFF
--- a/api/_dexes/cross-swap-service.ts
+++ b/api/_dexes/cross-swap-service.ts
@@ -837,26 +837,35 @@ function _prepCrossSwapQuotesRetrievalA2B(
   );
 
   // Return a list of results for each origin strategy
-  return originStrategies.map((originStrategy) => {
-    const { swapAndBridge, originSwapInitialRecipient } =
-      originStrategy.getOriginEntryPoints(originSwapChainId);
-    const originSwap = {
-      chainId: originSwapChainId,
-      tokenIn: crossSwap.inputToken,
-      tokenOut: bridgeableInputToken,
-      recipient: originSwapInitialRecipient.address,
-      slippageTolerance: crossSwap.slippageTolerance,
-      type: crossSwap.type,
-    };
+  return originStrategies.flatMap((originStrategy) => {
+    try {
+      const { swapAndBridge, originSwapInitialRecipient } =
+        originStrategy.getOriginEntryPoints(originSwapChainId);
+      const originSwap = {
+        chainId: originSwapChainId,
+        tokenIn: crossSwap.inputToken,
+        tokenOut: bridgeableInputToken,
+        recipient: originSwapInitialRecipient.address,
+        slippageTolerance: crossSwap.slippageTolerance,
+        type: crossSwap.type,
+      };
 
-    return {
-      originSwap,
-      originStrategy,
-      originSwapChainId,
-      destinationChainId,
-      bridgeableInputToken,
-      originSwapEntryPoint: swapAndBridge,
-    };
+      return {
+        originSwap,
+        originStrategy,
+        originSwapChainId,
+        destinationChainId,
+        bridgeableInputToken,
+        originSwapEntryPoint: swapAndBridge,
+      };
+    } catch (error) {
+      logger.debug({
+        at: "_prepCrossSwapQuotesRetrievalA2B",
+        message: "Could not map origin strategy",
+        error,
+      });
+      return [];
+    }
   });
 }
 

--- a/api/_dexes/cross-swap-service.ts
+++ b/api/_dexes/cross-swap-service.ts
@@ -546,24 +546,33 @@ function _prepCrossSwapQuotesRetrievalB2A(
     strategies
   );
 
-  return destinationStrategies.map((destinationStrategy) => {
-    const originRouter = originStrategy.getRouter(originSwapChainId);
-    const destinationRouter = destinationStrategy.getRouter(
-      destinationSwapChainId
-    );
-    const depositEntryPoint =
-      originStrategy.getOriginEntryPoints(originSwapChainId).deposit;
+  return destinationStrategies.flatMap((destinationStrategy) => {
+    try {
+      const originRouter = originStrategy.getRouter(originSwapChainId);
+      const destinationRouter = destinationStrategy.getRouter(
+        destinationSwapChainId
+      );
+      const depositEntryPoint =
+        originStrategy.getOriginEntryPoints(originSwapChainId).deposit;
 
-    return {
-      destinationSwap,
-      originRouter,
-      destinationRouter,
-      depositEntryPoint,
-      bridgeableOutputToken,
-      destinationSwapChainId,
-      destinationStrategy,
-      originStrategy,
-    };
+      return {
+        destinationSwap,
+        originRouter,
+        destinationRouter,
+        depositEntryPoint,
+        bridgeableOutputToken,
+        destinationSwapChainId,
+        destinationStrategy,
+        originStrategy,
+      };
+    } catch (error) {
+      logger.debug({
+        at: "_prepCrossSwapQuotesRetrievalB2A",
+        message: "Could not map destination strategy",
+        error,
+      });
+      return [];
+    }
   });
 }
 


### PR DESCRIPTION
Fixes 
```
      Error: LI.FI router address not found for chain id 56
          at Object.getRouter (/var/task/api/_dexes/lifi/lifi-router.js:58:19)
          at /var/task/api/_dexes/cross-swap-service.js:354:55
          at Array.map (<anonymous>)
          at _prepCrossSwapQuotesRetrievalB2A (/var/task/api/_dexes/cross-swap-service.js:352:34)
          at getCrossSwapQuotesForExactInputB2A (/var/task/api/_dexes/cross-swap-service.js:148:21)
          at /var/task/api/_dexes/cross-swap-service.js:61:16
          at Array.map (<anonymous>)
          at getCrossSwapQuoteForAmountType (/var/task/api/_dexes/cross-swap-service.js:54:39)
          at getCrossSwapQuotes (/var/task/api/_dexes/cross-swap-service.js:25:16)
          at handleApprovalSwap (/var/task/api/swap/approval/_service.js:28:79)
          at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
          at async /var/task/api/swap/approval/index.js:21:34
          at async r (/opt/rust/nodejs.js:2:15476)
          at async Server.<anonymous> (/opt/rust/nodejs.js:2:11350)
          at async Server.<anonymous> (/opt/rust/nodejs.js:16:7329)
```
when trying to get A2B swap quote where LiFi is not supported. Example
```
https://app.across.to/api/swap/approval?originChainId=130&destinationChainId=56&inputToken=0x078D782b760474a361dDA0AF3839290b0EF57AD6&outputToken=0x0000000000000000000000000000000000000000&amount=1000000&tradeType=exactInput&depositor=0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D
```