### PR TITLE
feat(swap): use makeCallWithBalance for exactInput and minOutput messages

### DIFF
--- a/api/_dexes/cross-swap-service.ts
+++ b/api/_dexes/cross-swap-service.ts
@@ -135,13 +135,7 @@ export async function getCrossSwapQuotesForExactInputB2B(
     outputToken: crossSwap.outputToken,
     exactInputAmount: crossSwap.amount,
     recipient: getMultiCallHandlerAddress(crossSwap.outputToken.chainId),
-    message: buildExactInputBridgeTokenMessage(
-      crossSwap,
-      ConvertDecimals(
-        crossSwap.inputToken.decimals,
-        crossSwap.outputToken.decimals
-      )(crossSwap.amount)
-    ),
+    message: buildExactInputBridgeTokenMessage(crossSwap),
   });
 
   if (bridgeQuote.outputAmount.lt(0)) {
@@ -158,11 +152,7 @@ export async function getCrossSwapQuotesForExactInputB2B(
     appFeeRecipient: crossSwap.appFeeRecipient,
     isNative: crossSwap.isOutputNative,
   });
-  bridgeQuote.message = buildExactInputBridgeTokenMessage(
-    crossSwap,
-    bridgeQuote.outputAmount,
-    appFee
-  );
+  bridgeQuote.message = buildExactInputBridgeTokenMessage(crossSwap, appFee);
 
   return {
     crossSwap,
@@ -215,11 +205,7 @@ export async function getCrossSwapQuotesForOutputB2B(
     isNative: crossSwap.isOutputNative,
   });
   if (crossSwap.type === AMOUNT_TYPE.MIN_OUTPUT) {
-    bridgeQuote.message = buildMinOutputBridgeTokenMessage(
-      crossSwap,
-      bridgeQuote.outputAmount,
-      appFee
-    );
+    bridgeQuote.message = buildMinOutputBridgeTokenMessage(crossSwap, appFee);
   }
   if (crossSwap.type === AMOUNT_TYPE.EXACT_OUTPUT && appFee.feeAmount.gt(0)) {
     bridgeQuote.message = buildExactOutputBridgeTokenMessage(crossSwap, appFee);
@@ -627,13 +613,7 @@ export async function getCrossSwapQuotesForExactInputA2B(
     outputToken: crossSwap.outputToken,
     exactInputAmount: prioritizedStrategy.originSwapQuote.minAmountOut,
     recipient: getMultiCallHandlerAddress(destinationChainId),
-    message: buildExactInputBridgeTokenMessage(
-      crossSwap,
-      ConvertDecimals(
-        prioritizedStrategy.originSwapQuote.tokenOut.decimals,
-        crossSwap.outputToken.decimals
-      )(prioritizedStrategy.originSwapQuote.minAmountOut)
-    ),
+    message: buildExactInputBridgeTokenMessage(crossSwap),
   });
 
   if (bridgeQuote.outputAmount.lt(0)) {
@@ -650,11 +630,7 @@ export async function getCrossSwapQuotesForExactInputA2B(
     appFeeRecipient: crossSwap.appFeeRecipient,
     isNative: crossSwap.isInputNative,
   });
