### PR TITLE
ci: revert `repository_dispatch` trigger

### DIFF
--- a/.github/workflows/e2e-api.yaml
+++ b/.github/workflows/e2e-api.yaml
@@ -1,15 +1,13 @@
 name: API E2E Tests
 
 on:
-  repository_dispatch:
-    types:
-      - "vercel.deployment.success"
+  deployment_status:
 
 jobs:
   e2e-api-tests:
     if: |
-      github.event_name == 'repository_dispatch' &&
-      github.event.client_payload.project.name == 'app-frontend-v3'
+      github.event.deployment_status.state == 'success' &&
+      contains(github.event.deployment_status.environment_url, 'app-frontend-v3')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,15 +1,13 @@
 name: UI E2E Tests
 
 on:
-  repository_dispatch:
-    types:
-      - "vercel.deployment.success"
+  deployment_status:
 
 jobs:
   e2e-tests:
     if: |
-      github.event_name == 'repository_dispatch' &&
-      github.event.client_payload.project.name == 'app-frontend-v3'
+      github.event.deployment_status.state == 'success' &&
+      contains(github.event.deployment_status.environment_url, 'app-frontend-v3')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
For our use case, the legacy `deployment_status` makes more sense