### PR TITLE
fix(swap): mismatched decimals

### DIFF
--- a/api/_auth.ts
+++ b/api/_auth.ts
@@ -8,7 +8,7 @@ export const Role = {
   OPT_IN_CHAINS: "opt-in-chains",
 };
 
-export function parseRole(req: TypedVercelRequest<unknown>) {
+export function parseRole(req: TypedVercelRequest<unknown, unknown>) {
   const xVercelProtectionBypass =
     req.headers?.["x-vercel-protection-bypass"] ||
     req.query?.["x-vercel-protection-bypass"];

--- a/api/_dexes/cross-swap-service.ts
+++ b/api/_dexes/cross-swap-service.ts
@@ -10,6 +10,7 @@ import {
   addTimeoutToPromise,
   getLogger,
   addMarkupToAmount,
+  ConvertDecimals,
 } from "../_utils";
 import { CrossSwap, CrossSwapQuotes, QuoteFetchOpts } from "./types";
 import {
@@ -134,7 +135,13 @@ export async function getCrossSwapQuotesForExactInputB2B(
     outputToken: crossSwap.outputToken,
     exactInputAmount: crossSwap.amount,
     recipient: getMultiCallHandlerAddress(crossSwap.outputToken.chainId),
-    message: buildExactInputBridgeTokenMessage(crossSwap, crossSwap.amount),
+    message: buildExactInputBridgeTokenMessage(
+      crossSwap,
+      ConvertDecimals(
+        crossSwap.inputToken.decimals,
+        crossSwap.outputToken.decimals
+      )(crossSwap.amount)
+    ),
   });
 
   if (bridgeQuote.outputAmount.lt(0)) {
@@ -622,7 +629,10 @@ export async function getCrossSwapQuotesForExactInputA2B(
     recipient: getMultiCallHandlerAddress(destinationChainId),
     message: buildExactInputBridgeTokenMessage(
       crossSwap,
-      prioritizedStrategy.originSwapQuote.minAmountOut
+      ConvertDecimals(
+        prioritizedStrategy.originSwapQuote.tokenOut.decimals,
+        crossSwap.outputToken.decimals
+      )(prioritizedStrategy.originSwapQuote.minAmountOut)
     ),
   });
 

--- a/api/_message.ts
+++ b/api/_message.ts
@@ -1,0 +1,7 @@
+// Vercel imposes a 14KB URL length limit (https://vercel.com/docs/errors/URL_TOO_LONG)
+// We use a POST request to avoid this limit if message is too long.
+export const MAX_MESSAGE_LENGTH = 25_000; // ~14KB
+
+export function isMessageTooLong(message: string) {
+  return message && message.length > MAX_MESSAGE_LENGTH;
+}

--- a/api/limits.ts
+++ b/api/limits.ts
@@ -90,7 +90,10 @@ const handler = async (
       const provider = getProvider(HUB_POOL_CHAIN_ID);
 
       assert(query, LimitsQueryParamsSchema);
-      assert(body, LimitsBodySchema);
+
+      if (body) {
+        assert(body, LimitsBodySchema);
+      }
 
       const {
         destinationChainId,
@@ -114,7 +117,7 @@ const handler = async (
         relayer,
         message: _messageFromQuery,
       } = query;
-      const { message: _messageFromBody } = body;
+      const { message: _messageFromBody } = body ?? {};
 
       const message = _messageFromQuery || _messageFromBody;
 

--- a/api/limits.ts
+++ b/api/limits.ts
@@ -64,10 +64,15 @@ const LimitsQueryParamsSchema = type({
   allowUnmatchedDecimals: optional(boolStr()),
 });
 
+const LimitsBodySchema = type({
+  message: optional(string()),
+});
+
 type LimitsQueryParams = Infer<typeof LimitsQueryParamsSchema>;
+type LimitsBody = Infer<typeof LimitsBodySchema>;
 
 const handler = async (
-  { query }: TypedVercelRequest<LimitsQueryParams>,
+  { query, body }: TypedVercelRequest<LimitsQueryParams, LimitsBody>,
   response: VercelResponse
 ) => {
   const logger = getLogger();
@@ -85,6 +90,7 @@ const handler = async (
       const provider = getProvider(HUB_POOL_CHAIN_ID);
 
       assert(query, LimitsQueryParamsSchema);
+      assert(body, LimitsBodySchema);
 
       const {
         destinationChainId,
@@ -102,7 +108,16 @@ const handler = async (
 
       // Optional parameters that caller can use to specify specific deposit details with which
       // to compute limits.
-      let { amount: _amount, recipient, relayer, message } = query;
+      let {
+        amount: _amount,
+        recipient,
+        relayer,
+        message: _messageFromQuery,
+      } = query;
+      const { message: _messageFromBody } = body;
+
+      const message = _messageFromQuery || _messageFromBody;
+
       // Very small amount to simulate a fill of the deposit that should always be available in the relayer's balance.
       const simulationAmount = ethers.BigNumber.from("100");
       recipient = recipient

--- a/api/suggested-fees.ts
+++ b/api/suggested-fees.ts
@@ -102,7 +102,10 @@ const handler = async (
       const hubPool = getHubPool(provider);
 
       assert(query, SuggestedFeesQueryParamsSchema);
-      assert(body, SuggestedFeesBodySchema);
+
+      if (body) {
+        assert(body, SuggestedFeesBodySchema);
+      }
 
       let {
         amount: amountInput,
@@ -112,7 +115,7 @@ const handler = async (
         relayer,
         message: _messageFromQuery,
       } = query;
-      const { message: _messageFromBody } = body;
+      const { message: _messageFromBody } = body ?? {};
 
       const message = _messageFromQuery || _messageFromBody;
 

--- a/test/api/main.test.ts
+++ b/test/api/main.test.ts
@@ -32,7 +32,7 @@ describe("API Test", () => {
   });
 
   test("limits has no load-time errors", async () => {
-    await limitsHandler(request as TypedVercelRequest<any>, response);
+    await limitsHandler(request as TypedVercelRequest<any, any>, response);
     expect(response.status).toHaveBeenCalledWith(400);
     expect(response.json).toHaveBeenCalledWith(
       expect.objectContaining(/At path: destinationChainId/)

--- a/test/api/main.test.ts
+++ b/test/api/main.test.ts
@@ -40,7 +40,7 @@ describe("API Test", () => {
   });
 
   test("suggested-fees has no load-time errors", async () => {
-    await feesHandler(request as TypedVercelRequest<any>, response);
+    await feesHandler(request as TypedVercelRequest<any, any>, response);
     expect(response.status).toHaveBeenCalledWith(400);
     expect(response.json).toHaveBeenCalledWith(
       expect.objectContaining(/At path: amount/)


### PR DESCRIPTION
This fixes a few things:
- Convert decimals for indicative quotes (this fixes USDC-BNB related swaps)
- Compact and bubble up more errors
- Allow providing message as POST body in suggested-fees and limits (sometimes Vercel would throw 414 URL_TOO_LONG errors while testing/fixing above)