### PR TITLE
fix: a2a destination swaps when not using 0x

### DIFF
--- a/api/_dexes/0x/allowance-holder.ts
+++ b/api/_dexes/0x/allowance-holder.ts
@@ -34,7 +34,7 @@ const API_HEADERS = {
   "0x-version": "v2",
 };
 
-const SWAP_PROVIDER_NAME = "0x";
+export const SWAP_PROVIDER_NAME = "0x";
 
 export function get0xStrategy(
   originSwapEntryPointContractName: OriginEntryPointContractName

--- a/api/_dexes/0x/allowance-holder.ts
+++ b/api/_dexes/0x/allowance-holder.ts
@@ -2,7 +2,7 @@ import { BigNumber } from "ethers";
 import { TradeType } from "@uniswap/sdk-core";
 import axios, { AxiosError } from "axios";
 
-import { getLogger } from "../../_utils";
+import { addMarkupToAmount, getLogger } from "../../_utils";
 import {
   OriginEntryPointContractName,
   QuoteFetchOpts,
@@ -63,6 +63,12 @@ export function get0xStrategy(
     opts?: QuoteFetchOpts
   ) => {
     try {
+      if (opts?.sellEntireBalance && opts.quoteBuffer) {
+        swap.amount = addMarkupToAmount(
+          BigNumber.from(swap.amount),
+          opts.quoteBuffer + swap.slippageTolerance / 100
+        ).toString();
+      }
       let swapAmount = swap.amount;
       if (tradeType === TradeType.EXACT_OUTPUT) {
         swapAmount = await estimateInputForExactOutput(

--- a/api/_dexes/0x/allowance-holder.ts
+++ b/api/_dexes/0x/allowance-holder.ts
@@ -34,7 +34,7 @@ const API_HEADERS = {
   "0x-version": "v2",
 };
 
-export const SWAP_PROVIDER_NAME = "0x";
+const SWAP_PROVIDER_NAME = "0x";
 
 export function get0xStrategy(
   originSwapEntryPointContractName: OriginEntryPointContractName

--- a/api/_dexes/cross-swap-service.ts
+++ b/api/_dexes/cross-swap-service.ts
@@ -40,6 +40,7 @@ import {
   CrossSwapQuotesRetrievalA2BResult,
   CrossSwapQuotesRetrievalB2AResult,
 } from "./types";
+import { SWAP_PROVIDER_NAME as SWAP_PROVIDER_NAME_0X } from "./0x/allowance-holder";
 
 const QUOTE_BUFFER = 0.005; // 0.5%
 
@@ -1087,10 +1088,13 @@ export async function getCrossSwapQuotesForExactInputByRouteA2A(
   const destinationSwapQuote = await destinationStrategy.fetchFn(
     {
       ...destinationSwap,
-      amount: addMarkupToAmount(
-        bridgeQuote.outputAmount,
-        QUOTE_BUFFER + crossSwap.slippageTolerance / 100
-      ).toString(),
+      amount:
+        destinationStrategy.strategyName === SWAP_PROVIDER_NAME_0X
+          ? addMarkupToAmount(
+              bridgeQuote.outputAmount,
+              QUOTE_BUFFER + crossSwap.slippageTolerance / 100
+            ).toString()
+          : bridgeQuote.outputAmount.toString(),
     },
     TradeType.EXACT_INPUT,
     {
@@ -1252,10 +1256,13 @@ export async function getCrossSwapQuotesForOutputByRouteA2A(
     destinationStrategy.fetchFn(
       {
         ...destinationSwap,
-        amount: addMarkupToAmount(
-          bridgeQuote.outputAmount,
-          QUOTE_BUFFER + crossSwapWithAppFee.slippageTolerance / 100
-        ).toString(),
+        amount:
+          destinationStrategy.strategyName === SWAP_PROVIDER_NAME_0X
+            ? addMarkupToAmount(
+                bridgeQuote.outputAmount,
+                QUOTE_BUFFER + crossSwapWithAppFee.slippageTolerance / 100
+              ).toString()
+            : bridgeQuote.outputAmount.toString(),
       },
       TradeType.EXACT_INPUT,
       {

--- a/api/_dexes/cross-swap-service.ts
+++ b/api/_dexes/cross-swap-service.ts
@@ -40,7 +40,6 @@ import {
   CrossSwapQuotesRetrievalA2BResult,
   CrossSwapQuotesRetrievalB2AResult,
 } from "./types";
-import { SWAP_PROVIDER_NAME as SWAP_PROVIDER_NAME_0X } from "./0x/allowance-holder";
 
 const QUOTE_BUFFER = 0.005; // 0.5%
 

--- a/api/_dexes/cross-swap-service.ts
+++ b/api/_dexes/cross-swap-service.ts
@@ -1088,18 +1088,13 @@ export async function getCrossSwapQuotesForExactInputByRouteA2A(
   const destinationSwapQuote = await destinationStrategy.fetchFn(
     {
       ...destinationSwap,
-      amount:
-        destinationStrategy.strategyName === SWAP_PROVIDER_NAME_0X
-          ? addMarkupToAmount(
-              bridgeQuote.outputAmount,
-              QUOTE_BUFFER + crossSwap.slippageTolerance / 100
-            ).toString()
-          : bridgeQuote.outputAmount.toString(),
+      amount: bridgeQuote.outputAmount.toString(),
     },
     TradeType.EXACT_INPUT,
     {
       sources: prioritizedOriginStrategy.destinationSources,
       sellEntireBalance: true,
+      quoteBuffer: QUOTE_BUFFER,
     }
   );
 
@@ -1256,18 +1251,13 @@ export async function getCrossSwapQuotesForOutputByRouteA2A(
     destinationStrategy.fetchFn(
       {
         ...destinationSwap,
-        amount:
-          destinationStrategy.strategyName === SWAP_PROVIDER_NAME_0X
-            ? addMarkupToAmount(
-                bridgeQuote.outputAmount,
-                QUOTE_BUFFER + crossSwapWithAppFee.slippageTolerance / 100
-              ).toString()
-            : bridgeQuote.outputAmount.toString(),
+        amount: bridgeQuote.outputAmount.toString(),
       },
       TradeType.EXACT_INPUT,
       {
         sources: destinationSources,
         sellEntireBalance: true,
+        quoteBuffer: QUOTE_BUFFER,
       }
     ),
     // 3.2. Get origin swap quote for any input token -> bridgeable input token

--- a/api/_dexes/types.ts
+++ b/api/_dexes/types.ts
@@ -170,6 +170,7 @@ export type QuoteFetchOpts = Partial<{
   useIndicativeQuote: boolean;
   sources?: ReturnType<GetSourcesFn>;
   sellEntireBalance?: boolean;
+  quoteBuffer?: number;
 }>;
 
 export type OriginEntryPointContractName =


### PR DESCRIPTION
Avoid modifying the amount used in the destination swap when we are not using 0x.
This is making fills fail when doing USDC.e -> GHO on Lens.

Tests:
- Exact input Arbitrum USDC.e -> Lens GHO
[Deposit](https://arbiscan.io/tx/0x86169c9c55c3cb9f20beda5d330b33cb8af7ce19cbd547a20fa4309ad3e3df7f) - [Fill](https://explorer.lens.xyz/tx/0x17fa9320b1ebdcb1d6a9177029a321b6f90364315b92559c8ade10ed905f836a)  

- Exact input Optimism USDC.e -> Arbitrum AAVE
[Deposit](https://optimistic.etherscan.io/tx/0xf7b2b14411b027c4eb247930b6d307c06a8d216cefab8181fa2d7ea2aadb032a#eventlog) - [Fill](https://arbiscan.io/tx/0x49a533fbc2849b4a0fa49fe6165d824fc08f2d978cd35ebf8bfc2e75f51f6880)

- Min output Optimism USDC.e -> Arbitrum APE
[Deposit](https://optimistic.etherscan.io/tx/0x162ae8f627674c422a74d74b037c671f225c0f46184f6f78e21524789a9eae7d) - [Fill](https://arbiscan.io/tx/0x6cbf6074ae0de1450b0ea72a103b5982d876fbcf97af49ec46e6a0fcfbc7c64a) 

- Exact output Optimism USDC.e -> Arbitrum APE
[Deposit](https://optimistic.etherscan.io/tx/0x4c124b7d6abaf5d9338dcef3f9b887098be0403d0eefba3c674f2fbbdec0e664) - [Fill](https://arbiscan.io/tx/0xcf3bfe8ff4adcca350aa99459f6ad152120763ea0f072cb238f530e55d618442) 
