### PR TITLE
fix: use executeStrategies for A2A output swaps

### DIFF
--- a/api/_dexes/cross-swap-service.ts
+++ b/api/_dexes/cross-swap-service.ts
@@ -1283,23 +1283,28 @@ export async function getCrossSwapQuotesForOutputByRouteA2A(
       }
     ),
     // 3.2. Get origin swap quote for any input token -> bridgeable input token
-    (async () => {
-      assertSources(originSources);
-      return originStrategy.fetchFn(
-        {
-          ...originSwap,
-          depositor: crossSwapWithAppFee.depositor,
-          amount: addMarkupToAmount(
-            bridgeQuote.inputAmount,
-            QUOTE_BUFFER
-          ).toString(),
+    executeStrategies(
+      [
+        async () => {
+          assertSources(originSources);
+          return originStrategy.fetchFn(
+            {
+              ...originSwap,
+              depositor: crossSwapWithAppFee.depositor,
+              amount: addMarkupToAmount(
+                bridgeQuote.inputAmount,
+                QUOTE_BUFFER
+              ).toString(),
+            },
+            TradeType.EXACT_OUTPUT,
+            {
+              sources: originSources,
+            }
+          );
         },
-        TradeType.EXACT_OUTPUT,
-        {
-          sources: originSources,
-        }
-      );
-    })(),
+      ],
+      strategies.prioritizationMode
+    ),
   ]);
   const appFee = calculateAppFee({
     outputAmount:


### PR DESCRIPTION
While doing test case 3.1.2 (Invalid source - negative scenario), I noticed that for A2A output based swaps, we are not wrapping the fetch function in `executeStrategies`. This makes it so we skip all the error handling and consolidation logic in which is part of `executeStrategies`.

For output A2A, we return this even if the user passes a valid source like 'camelot_v3'.

>None of the provided sources are valid. Call the endpoint /swap/sources to get a list of valid sources.

Wrapping the fetch function call should fix the issue.