### PR TITLE
fix: allow origin swaps for native token inputs

### DIFF
--- a/api/_dexes/utils.ts
+++ b/api/_dexes/utils.ts
@@ -172,20 +172,6 @@ export function getCrossSwapTypes(params: {
     params.destinationChainId
   );
 
-  // Prefer destination swap if input token is native because legacy
-  // `UniversalSwapAndBridge` does not support native tokens as input.
-  if (params.isInputNative) {
-    if (inputBridgeable) {
-      return [CROSS_SWAP_TYPE.BRIDGEABLE_TO_ANY];
-    }
-    // We can't bridge native tokens that are not ETH, e.g. MATIC or AZERO. Therefore
-    // throw until we have periphery contract audited so that it can accept native
-    // tokens and do an origin swap.
-    throw new Error(
-      "Unsupported swap: Input token is native but not bridgeable"
-    );
-  }
-
   if (inputBridgeable && outputBridgeable) {
     return [
       CROSS_SWAP_TYPE.ANY_TO_BRIDGEABLE,


### PR DESCRIPTION
With the new periphery contract, we can perform origin swaps even if the input is a native token.

Tested this with the following transactions:

**Origin swap + bridge**

Request:

- Input token: 0.001 ETH on Optimism
- Output token: USDC on Base
- Origin txn: https://optimistic.etherscan.io/tx/0x535c64458f7e1bb37549d65825bc552c484c29846f390f4da9f8ba07324375bc
- Destination txn: https://basescan.org/tx/0x058c6ee526287683ffea0e781df628ceeb7eaf58f6552fd826e22103b2f3cd14

**Origin + destination swap**

Request:

- Input token: BNB on BSC
- Output token: UNI on Unichain
- Origin txn: https://bscscan.com/tx/0xb6f8679d1b1bf322dcd2951f223aa27d09fb4a5e0fb5797793b71538a748424f
- Destination txn: https://unichain.blockscout.com/tx/0x6650ed4aaca2df3024c9b9c868fe12ee3006d928ab11d5b32bb43bc4cb493319