### PR TITLE
fix: minor changes needed for SVM origin swaps

### DIFF
--- a/api/swap/_utils.ts
+++ b/api/swap/_utils.ts
@@ -127,16 +127,19 @@ export async function handleBaseSwapQueryParams(
     : undefined;
 
   if (isDestinationSvm) {
-    if (!recipient) {
-      throw new InvalidParamError({
-        param: "recipient",
-        message: "Recipient is required for SVM destinations",
-      });
-    }
     if (appFee || appFeeRecipient) {
       throw new InvalidParamError({
         param: "appFee, appFeeRecipient",
         message: "App fee is not supported for SVM destinations",
+      });
+    }
+  }
+
+  if (isOriginSvm || isDestinationSvm) {
+    if (!recipient) {
+      throw new InvalidParamError({
+        param: "recipient",
+        message: "Recipient is required for SVM destinations or origins",
       });
     }
   }

--- a/api/swap/_utils.ts
+++ b/api/swap/_utils.ts
@@ -139,7 +139,7 @@ export async function handleBaseSwapQueryParams(
     if (!recipient) {
       throw new InvalidParamError({
         param: "recipient",
-        message: "Recipient is required for SVM destinations or origins",
+        message: "Recipient is required for routes involving an SVM chain",
       });
     }
   }

--- a/api/swap/approval/_utils.ts
+++ b/api/swap/approval/_utils.ts
@@ -299,12 +299,18 @@ async function _buildDepositTxForAllowanceHolderSvm(
   );
   const inputToken = address(
     sdk.utils
-      .toAddressType(crossSwap.inputToken.address, originChainId)
+      .toAddressType(
+        crossSwapQuotes.bridgeQuote.inputToken.address,
+        originChainId
+      )
       .toBase58()
   );
   const outputToken = address(
     sdk.utils
-      .toAddressType(crossSwap.outputToken.address, destinationChainId)
+      .toAddressType(
+        crossSwapQuotes.bridgeQuote.outputToken.address,
+        destinationChainId
+      )
       .toBase58()
   );
   const inputAmount = BigInt(

--- a/src/data/examples/rpc-providers.json
+++ b/src/data/examples/rpc-providers.json
@@ -16,7 +16,8 @@
         "59144": "https://rpc.linea.build",
         "81457": "https://rpc.blast.io",
         "534352": "https://rpc.scroll.io",
-        "7777777": "https://rpc.zora.energy"
+        "7777777": "https://rpc.zora.energy",
+        "34268394551451": "https://api.mainnet-beta.solana.com"
       }
     }
   }


### PR DESCRIPTION
While we get the approach for handling messages finalized, here are some prerequisites:
- In `buildDestinationSwapCrossChainMessage`, we should consider the destination and fallback recipients separately from the depositor
- Make recipient required for origin and destination SVM swaps
- Fix: Make input and output token in the bridge message be the bridge input and bridge output as opposed to the swap input and swap output
- Add Solana RPC to `src/data/examples/rpc-providers.json`