### PR TITLE
fix: close sidebar on select

### DIFF
--- a/src/components/Sidebar/components/WalletContent.tsx
+++ b/src/components/Sidebar/components/WalletContent.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useEffect } from "react";
 import { Connector, useAccount } from "wagmi";
 import { useWallet } from "@solana/wallet-adapter-react";
 import styled from "@emotion/styled";
@@ -95,6 +95,13 @@ function SVMWalletContent() {
   const { closeSidebar } = useSidebarContext();
   const { connected: isSolanaConnected } = useWallet();
 
+  useEffect(() => {
+    if (!connecting && isSolanaConnected) {
+      closeSidebar();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [connecting, isSolanaConnected]);
+
   const handleClickSvmWallet = useCallback(
     async (walletAdapter: WalletAdapter) => {
       try {
@@ -102,14 +109,11 @@ function SVMWalletContent() {
           await disconnect();
         }
         select(walletAdapter.name);
-        walletAdapter.once("connect", () => {
-          closeSidebar();
-        });
       } catch (e) {
         console.error("Error connecting to Solana wallet", e);
       }
     },
-    [select, connected, disconnect, closeSidebar]
+    [select, connected, disconnect]
   );
 
   if (isSolanaConnected) {


### PR DESCRIPTION
Solana was having issues with the .once() event listener. However, the combination of ~isConnecting && isConnected is unique to our current state flow for when a wallet completes connection.

Closes ACX-4291