### PR TITLE
chore: change variable name for easier understanding

### DIFF
--- a/api/swap/_utils.ts
+++ b/api/swap/_utils.ts
@@ -209,12 +209,12 @@ const ActionArg = refine(
   object({
     value: unknown(), // Will be validated at runtime
     populateDynamically: optional(boolean()),
-    balanceSource: optional(validEvmAddress()),
+    balanceSourceToken: optional(validEvmAddress()),
   }),
-  "balanceSource",
+  "balanceSourceToken",
   (argument) => {
-    if (argument.populateDynamically && !argument.balanceSource) {
-      return "balanceSource is required when populateDynamically is true";
+    if (argument.populateDynamically && !argument.balanceSourceToken) {
+      return "balanceSourceToken is required when populateDynamically is true";
     }
     return true;
   }
@@ -400,7 +400,7 @@ export function getWrappedCallForMakeCallWithBalance(
     .map((arg, index) => {
       if (arg.populateDynamically) {
         return {
-          token: arg.balanceSource,
+          token: arg.balanceSourceToken,
           // Arguments start at byte 4 (after the 4-byte function selector)
           // And each argument is 32 bytes long
           offset: 4 + index * 32,

--- a/scripts/tests/_swap-utils.ts
+++ b/scripts/tests/_swap-utils.ts
@@ -427,7 +427,7 @@ export async function getERC20DestinationAction(testCase: {
           {
             value: testCase.params.amount,
             populateDynamically: true,
-            balanceSource: testCase.params.outputToken,
+            balanceSourceToken: testCase.params.outputToken,
           },
         ],
         value: "0",


### PR DESCRIPTION
While forming the request body for embedded crosschain actions in the crosschain swap API, it was a bit confusing to grasp that `balanceSource` should actually be the token on destination chain and not the multicall Handler on the destination chain. 

Therefore to make it easier to understand for developers and integrator, we felt a better way to present this would be to call it `balanceSourceToken` to clearly indicate that a token address should be given here. Thus this PR changes `balanceSource` to `balanceSourceToken`.
