### PR TITLE
fix: codegen enhancements

### DIFF
--- a/api/_dexes/lifi/utils/sources.ts
+++ b/api/_dexes/lifi/utils/sources.ts
@@ -1,5 +1,5 @@
 // Auto-generated file. Do not edit manually.
-// Generated on 2025-08-19T10:24:43.694Z
+// Generated on 2025-08-19T17:58:21.186Z
 // This file contains available liquidity sources for LiFi DEX integration
 
 export const SOURCES = {
@@ -115,7 +115,6 @@ export const SOURCES = {
       { key: "sushiswap", names: ["sushiswap"] },
       { key: "okx", names: ["okx"] },
     ],
-    "60808": [{ key: "lifidexaggregator", names: ["lifidexaggregator"] }],
     "81457": [
       { key: "openocean", names: ["openocean"] },
       { key: "kyberswap", names: ["kyberswap"] },

--- a/scripts/utils/codegen-utils.ts
+++ b/scripts/utils/codegen-utils.ts
@@ -1,0 +1,49 @@
+import { writeFileSync, readFileSync, existsSync } from "fs";
+import * as prettier from "prettier";
+
+/**
+ * Writes a file with change detection, only updating if content has actually changed
+ * @param filePath - Path to the file to write
+ * @param description - Description for the file (e.g., "This file contains available liquidity sources for 0x DEX integration")
+ * @param codeContent - The actual code content (without timestamp)
+ * @returns true if the file was updated, false if no changes were detected
+ */
+export async function writeFileWithChangeDetection(
+  filePath: string,
+  description: string,
+  codeContent: string
+): Promise<boolean> {
+  const timestampComment = `// Auto-generated file. Do not edit manually.
+// Generated on ${new Date().toISOString()}
+// ${description}
+
+`;
+  const formattedCode = await prettier.format(codeContent, {
+    parser: "typescript",
+  });
+  const fullContent = timestampComment + formattedCode;
+
+  if (existsSync(filePath)) {
+    const existingContent = readFileSync(filePath, "utf8");
+
+    // Extract the code part from existing content (skip timestamp comment)
+    // Look for the first non-comment line and take everything from there
+    const existingCodeMatch = existingContent.match(
+      /^(?:\s*\/\/.*\n?)*\s*([\s\S]*)$/
+    );
+    const existingCode = existingCodeMatch ? existingCodeMatch[1] : "";
+
+    if (existingCode !== formattedCode) {
+      writeFileSync(filePath, fullContent);
+      console.log(`✅ Updated: ${filePath}`);
+      return true;
+    } else {
+      console.log(`⏭️  No changes detected: ${filePath}`);
+      return false;
+    }
+  } else {
+    writeFileSync(filePath, fullContent);
+    console.log(`✅ Generated: ${filePath}`);
+    return true;
+  }
+}


### PR DESCRIPTION
We added `scripts/generate-dex-sources.ts` to `lint-staged` but this was causing frequent merge conflicts due to timestamp changes even though the actual source file did not change.

In this PR:

- Create new reusable function `writeFileWithChangeDetection` which only updates generated files if there is a change in content. This will let us leverage the same functionality for future codegen scripts.
- Update usage in `scripts/generate-dex-sources.ts`.

I tested and ensured that only a single file is updated and the other one is skipped if there are no real changes.

```
⏭️  No changes detected: /Users/ashwinswaroop/Repos/frontend/api/_dexes/0x/utils/sources.ts
✅ Updated: /Users/ashwinswaroop/Repos/frontend/api/_dexes/lifi/utils/sources.ts
```

The updated file is included in my commit for reference.