-  bridgeQuote.message = buildExactInputBridgeTokenMessage(
-    crossSwap,
-    bridgeQuote.outputAmount,
-    appFee
-  );
+  bridgeQuote.message = buildExactInputBridgeTokenMessage(crossSwap, appFee);
 
   return {
     crossSwap,
@@ -763,7 +739,6 @@ export async function getCrossSwapQuotesForOutputA2B(
   ) {
     bridgeQuote.message = buildMinOutputBridgeTokenMessage(
       crossSwapWithAppFee,
-      bridgeQuote.outputAmount,
       appFee
     );
   }

--- a/api/_dexes/cross-swap-service.ts
+++ b/api/_dexes/cross-swap-service.ts
@@ -10,7 +10,6 @@ import {
   addTimeoutToPromise,
   getLogger,
   addMarkupToAmount,
-  ConvertDecimals,
 } from "../_utils";
 import { CrossSwap, CrossSwapQuotes, QuoteFetchOpts } from "./types";
 import {

--- a/api/_dexes/cross-swap-service.ts
+++ b/api/_dexes/cross-swap-service.ts
@@ -679,7 +679,10 @@ export async function getCrossSwapQuotesForOutputA2B(
     outputToken: crossSwapWithAppFee.outputToken,
     minOutputAmount: crossSwapWithAppFee.amount,
     recipient: getMultiCallHandlerAddress(destinationChainId),
-    message: buildExactOutputBridgeTokenMessage(crossSwapWithAppFee),
+    message:
+      crossSwapWithAppFee.type === AMOUNT_TYPE.EXACT_OUTPUT
+        ? buildExactOutputBridgeTokenMessage(crossSwapWithAppFee)
+        : buildMinOutputBridgeTokenMessage(crossSwapWithAppFee),
   });
 
   const strategyFetches = results.map((result) => {
@@ -733,23 +736,12 @@ export async function getCrossSwapQuotesForOutputA2B(
     appFeeRecipient: crossSwapWithAppFee.appFeeRecipient,
     isNative: crossSwapWithAppFee.isOutputNative,
   });
-  if (
-    crossSwapWithAppFee.type === AMOUNT_TYPE.MIN_OUTPUT &&
-    (crossSwapWithAppFee.isOutputNative || appFee.feeAmount.gt(0))
-  ) {
-    bridgeQuote.message = buildMinOutputBridgeTokenMessage(
-      crossSwapWithAppFee,
-      appFee
-    );
-  }
-  if (
-    crossSwapWithAppFee.type === AMOUNT_TYPE.EXACT_OUTPUT &&
-    appFee.feeAmount.gt(0)
-  ) {
-    bridgeQuote.message = buildExactOutputBridgeTokenMessage(
-      crossSwapWithAppFee,
-      appFee
-    );
+
+  if (appFee.feeAmount.gt(0)) {
+    bridgeQuote.message =
+      crossSwapWithAppFee.type === AMOUNT_TYPE.EXACT_OUTPUT
+        ? buildExactOutputBridgeTokenMessage(crossSwapWithAppFee, appFee)
+        : buildMinOutputBridgeTokenMessage(crossSwapWithAppFee, appFee);
   }
 
   return {

--- a/api/_multicall-handler.ts
+++ b/api/_multicall-handler.ts
@@ -80,6 +80,25 @@ export function encodeDrainCalldata(token: string, destination: string) {
   ]);
 }
 
+/**
+ * Encodes calldata for withdrawing all wrapped native tokens using MulticallHandler's makeCallWithBalance
+ * @param token - The wrapped native token contract address
+ */
+export function encodeWithdrawAllWethCalldata(token: string) {
+  return encodeMakeCallWithBalanceCalldata(
+    token,
+    encodeWethWithdrawCalldata(BigNumber.from(0)), // Placeholder amount, will be replaced
+    "0", // No ETH value needed for this call
+    // Replacement instructions to dynamically set the balance to withdraw
+    [
+      {
+        token,
+        offset: 4, // Amount is the only parameter, so just skip the first 4 bytes which are the function selector
+      },
+    ]
+  );
+}
+
 export function encodeMakeCallWithBalanceCalldata(
   target: string,
   callData: string,

--- a/api/_multicall-handler.ts
+++ b/api/_multicall-handler.ts
@@ -89,7 +89,7 @@ export function encodeWithdrawAllWethCalldata(token: string) {
     token,
     encodeWethWithdrawCalldata(BigNumber.from(0)), // Placeholder amount, will be replaced
     "0", // No ETH value needed for this call
-    // Replacement instructions to dynamically set the balance to withdraw
+    // Replacement instructions to dynamically set the balance to withdraw:
     [
       {
         token,


### PR DESCRIPTION
This PR:

- Starts using MulticallHandler's `makeCallWithBalance` function to perform unwrap and transfer actions whenever the tradeType is `exactInput` or `minOutput`. This ensures we use all available balances at destination.

  Some tests:

  - **exactInput – B2A – usdc-eth**
    - [Deposit](https://optimistic.etherscan.io/tx/0x4b8764d502ba949f0917b5742240a9f28f9669fcc65f44d0e8a69fff988c1e3e)
    - [Fill](https://arbiscan.io/tx/0x72fd5832ee68ffa1003fc6f8a17bc1341760e5bc39ba58de35b3888e4d533e00)

  - **minOutput – B2A – usdc-eth**
    - [Deposit](https://optimistic.etherscan.io/tx/0x3897554810f7b23d4e2ef5f54b2849011c50455086d2aaee73e9024976ed7869)
    - [Fill](https://arbiscan.io/tx/0x570f3d2748ab4188a5df5dbccde65f76c5756a6d2373cc150766b317a44446cf)

  

- Improves transactions in which we were doing two transfers but could've done a single one. The cause of this was that we were not using the minOutput message creation function within the A2B flow.

   See these fills: [before](https://arbiscan.io/tx/0xaa5e49ba611334281aac65af7a0d0c15a171921066544da417c85fcdd400eda7), [after](https://arbiscan.io/tx/0x745e894f4d988bacb128fe5329f7524ac5a0e4cf935cfe37a893568e3e4df464).

- Fixes an edge case with EXACT_OUTPUT transactions including a destination swap that were leaving tokens in the MulticallHandler contract. The cause of this was a missing drain call.

   See these fills:
    - [before](https://arbiscan.io/tx/0xbc4537cf3065829ca99686259b32b0251ba4f6543579874a2e14a3f429b74b9e): note we unwrapped only 0.001 weth but there were no transfers for the extra tokens.
    - [after](https://arbiscan.io/tx/0x940f8aa4716b33085e1b28f34223c6ae87f7dc83a0a416e06f129536b62c8f20): we unwrapped 0.001 weth but there's an extra call transferring the extra tokens. 



