### PR TITLE
check if sol address is program

### DIFF
--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -1,7 +1,9 @@
 import { utils } from "ethers";
 
 import { ChainId } from "./constants";
-import { getProvider } from "./providers";
+import { getProvider, getSVMRpc } from "./providers";
+import { address as solanaAddress } from "@solana/kit";
+import { chainIsSvm } from "./sdk";
 
 export function isValidAddress(address: string) {
   return utils.isAddress(address);
@@ -12,7 +14,23 @@ export function getAddress(address: string) {
 }
 
 export const noContractCode = "0x";
+
 export async function getCode(address: string, chainId: ChainId) {
   const provider = getProvider(chainId);
   return await provider.getCode(address);
+}
+
+export async function isProgram(address: string, chainId: ChainId) {
+  if (!chainIsSvm(chainId)) {
+    throw new Error(`Chain ${chainId} is not an SVM chain`);
+  }
+  const rpc = getSVMRpc(chainId);
+  const addr = solanaAddress(address);
+  const { value: accountInfo } = await rpc.getAccountInfo(addr).send();
+
+  if (!accountInfo) {
+    throw new Error(`Account ${address} does not exist on chain ${chainId}`);
+  }
+
+  return accountInfo.executable;
 }


### PR DESCRIPTION
closes ACX-4309
## Fix useAddressType called with mismatched address/chain ecosystems

### Problem
When selecting EVM => SVM bridge routes, `useAddressType` was incorrectly called with EVM addresses and SVM chain IDs, causing validation errors and incorrect address type detection.

### Solution
- Updated `useToAccount` to only validate addresses when they match the destination chain ecosystem
- EVM addresses are only validated when destination is EVM
- SVM addresses are only validated when destination is SVM  

### Notes
We currently have no use for checking if a destination address is a program or not, since we only support USDC.
BUT int he future we might want to display a warning to the user to prevent them from blackholing funds.