### PR TITLE
feat: add swap api calldata marker

### DIFF
--- a/api/_integrator-id.ts
+++ b/api/_integrator-id.ts
@@ -1,6 +1,7 @@
 import { utils } from "ethers";
 
 export const DOMAIN_CALLDATA_DELIMITER = "0x1dc0de";
+export const SWAP_CALLDATA_MARKER = "0x73c0de";
 
 export function isValidIntegratorId(integratorId: string) {
   return (
@@ -26,4 +27,8 @@ export function tagIntegratorId(integratorId: string, txData: string) {
   return utils.hexlify(
     utils.concat([txData, DOMAIN_CALLDATA_DELIMITER, integratorId])
   );
+}
+
+export function tagSwapApiMarker(txData: string) {
+  return utils.hexlify(utils.concat([txData, SWAP_CALLDATA_MARKER]));
 }

--- a/api/swap/approval/_utils.ts
+++ b/api/swap/approval/_utils.ts
@@ -2,7 +2,7 @@ import { PopulatedTransaction } from "ethers";
 import * as sdk from "@across-protocol/sdk";
 
 import { CrossSwapQuotes } from "../../_dexes/types";
-import { tagIntegratorId } from "../../_integrator-id";
+import { tagIntegratorId, tagSwapApiMarker } from "../../_integrator-id";
 import { getSpokePool } from "../../_utils";
 import {
   getSpokePoolPeriphery,
@@ -233,11 +233,15 @@ export async function buildCrossSwapTxForAllowanceHolder(
       );
     }
   }
+  const txDataWithIntegratorId = integratorId
+    ? tagIntegratorId(integratorId, tx.data!)
+    : tx.data!;
+  const txDataWithSwapApiMarker = tagSwapApiMarker(txDataWithIntegratorId);
 
   return {
     from: crossSwapQuotes.crossSwap.depositor,
     to: toAddress,
-    data: integratorId ? tagIntegratorId(integratorId, tx.data!) : tx.data!,
+    data: txDataWithSwapApiMarker,
     value: tx.value,
   };
 }


### PR DESCRIPTION
This PR appends `0x73c0de` marker (0x73 = sw) to the calldata in order to identify transactions built by the Swap API.