### PR TITLE
fix: align percentage query params `slippage` and `appFee`

### DIFF
--- a/api/swap/_utils.ts
+++ b/api/swap/_utils.ts
@@ -62,11 +62,13 @@ export const BaseSwapQueryParamsSchema = type({
   integratorId: optional(string()),
   refundAddress: optional(validAddress()),
   refundOnOrigin: optional(boolStr()),
+  // DEPRECATED: Use `slippage` instead
   slippageTolerance: optional(positiveFloatStr(50)), // max. 50% slippage
+  slippage: optional(positiveFloatStr(0.5)), // max. 50% slippage
   skipOriginTxEstimation: optional(boolStr()),
   excludeSources: optional(union([array(string()), string()])),
   includeSources: optional(union([array(string()), string()])),
-  appFeePercent: optional(positiveFloatStr(1)),
+  appFee: optional(positiveFloatStr(1)),
   appFeeRecipient: optional(validAddress()),
 });
 
@@ -89,11 +91,12 @@ export async function handleBaseSwapQueryParams(
     integratorId,
     refundAddress,
     refundOnOrigin: _refundOnOrigin = "true",
-    slippageTolerance = "1", // Default to 1% slippage
+    slippageTolerance,
+    slippage = "0.01", // Default to 1% slippage
     skipOriginTxEstimation: _skipOriginTxEstimation = "false",
     excludeSources: _excludeSources,
     includeSources: _includeSources,
-    appFeePercent,
+    appFee,
     appFeeRecipient,
   } = query;
 
@@ -125,14 +128,11 @@ export async function handleBaseSwapQueryParams(
   }
 
   // Validate that both app fee parameters are provided together
