### PR TITLE
chore: only use SpokePoolPeriphery in strategy configs

### DIFF
--- a/api/_dexes/gho/multicall.ts
+++ b/api/_dexes/gho/multicall.ts
@@ -5,18 +5,15 @@ import {
   MULTICALL3_ADDRESS,
   TOKEN_SYMBOLS_MAP,
 } from "../../_constants";
-import { getUniversalSwapAndBridgeAddress } from "../../_swap-and-bridge";
-import {
-  getMulticall3,
-  getMulticall3Address,
-  getSpokePoolAddress,
-} from "../../_utils";
+import { getMulticall3, getMulticall3Address } from "../../_utils";
 import { QuoteFetchStrategy, Swap } from "../types";
 import { getWghoContract } from "./utils/wgho";
 import { getSwapRouter02Strategy } from "../uniswap/swap-router-02";
 import { encodeApproveCalldata } from "../../_multicall-handler";
 import { getErc20 } from "../../_erc20";
-import { makeGetSources } from "../utils";
+import { getOriginSwapEntryPoints, makeGetSources } from "../utils";
+
+const SWAP_PROVIDER_NAME = "gho-multicall3";
 
 /**
  * Returns a swap quote fetch strategy for handling Stable -> GHO swaps.
@@ -29,29 +26,14 @@ export function getWghoMulticallStrategy(): QuoteFetchStrategy {
     };
   };
 
-  const getOriginEntryPoints = (chainId: number) => {
-    return {
-      originSwapInitialRecipient: {
-        name: "UniversalSwapAndBridge",
-        address: getUniversalSwapAndBridgeAddress("gho-multicall3", chainId),
-      },
-      swapAndBridge: {
-        name: "UniversalSwapAndBridge",
-        address: getUniversalSwapAndBridgeAddress("gho-multicall3", chainId),
-        dex: "gho-multicall3",
-      },
-      deposit: {
-        name: "SpokePool",
-        address: getSpokePoolAddress(chainId),
-      },
-    } as const;
-  };
+  const getOriginEntryPoints = (chainId: number) =>
+    getOriginSwapEntryPoints("SpokePoolPeriphery", chainId, SWAP_PROVIDER_NAME);
 
   const getSources = makeGetSources({
-    strategy: "gho-multicall3",
+    strategy: SWAP_PROVIDER_NAME,
     sources: {
       [CHAIN_IDs.MAINNET]: [
-        { key: "gho-multicall3", names: ["gho-multicall3"] },
+        { key: SWAP_PROVIDER_NAME, names: [SWAP_PROVIDER_NAME] },
       ],
     },
   });
@@ -106,7 +88,7 @@ export function getWghoMulticallStrategy(): QuoteFetchStrategy {
 
     // 2. Perform swap via Uniswap Stable -> GHO
     const swapRouter02Strategy = getSwapRouter02Strategy(
-      "UniversalSwapAndBridge",
+      "SpokePoolPeriphery",
       "trading-api"
     );
     const ghoSwap = {
@@ -188,14 +170,14 @@ export function getWghoMulticallStrategy(): QuoteFetchStrategy {
       slippageTolerance: swap.slippageTolerance,
       swapTxns: [aggregateTx],
       swapProvider: {
-        name: "gho-multicall3",
-        sources: ["gho-multicall3", "uniswap_v3"],
+        name: SWAP_PROVIDER_NAME,
+        sources: [SWAP_PROVIDER_NAME, "uniswap_v3"],
       },
     };
   };
 
   return {
-    strategyName: "gho-multicall3",
+    strategyName: SWAP_PROVIDER_NAME,
     getRouter,
     getOriginEntryPoints,
     fetchFn,

--- a/api/_dexes/gho/wrapped-gho.ts
+++ b/api/_dexes/gho/wrapped-gho.ts
@@ -2,13 +2,13 @@ import { TradeType } from "@uniswap/sdk-core";
 import { BigNumber } from "ethers";
 
 import { CHAIN_IDs, TOKEN_SYMBOLS_MAP } from "../../_constants";
-import { getUniversalSwapAndBridgeAddress } from "../../_swap-and-bridge";
-import { getSpokePoolAddress } from "../../_utils";
 import { QuoteFetchStrategy, Swap } from "../types";
 import { getWghoContract, WGHO_ADDRESS } from "./utils/wgho";
 import { getSwapRouter02Strategy } from "../uniswap/swap-router-02";
 import { encodeApproveCalldata } from "../../_multicall-handler";
-import { makeGetSources } from "../utils";
+import { getOriginSwapEntryPoints, makeGetSources } from "../utils";
+
+const SWAP_PROVIDER_NAME = "wrapped-gho";
 
 /**
  * Returns a swap quote fetch strategy for handling GHO/WGHO swaps.
@@ -21,28 +21,15 @@ export function getWrappedGhoStrategy(): QuoteFetchStrategy {
     };
   };
 
-  const getOriginEntryPoints = (chainId: number) => {
-    return {
-      originSwapInitialRecipient: {
-        name: "UniversalSwapAndBridge",
-        address: getUniversalSwapAndBridgeAddress("gho", chainId),
-      },
-      swapAndBridge: {
-        name: "UniversalSwapAndBridge",
-        address: getUniversalSwapAndBridgeAddress("gho", chainId),
-        dex: "gho",
-      },
-      deposit: {
-        name: "SpokePool",
-        address: getSpokePoolAddress(chainId),
-      },
-    } as const;
-  };
+  const getOriginEntryPoints = (chainId: number) =>
+    getOriginSwapEntryPoints("SpokePoolPeriphery", chainId, SWAP_PROVIDER_NAME);
 
   const getSources = makeGetSources({
-    strategy: "gho",
+    strategy: SWAP_PROVIDER_NAME,
     sources: {
-      [CHAIN_IDs.MAINNET]: [{ key: "gho", names: ["gho"] }],
+      [CHAIN_IDs.MAINNET]: [
+        { key: SWAP_PROVIDER_NAME, names: [SWAP_PROVIDER_NAME] },
+      ],
     },
   });
 
@@ -103,15 +90,15 @@ export function getWrappedGhoStrategy(): QuoteFetchStrategy {
         slippageTolerance: swap.slippageTolerance,
         swapTxns,
         swapProvider: {
-          name: "wrapped-gho",
-          sources: ["wgho"],
+          name: SWAP_PROVIDER_NAME,
+          sources: ["wgho", SWAP_PROVIDER_NAME],
         },
       };
     }
 
     // If we get here, we need to encode the calldata for the swap GHO -> Any via `SwapRouter02`.
     const swapRouter02Strategy = getSwapRouter02Strategy(
-      "UniversalSwapAndBridge",
+      "SpokePoolPeriphery",
       "trading-api"
     );
     const ghoSwap = {
@@ -163,14 +150,14 @@ export function getWrappedGhoStrategy(): QuoteFetchStrategy {
       slippageTolerance: swap.slippageTolerance,
       swapTxns,
       swapProvider: {
-        name: "wrapped-gho",
-        sources: ["wgho", "uniswap_v3"],
+        name: SWAP_PROVIDER_NAME,
+        sources: ["wgho", SWAP_PROVIDER_NAME, "uniswap_v3"],
       },
     };
   };
 
   return {
-    strategyName: "wrapped-gho",
+    strategyName: SWAP_PROVIDER_NAME,
     getRouter,
     getOriginEntryPoints,
     fetchFn,

--- a/api/_dexes/types.ts
+++ b/api/_dexes/types.ts
@@ -51,8 +51,8 @@ export type SupportedDex =
   | "uniswap"
   | "uniswap-v3/swap-router-02"
   | "uniswap-v3/universal-router"
-  | "gho"
   | "gho-multicall3"
+  | "wrapped-gho"
   | "lifi"
   | "0x";
 

--- a/api/_dexes/uniswap/universal-router.ts
+++ b/api/_dexes/uniswap/universal-router.ts
@@ -38,7 +38,7 @@ export function getUniversalRouterStrategy(): QuoteFetchStrategy {
   };
 
   const getOriginEntryPoints = (chainId: number) =>
-    getOriginSwapEntryPoints("UniversalSwapAndBridge", chainId, STRATEGY_NAME);
+    getOriginSwapEntryPoints("SpokePoolPeriphery", chainId, STRATEGY_NAME);
 
   const getSources = makeGetSources({
     strategy: STRATEGY_NAME,

--- a/api/swap/_configs.ts
+++ b/api/swap/_configs.ts
@@ -15,11 +15,11 @@ export const quoteFetchStrategies: QuoteFetchStrategies = {
   default: [
     get0xStrategy("SpokePoolPeriphery"),
     getLifiStrategy("SpokePoolPeriphery"),
-    getSwapRouter02Strategy("UniversalSwapAndBridge", "trading-api"),
+    getSwapRouter02Strategy("SpokePoolPeriphery", "trading-api"),
   ],
   chains: {
     [CHAIN_IDs.LENS]: [
-      getSwapRouter02Strategy("UniversalSwapAndBridge", "sdk-swap-quoter"),
+      getSwapRouter02Strategy("SpokePoolPeriphery", "sdk-swap-quoter"),
     ],
   },
   swapPairs: {


### PR DESCRIPTION
This configures all swap strategies to use the new `SpokePoolPeriphery` contract for consistency