### PR TITLE
fix: make value optional in action argument

### DIFF
--- a/api/swap/_utils.ts
+++ b/api/swap/_utils.ts
@@ -296,7 +296,7 @@ export function encodeActionCalls(actions: Action[], targetChainId: number) {
     return args.map((arg) => {
       if (Array.isArray(arg)) {
         return flattenArgs(arg, depth + 1);
-      } else if (arg && typeof arg === "object" && "value" in arg) {
+      } else if (arg && typeof arg === "object") {
         // Fields to be populated dynamically must be zeroed out
         return arg.populateDynamically ? "0" : arg.value;
       } else {


### PR DESCRIPTION
When setting `populateDynamically` to true, we shouldn't require the `value` field to be populated in the action since it gets overridden anyway. Currently we throw an exception in this case because we are looking for `("value" in arg)` to do the dynamic population and skip processing if it's not present.

We can fix this by only using `arg.value` if `populateDynamically` is not set and `value` is set. Else we default to 0 as it was before.

**Test case:**
Bridge + destination swap USDC to >0.005 WETH from Arbitrum to Optimism and transfer all available destination swap output token to dev wallet 2 (0x718648C8c531F91b528A7757dD2bE813c3940608). I omitted the `value` field.

```
actions: [
      {
        target: testCase.params.outputToken,
        functionSignature: "function transfer(address to, uint256 value)",
        args: [
          { value: ACROSS_DEV_WALLET_2 },
          {
            populateDynamically: true,
            balanceSource: testCase.params.outputToken,
          },
        ],
        value: "0",
      },
    ],
```

**Test Result:**
- Origin txn: https://arbiscan.io/tx/0x79498f1a6ce0612a82e0336ae2ced53f587654a24d649ebd98eb821f74bc92c1
- Destination txn: https://optimistic.etherscan.io/tx/0xf5ab61b7dbd8378604b08c5a2219e22f3c21c4bd919da2a4563ef1f0e585199f