-  if (
-    (appFeePercent && !appFeeRecipient) ||
-    (!appFeePercent && appFeeRecipient)
-  ) {
+  if ((appFee && !appFeeRecipient) || (!appFee && appFeeRecipient)) {
     throw new InvalidParamError({
-      param: "appFeePercent, appFeeRecipient",
+      param: "appFee, appFeeRecipient",
       message:
-        "Both 'appFeePercent' and 'appFeeRecipient' must be provided together, or neither should be provided.",
+        "Both 'appFee' and 'appFeeRecipient' must be provided together, or neither should be provided.",
     });
   }
 
@@ -160,10 +160,11 @@ export async function handleBaseSwapQueryParams(
   const amountType = tradeType as AmountType;
   const amount = BigNumber.from(_amount);
 
-  const slippageToleranceNum = parseFloat(slippageTolerance);
-  const appFeePercentNum = appFeePercent
-    ? parseFloat(appFeePercent)
+  const slippageToleranceNum = slippageTolerance
+    ? parseFloat(slippageTolerance)
     : undefined;
+  const slippageNum = parseFloat(slippage);
+  const appFeePercentNum = appFee ? parseFloat(appFee) : undefined;
 
   const [inputToken, outputToken] = await Promise.all([
     getCachedTokenInfo({
@@ -190,6 +191,7 @@ export async function handleBaseSwapQueryParams(
     recipient,
     depositor,
     slippageTolerance: slippageToleranceNum,
+    slippage: slippageNum,
     excludeSources,
     includeSources,
     appFeePercent: appFeePercentNum,

--- a/api/swap/_utils.ts
+++ b/api/swap/_utils.ts
@@ -164,7 +164,7 @@ export async function handleBaseSwapQueryParams(
     ? parseFloat(slippageTolerance)
     : undefined;
   const slippageNum = parseFloat(slippage);
-  const appFeePercentNum = appFee ? parseFloat(appFee) : undefined;
+  const appFeeNum = appFee ? parseFloat(appFee) : undefined;
 
   const [inputToken, outputToken] = await Promise.all([
     getCachedTokenInfo({
@@ -194,7 +194,7 @@ export async function handleBaseSwapQueryParams(
     slippage: slippageNum,
     excludeSources,
     includeSources,
-    appFeePercent: appFeePercentNum,
+    appFeePercent: appFeeNum,
     appFeeRecipient,
   };
 }

--- a/api/swap/approval/_service.ts
+++ b/api/swap/approval/_service.ts
@@ -69,7 +69,7 @@ export async function handleApprovalSwap(
       ? handleSwapBody(request.body, Number(request.query.destinationChainId))
       : { actions: [] };
 
-  const slippageTolerance = _slippageTolerance ?? (slippage * 100);
+  const slippageTolerance = _slippageTolerance ?? slippage * 100;
 
   const crossSwapQuotes = await getCrossSwapQuotes(
     {

--- a/api/swap/approval/_service.ts
+++ b/api/swap/approval/_service.ts
@@ -56,7 +56,8 @@ export async function handleApprovalSwap(
     refundAddress,
     recipient,
     depositor,
-    slippageTolerance,
+    slippageTolerance: _slippageTolerance, // DEPRECATED: slippage expressed as 0 <= slippage <= 100, 1 = 1%
+    slippage, // slippage expressed as 0 <= slippage <= 1, 0.01 = 1%
     excludeSources,
     includeSources,
     appFeePercent,
@@ -67,6 +68,8 @@ export async function handleApprovalSwap(
     request.body && Object.keys(request.body).length > 0
       ? handleSwapBody(request.body, Number(request.query.destinationChainId))
       : { actions: [] };
+
+  const slippageTolerance = _slippageTolerance ?? slippage * 100;
 
   const crossSwapQuotes = await getCrossSwapQuotes(
     {

--- a/api/swap/approval/_service.ts
+++ b/api/swap/approval/_service.ts
@@ -69,7 +69,7 @@ export async function handleApprovalSwap(
       ? handleSwapBody(request.body, Number(request.query.destinationChainId))
       : { actions: [] };
 
-  const slippageTolerance = _slippageTolerance ?? slippage * 100;
+  const slippageTolerance = _slippageTolerance ?? (slippage * 100);
 
   const crossSwapQuotes = await getCrossSwapQuotes(
     {

--- a/scripts/tests/_swap-utils.ts
+++ b/scripts/tests/_swap-utils.ts
@@ -69,9 +69,9 @@ export const argsFromCli = yargs(hideBin(process.argv))
         description: "Amount of input token.",
         default: 1_000_000,
       })
-      .option("slippageTolerance", {
+      .option("slippage", {
         alias: "s",
-        description: "Slippage tolerance.",
+        description: "Slippage tolerance. 0 <= slippage <= 1, 0.01 = 1%",
       })
       .option("tradeType", {
         alias: "tt",
@@ -115,9 +115,9 @@ export const argsFromCli = yargs(hideBin(process.argv))
         description: "Comma-separated list of sources to exclude.",
         type: "string",
       })
-      .option("appFeePercent", {
+      .option("appFee", {
         alias: "apf",
-        description: "App fee percent.",
+        description: "App fee percent. 0 <= appFee <= 1, 0.01 = 1%",
         type: "number",
       })
       .option("appFeeRecipient", {
@@ -187,7 +187,7 @@ export async function fetchSwapQuotes() {
       inputToken,
       outputToken,
       amount,
-      slippageTolerance,
+      slippage,
       tradeType,
       recipient,
       depositor,
@@ -195,7 +195,7 @@ export async function fetchSwapQuotes() {
       skipOriginTxEstimation,
       includeSources,
       excludeSources,
-      appFeePercent,
+      appFee,
       appFeeRecipient,
     } = argsFromCli;
     const params = {
@@ -204,7 +204,7 @@ export async function fetchSwapQuotes() {
       inputToken,
       outputToken,
       amount,
-      slippageTolerance,
+      slippage,
       tradeType,
       recipient,
       depositor,
@@ -218,7 +218,7 @@ export async function fetchSwapQuotes() {
         typeof excludeSources === "string"
           ? excludeSources.split(",")
           : excludeSources,
-      appFeePercent,
+      appFee,
       appFeeRecipient,
     };
     console.log("Params:", params);


### PR DESCRIPTION
Attempt to align percentage query param values `slippage` and `appFee`:
- `slippage` and `appFee` are expressed in range `0 <= x <= 1`, i.e. 0.01 = 1%
- `slippageTolerance` kept for backwards compatibility