### PR TITLE
fix: assert sources inside fetch function

### DIFF
--- a/api/_dexes/cross-swap-service.ts
+++ b/api/_dexes/cross-swap-service.ts
@@ -246,9 +246,9 @@ export async function getCrossSwapQuotesForExactInputB2A(
         includeSources: crossSwap.includeSources,
       }
     );
-    assertSources(sources);
 
     const fetchFn = async () => {
+      assertSources(sources);
       // 1. Get destination swap quote for bridgeable output token -> any token
       const indicativeDestinationSwapQuote =
         await result.destinationStrategy.fetchFn(
@@ -370,9 +370,9 @@ export async function getCrossSwapQuotesForOutputB2A(
         includeSources: crossSwapWithAppFee.includeSources,
       }
     );
-    assertSources(sources);
 
     const fetchFn = async () => {
+      assertSources(sources);
       // 1. Get destination swap quote for bridgeable output token -> any token
       const destinationSwapQuote = await result.destinationStrategy.fetchFn(
         {
@@ -579,9 +579,9 @@ export async function getCrossSwapQuotesForExactInputA2B(
         includeSources: crossSwap.includeSources,
       }
     );
-    assertSources(sources);
 
     const fetchFn = async () => {
+      assertSources(sources);
       // 1. Get origin swap quote for any input token -> bridgeable output token
       const originSwapQuote = await result.originStrategy.fetchFn(
         {
@@ -704,9 +704,9 @@ export async function getCrossSwapQuotesForOutputA2B(
         includeSources: crossSwapWithAppFee.includeSources,
       }
     );
-    assertSources(sources);
 
     const fetchFn = async () => {
+      assertSources(sources);
       const originSwapQuote = await result.originStrategy.fetchFn(
         {
           ...result.originSwap,
@@ -988,7 +988,6 @@ export async function getCrossSwapQuotesForExactInputByRouteA2A(
         includeSources: crossSwap.includeSources,
       }
     );
-    assertSources(originSources);
 
     const destinationSources = result.destinationStrategy.getSources(
       result.destinationSwap.chainId,
@@ -997,9 +996,10 @@ export async function getCrossSwapQuotesForExactInputByRouteA2A(
         includeSources: crossSwap.includeSources,
       }
     );
-    assertSources(destinationSources);
 
     const fetchFn = async () => {
+      assertSources(originSources);
+      assertSources(destinationSources);
       // 1. Get origin swap quote for any input token -> bridgeable input token
       const originSwapQuote = await result.originStrategy.fetchFn(
         {
@@ -1151,9 +1151,9 @@ export async function getCrossSwapQuotesForOutputByRouteA2A(
         includeSources: crossSwapWithAppFee.includeSources,
       }
     );
-    assertSources(destinationSources);
 
     const fetchFn = async () => {
+      assertSources(destinationSources);
       // 1. Get destination swap quote for bridgeable output token -> any token
       const destinationSwapQuote = await result.destinationStrategy.fetchFn(
         {
@@ -1232,7 +1232,6 @@ export async function getCrossSwapQuotesForOutputByRouteA2A(
     excludeSources: crossSwapWithAppFee.excludeSources,
     includeSources: crossSwapWithAppFee.includeSources,
   });
-  assertSources(originSources);
 
   const [finalDestinationSwapQuote, originSwapQuote] = await Promise.all([
     // 3.1. Get destination swap quote for bridgeable output token -> any token
@@ -1249,20 +1248,23 @@ export async function getCrossSwapQuotesForOutputByRouteA2A(
       }
     ),
     // 3.2. Get origin swap quote for any input token -> bridgeable input token
-    originStrategy.fetchFn(
-      {
-        ...originSwap,
-        depositor: crossSwapWithAppFee.depositor,
-        amount: addMarkupToAmount(
-          bridgeQuote.inputAmount,
-          QUOTE_BUFFER
-        ).toString(),
-      },
-      TradeType.EXACT_OUTPUT,
-      {
-        sources: originSources,
-      }
-    ),
+    (async () => {
+      assertSources(originSources);
+      return originStrategy.fetchFn(
+        {
+          ...originSwap,
+          depositor: crossSwapWithAppFee.depositor,
+          amount: addMarkupToAmount(
+            bridgeQuote.inputAmount,
+            QUOTE_BUFFER
+          ).toString(),
+        },
+        TradeType.EXACT_OUTPUT,
+        {
+          sources: originSources,
+        }
+      );
+    })(),
   ]);
   const appFee = calculateAppFee({
     outputAmount:


### PR DESCRIPTION
Source keys are not fully shared between strategies like 0x and LiFi.

0x: https://github.com/across-protocol/frontend/blob/fix-source-assertion/api/_dexes/0x/utils/sources.ts#L5

LiFi: https://github.com/across-protocol/frontend/blob/fix-source-assertion/api/_dexes/lifi/utils/sources.ts#L5

For example, "Camelot_V3" is not present for LiFi so in the current implementation we would throw when trying to assert the source of LiFi even though it exists for 0x.

In this PR, I am moving the `assertSources` call inside the fetch function so that it will not fail the swap but pick the first successful one via `executeStrategies`.

https://github.com/across-protocol/frontend/blob/fix-source-assertion/api/_dexes/cross-swap-service.ts#L1451-L1469

### Testing

excludeSources was set to velodrome_v2 and I can see in the response steps that we did not use it.
```
     "swapProvider": {
        "name": "0x",
        "sources": [
          "sushiswap_v3"
        ]
      }
```
- Origin txn: https://optimistic.etherscan.io/tx/0x1b89f1e5170f1f5804f278f255e9f94650b3d122702c99ef566e1be6c2b8a9b0
- Destination txn: https://arbiscan.io/tx/0x6af9c46e45668c29e6031367c7fffae2f98b5e0b92c68334d4bbae10d3930cc0


includeSources was set to camelot_v3 and I can see in the response steps that we used only it.
```
     "swapProvider": {
        "name": "0x",
        "sources": [
          "camelot_v3"
        ]
      }
```

- Origin txn: https://optimistic.etherscan.io/tx/0x93cd242543940ef70aea54f6069f3f919ce74fe171650014034a17fde0b4789a
- Destination txn: https://arbiscan.io/tx/0xca9794e186374b7d68838ccdbbea08ba0c8d5053d2e00984840825923cb7d6ec