### PR TITLE
fix: 0x source filter

### DIFF
--- a/api/_dexes/0x/allowance-holder.ts
+++ b/api/_dexes/0x/allowance-holder.ts
@@ -76,17 +76,18 @@ export function get0xStrategy(
       const sourcesParams =
         sources?.sourcesType === "exclude"
           ? {
-              excludeSources: sources.sourcesKeys.join(","),
+              excludedSources: sources.sourcesKeys.join(","),
             }
           : // We need to invert the include sources to be compatible with the API
             // because 0x doesn't support the `includeSources` parameter
             sources?.sourcesType === "include"
             ? {
-                excludeSources: SOURCES.sources[swap.chainId]
+                excludedSources: SOURCES.sources[swap.chainId]
                   .map((s) => s.key)
                   .filter(
                     (sourceKey) => !sources.sourcesKeys.includes(sourceKey)
-                  ),
+                  )
+                  .join(","),
               }
             : {};
 
@@ -120,9 +121,24 @@ export function get0xStrategy(
         });
       }
 
-      const usedSources = quote.route.fills.map((fill: { source: string }) =>
-        fill.source.toLowerCase()
+      const usedSources: string[] = quote.route.fills.map(
+        (fill: { source: string }) => fill.source.toLowerCase()
       );
+
+      if (
+        sources?.sourcesType === "include" &&
+        !usedSources.every((source: string) =>
+          sources.sourcesNames?.includes(source)
+        )
+      ) {
+        throw new UpstreamSwapProviderError({
+          message: `0x: Used sources ${usedSources.join(
+            ", "
+          )} do not match include sources ${sources.sourcesKeys.join(", ")}`,
+          code: UPSTREAM_SWAP_PROVIDER_ERRORS.NO_POSSIBLE_ROUTE,
+          swapProvider: "0x",
+        });
+      }
 
       const expectedAmountIn = BigNumber.from(quote.sellAmount);
       const maximumAmountIn = expectedAmountIn;

--- a/api/_dexes/types.ts
+++ b/api/_dexes/types.ts
@@ -140,6 +140,7 @@ export type GetSourcesFn = (
 ) =>
   | {
       sourcesKeys: string[];
+      sourcesNames?: string[];
       sourcesType: "exclude" | "include";
     }
   | undefined;

--- a/api/_dexes/utils.ts
+++ b/api/_dexes/utils.ts
@@ -871,21 +871,26 @@ export function makeGetSources(sources: DexSources) {
             isValidSource(includeSource, chainId, sources)
           )
         : [];
-    const sourcesKeys = Array.from(
+    const sourcesData = Array.from(
       new Set(
-        filteredSources.flatMap(
-          (source) =>
-            sources.sources[chainId].find((s) =>
-              s.names.some(
-                (name) => name.toLowerCase() === source.toLowerCase()
-              )
-            )?.key || []
-        )
+        filteredSources.flatMap((source) => {
+          const sourceData = sources.sources[chainId].find((s) =>
+            s.names.some((name) => name.toLowerCase() === source.toLowerCase())
+          );
+          if (!sourceData) {
+            return [];
+          }
+          return {
+            key: sourceData.key,
+            names: sourceData.names,
+          };
+        })
       )
     );
 
     return {
-      sourcesKeys,
+      sourcesKeys: sourcesData.map((s) => s.key),
+      sourcesNames: sourcesData.flatMap((s) => s.names),
       sourcesType: opts?.excludeSources ? "exclude" : "include",
     } as const;
   };


### PR DESCRIPTION
I found 2 issues with the current implementation of the 0x strategy's source filtering logic:

1. The 0x docs say that the parameter name must be `excludedSources`: https://0x.org/docs/api#tag/Swap/operation/swap::allowanceHolder::getQuote. We are currently setting it as `excludeSources`.
2. If the user calls our Swap API with the `includeSources` parameter set, we will convert it to an exclusion set by excluding everything except what is included. This is needed for 0x because they only accept an `excludedSources` parameter and not an `includedSources` one. But this can still cause our Swap API to not honor the inclusion list because what we store in our `sources.ts` file may not always match 0x's available sources since they may keep updating the list. So then we would invert the inclusion set to an exclusion set but we would miss excluding any new additions on 0x's side unless we regenerate the `sources.ts` file. We can regenerate frequently, but we should probably still have an extra safeguard as shown in this PR so that the user's experience is consistent.