### PR TITLE
fix: solana deposit status tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,7 @@ stats.*
 /blob-report/
 /playwright/.cache/
 .cache-synpress
+
+# Local development
+.yalc
+yalc.lock

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@across-protocol/constants": "^3.1.68",
     "@across-protocol/contracts": "^4.1.1",
-    "@across-protocol/sdk": "^4.3.17",
+    "@across-protocol/sdk": "^4.3.37",
     "@amplitude/analytics-browser": "^2.3.5",
     "@balancer-labs/sdk": "1.1.6-beta.16",
     "@coral-xyz/borsh": "^0.30.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -61,10 +61,10 @@
     yargs "^17.7.2"
     zksync-web3 "^0.14.3"
 
-"@across-protocol/sdk@^4.3.17":
-  version "4.3.30"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.3.30.tgz#ab436b1d98ed47f92dbcab9d4fdeab3c9ffaa215"
-  integrity sha512-ZbTBicv3djuw2epkgIlopE+6KTyMh5kvQ6MYro2pk2Vq5hc+ZDJgnrgb1tjUOH3ttZv/Z4cO6eA/6OJqeKnB3A==
+"@across-protocol/sdk@^4.3.37":
+  version "4.3.37"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.3.37.tgz#82b82dddcb85b7707d793e300dadff3e0f7fb2dc"
+  integrity sha512-Zhcl1Tvkc0FKzrQZZRpZUHGPvtubBdczGTn7An8hZFTe3lXNwDiSf4vpMr63fgFgKdcTExhwrOa/lFiZHMvu9Q==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/constants" "^3.1.71"
@@ -16819,14 +16819,7 @@ is-callable@^1.1.3, is-callable@^1.2.7:
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.7.tgz#3bc2a85ea742d9e36205dcacdd72ca1fdc51b055"
   integrity sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==
 
-is-core-module@^2.13.0:
-  version "2.16.1"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.16.1.tgz#2a98801a849f43e2add644fbb6bc6229b19a4ef4"
-  integrity sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==
-  dependencies:
-    hasown "^2.0.2"
-
-is-core-module@^2.16.0:
+is-core-module@^2.13.0, is-core-module@^2.16.0:
   version "2.16.1"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.16.1.tgz#2a98801a849f43e2add644fbb6bc6229b19a4ef4"
   integrity sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==
@@ -21669,16 +21662,7 @@ resolve@1.17.0:
   dependencies:
     path-parse "^1.0.6"
 
-resolve@^1.1.6, resolve@^1.10.0, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.22.1:
-  version "1.22.10"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.10.tgz#b663e83ffb09bbf2386944736baae803029b8b39"
-  integrity sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==
-  dependencies:
-    is-core-module "^2.16.0"
-    path-parse "^1.0.7"
-    supports-preserve-symlinks-flag "^1.0.0"
-
-resolve@^1.22.8:
+resolve@^1.1.6, resolve@^1.10.0, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.22.1, resolve@^1.22.8:
   version "1.22.10"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.10.tgz#b663e83ffb09bbf2386944736baae803029b8b39"
   integrity sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==


### PR DESCRIPTION
closes ACX-4258

[test tx](https://app-frontend-v3-git-fix-deposit-status-tracking-uma.vercel.app/bridge/5THjSXkZEzXfs9X6Rk24zQn7CLHzk9hWFfuwynTqunR4Fiqp6DVeA9bwEUrA1BK4H3hT8G2vLanPu9ok74Khhobc?originChainId=34268394551451&destinationChainId=42161&inputTokenSymbol=USDC&outputTokenSymbol=USDC&referrer=)

<img width="768" height="746" alt="Screenshot 2025-08-05 at 16 57 13" src="https://github.com/user-attachments/assets/1749ce44-d9e9-4556-ae94-139f494d143b" />
