### PR TITLE
fix: output amount b2a

### DIFF
--- a/api/_dexes/cross-swap-service.ts
+++ b/api/_dexes/cross-swap-service.ts
@@ -449,6 +449,7 @@ export async function getCrossSwapQuotesForOutputB2A(
       routerAddress: destinationRouter.address,
       appFee,
     }),
+    forceExactOutput: true,
   });
   assertMinOutputAmount(
     bridgeQuote.outputAmount,


### PR DESCRIPTION
This set allows the recipient to be paid out in a single token for dust in the case of B2A.

Previous fill: https://basescan.org/tx/0x4211a8084a3b5ef3c4b8254056d515a219f174c43833060f8eb6046c20cf3688
Fixed fill: https://basescan.org/tx/0xd3a646c0f4cd5f3cbc6216923624eb3516666ed3067ed661428138e83c182aec