### PR TITLE
fix: Solana cron cache gas prices

### DIFF
--- a/api/_dexes/lifi/utils/sources.ts
+++ b/api/_dexes/lifi/utils/sources.ts
@@ -1,5 +1,5 @@
 // Auto-generated file. Do not edit manually.
-// Generated on 2025-08-19T17:58:21.186Z
+// Generated on 2025-08-20T19:19:37.700Z
 // This file contains available liquidity sources for LiFi DEX integration
 
 export const SOURCES = {
@@ -115,6 +115,7 @@ export const SOURCES = {
       { key: "sushiswap", names: ["sushiswap"] },
       { key: "okx", names: ["okx"] },
     ],
+    "60808": [{ key: "lifidexaggregator", names: ["lifidexaggregator"] }],
     "81457": [
       { key: "openocean", names: ["openocean"] },
       { key: "kyberswap", names: ["kyberswap"] },

--- a/api/cron-cache-gas-prices.ts
+++ b/api/cron-cache-gas-prices.ts
@@ -12,7 +12,7 @@ import {
   resolveVercelEndpoint,
 } from "./_utils";
 import { UnauthorizedError } from "./_errors";
-import { CHAIN_IDs } from "./_constants";
+import { CHAIN_IDs, TOKEN_SYMBOLS_MAP } from "./_constants";
 import { getDepositArgsForCachedGasDetails } from "./_gas";
 import { getEnvs } from "./_env";
 
@@ -123,7 +123,14 @@ const handler = async (
       Promise.all(
         mainnetChains
           .filter((chain) => chain.chainId !== CHAIN_IDs.LINEA)
-          .map((chain) => updateGasPricePromise(chain.chainId))
+          .map((chain) =>
+            chain.chainId === CHAIN_IDs.SOLANA
+              ? updateGasPricePromise(
+                  chain.chainId,
+                  TOKEN_SYMBOLS_MAP.USDC.addresses[CHAIN_IDs.SOLANA]
+                )
+              : updateGasPricePromise(chain.chainId)
+          )
       ),
       Promise.all(
         lineaDestinationRoutes().map((destinationToken) =>


### PR DESCRIPTION
We were trying to estimate Solana gas fees without providing a transaction, but the gas oracle needs one in order to return an estimate. See [here](https://github.com/across-protocol/sdk/blob/master/src/gasPriceOracle/adapters/solana.ts#L16).