### PR TITLE
refactor: prepare multi-bridge-strategy support

### DIFF
--- a/api/_bridges/across/strategy.ts
+++ b/api/_bridges/across/strategy.ts
@@ -42,7 +42,7 @@ export function getAcrossBridgeStrategy(): BridgeStrategy {
       return getBridgeQuoteMessage(crossSwap, appFee);
     },
 
-    getQuoteExactInput: async ({
+    getQuoteForExactInput: async ({
       inputToken,
       outputToken,
       exactInputAmount,

--- a/api/_bridges/across/strategy.ts
+++ b/api/_bridges/across/strategy.ts
@@ -1,0 +1,92 @@
+import {
+  BridgeStrategy,
+  GetExactInputBridgeQuoteParams,
+  BridgeCapabilities,
+  GetOutputBridgeQuoteParams,
+} from "../types";
+import { CrossSwap, CrossSwapQuotes } from "../../_dexes/types";
+import {
+  getBridgeQuoteForExactInput,
+  getBridgeQuoteForOutput,
+} from "../../_utils";
+import { buildCrossSwapTxForAllowanceHolder } from "../../swap/approval/_utils";
+import {
+  getBridgeQuoteRecipient,
+  getBridgeQuoteMessage,
+} from "../../_dexes/utils";
+import { AppFee } from "../../_dexes/utils";
+
+const name = "across";
+const capabilities: BridgeCapabilities = {
+  ecosystems: ["evm", "svm"],
+  supports: {
+    A2A: true,
+    A2B: true,
+    B2A: true,
+    B2B: true,
+    B2BI: true,
+    crossChainMessage: true,
+  },
+};
+
+export function getAcrossBridgeStrategy(): BridgeStrategy {
+  return {
+    name,
+    capabilities,
+
+    getBridgeQuoteRecipient: (crossSwap: CrossSwap) => {
+      return getBridgeQuoteRecipient(crossSwap);
+    },
+
+    getBridgeQuoteMessage: (crossSwap: CrossSwap, appFee?: AppFee) => {
+      return getBridgeQuoteMessage(crossSwap, appFee);
+    },
+
+    getQuoteExactInput: async ({
+      inputToken,
+      outputToken,
+      exactInputAmount,
+      recipient,
+      message,
+    }: GetExactInputBridgeQuoteParams) => {
+      const bridgeQuote = await getBridgeQuoteForExactInput({
+        inputToken,
+        outputToken,
+        exactInputAmount,
+        recipient,
+        message,
+      });
+      return { bridgeQuote };
+    },
+
+    getQuoteForOutput: async ({
+      inputToken,
+      outputToken,
+      minOutputAmount,
+      forceExactOutput,
+      recipient,
+      message,
+    }: GetOutputBridgeQuoteParams) => {
+      const bridgeQuote = await getBridgeQuoteForOutput({
+        inputToken,
+        outputToken,
+        minOutputAmount,
+        recipient,
+        message,
+        forceExactOutput,
+      });
+      return { bridgeQuote };
+    },
+
+    buildTxForAllowanceHolder: async (params: {
+      quotes: CrossSwapQuotes;
+      integratorId?: string | undefined;
+    }) => {
+      const tx = await buildCrossSwapTxForAllowanceHolder(
+        params.quotes,
+        params.integratorId
+      );
+      return tx;
+    },
+  };
+}

--- a/api/_bridges/index.ts
+++ b/api/_bridges/index.ts
@@ -1,0 +1,20 @@
+import { getAcrossBridgeStrategy } from "./across/strategy";
+import { BridgeStrategiesConfig } from "./types";
+
+export const bridgeStrategies: BridgeStrategiesConfig = {
+  default: getAcrossBridgeStrategy(),
+};
+
+// TODO: Extend the strategy selection based on more sophisticated logic when we start
+// implementing burn/mint bridges.
+export function getBridgeStrategy({
+  originChainId,
+  destinationChainId,
+}: {
+  originChainId: number;
+  destinationChainId: number;
+}) {
+  const fromToChainOverride =
+    bridgeStrategies.fromToChains?.[originChainId]?.[destinationChainId];
+  return fromToChainOverride ?? bridgeStrategies.default;
+}

--- a/api/_bridges/types.ts
+++ b/api/_bridges/types.ts
@@ -1,0 +1,90 @@
+import { BigNumber } from "ethers";
+
+import { CrossSwap, CrossSwapQuotes, Token } from "../_dexes/types";
+import { AppFee } from "../_dexes/utils";
+
+export type BridgeStrategiesConfig = {
+  default: BridgeStrategy;
+  fromToChains?: {
+    [fromChainId: number]: {
+      [toChainId: number]: BridgeStrategy;
+    };
+  };
+};
+
+export type BridgeCapabilities = {
+  ecosystems: ("evm" | "svm")[];
+  supports: {
+    A2A: boolean;
+    A2B: boolean;
+    B2A: boolean;
+    B2B: boolean;
+    B2BI?: boolean;
+    crossChainMessage: boolean;
+  };
+};
+
+export type BridgeContracts = {
+  depositEntryPoint?: { name: string; address: string };
+};
+
+export type OriginTx =
+  | {
+      ecosystem: "evm";
+      chainId: number;
+      from: string;
+      to: string;
+      data: string;
+      value?: BigNumber;
+    }
+  | {
+      ecosystem: "svm";
+      chainId: number;
+      to: string;
+      data: string;
+    };
+
+export type GetBridgeQuoteParams = {
+  inputToken: Token;
+  outputToken: Token;
+  recipient?: string;
+  message?: string;
+};
+
+export type GetExactInputBridgeQuoteParams = GetBridgeQuoteParams & {
+  exactInputAmount: BigNumber;
+};
+
+export type GetOutputBridgeQuoteParams = GetBridgeQuoteParams & {
+  minOutputAmount: BigNumber;
+  forceExactOutput?: boolean;
+};
+
+export type BridgeStrategy = {
+  name: string;
+  capabilities: BridgeCapabilities;
+
+  getBridgeQuoteRecipient: (crossSwap: CrossSwap) => string;
+
+  getBridgeQuoteMessage: (
+    crossSwap: CrossSwap,
+    appFee?: AppFee
+  ) => string | undefined;
+
+  getQuoteExactInput: (params: GetExactInputBridgeQuoteParams) => Promise<{
+    bridgeQuote: CrossSwapQuotes["bridgeQuote"];
+    contracts?: BridgeContracts;
+  }>;
+
+  getQuoteForOutput: (params: GetOutputBridgeQuoteParams) => Promise<{
+    bridgeQuote: CrossSwapQuotes["bridgeQuote"];
+    contracts?: BridgeContracts;
+  }>;
+
+  buildTxForAllowanceHolder: (params: {
+    quotes: CrossSwapQuotes;
+    integratorId?: string;
+  }) => Promise<OriginTx>;
+
+  getAllowanceSpender?(quotes: CrossSwapQuotes): string | undefined;
+};

--- a/api/_bridges/types.ts
+++ b/api/_bridges/types.ts
@@ -71,7 +71,7 @@ export type BridgeStrategy = {
     appFee?: AppFee
   ) => string | undefined;
 
-  getQuoteExactInput: (params: GetExactInputBridgeQuoteParams) => Promise<{
+  getQuoteForExactInput: (params: GetExactInputBridgeQuoteParams) => Promise<{
     bridgeQuote: CrossSwapQuotes["bridgeQuote"];
     contracts?: BridgeContracts;
   }>;

--- a/api/_bridges/types.ts
+++ b/api/_bridges/types.ts
@@ -85,6 +85,4 @@ export type BridgeStrategy = {
     quotes: CrossSwapQuotes;
     integratorId?: string;
   }) => Promise<OriginTx>;
-
-  getAllowanceSpender?(quotes: CrossSwapQuotes): string | undefined;
 };

--- a/api/_dexes/cross-swap-service.ts
+++ b/api/_dexes/cross-swap-service.ts
@@ -135,7 +135,7 @@ export async function getCrossSwapQuotesForExactInputB2B(
     strategies
   );
 
-  const { bridgeQuote } = await bridge.getQuoteExactInput({
+  const { bridgeQuote } = await bridge.getQuoteForExactInput({
     inputToken: crossSwap.inputToken,
     outputToken: crossSwap.outputToken,
     exactInputAmount: crossSwap.amount,
@@ -260,7 +260,7 @@ export async function getCrossSwapQuotesForExactInputB2BI(
   )(crossSwap.amount);
 
   // 1. We fetch a quote from inputToken.chainId -> intermediaryOutputToken.chainId
-  const { bridgeQuote } = await bridge.getQuoteExactInput({
+  const { bridgeQuote } = await bridge.getQuoteForExactInput({
     inputToken: crossSwap.inputToken,
     outputToken: indirectDestinationRoute.intermediaryOutputToken,
     exactInputAmount: crossSwap.amount,
@@ -489,7 +489,7 @@ export async function getCrossSwapQuotesForExactInputB2A(
   } = prioritizedStrategy.result;
 
   // 2. Get bridge quote for bridgeable input token -> any token with exact input amount.
-  const { bridgeQuote } = await bridge.getQuoteExactInput({
+  const { bridgeQuote } = await bridge.getQuoteForExactInput({
     inputToken: crossSwap.inputToken,
     outputToken: bridgeableOutputToken,
     exactInputAmount: crossSwap.amount,
@@ -827,7 +827,7 @@ export async function getCrossSwapQuotesForExactInputA2B(
   } = prioritizedStrategy.result;
 
   // 2. Get bridge quote for bridgeable input token -> bridgeable output token
-  const { bridgeQuote } = await bridge.getQuoteExactInput({
+  const { bridgeQuote } = await bridge.getQuoteForExactInput({
     inputToken: bridgeableInputToken,
     outputToken: crossSwap.outputToken,
     exactInputAmount: prioritizedStrategy.originSwapQuote.minAmountOut,
@@ -1263,7 +1263,7 @@ export async function getCrossSwapQuotesForExactInputByRouteA2A(
   } = prioritizedOriginStrategy.result;
 
   // 3. Get bridge quote for bridgeable input token -> bridgeable output token
-  const { bridgeQuote } = await bridge.getQuoteExactInput({
+  const { bridgeQuote } = await bridge.getQuoteForExactInput({
     inputToken: bridgeableInputToken,
     outputToken: bridgeableOutputToken,
     exactInputAmount: prioritizedOriginStrategy.originSwapQuote.minAmountOut,

--- a/api/_dexes/cross-swap-service.ts
+++ b/api/_dexes/cross-swap-service.ts
@@ -1,12 +1,10 @@
 import { TradeType } from "@uniswap/sdk-core";
 
 import {
-  getBridgeQuoteForOutput,
   getRouteByInputTokenAndDestinationChain,
   getRouteByOutputTokenAndOriginChain,
   getRoutesByChainIds,
   getTokenByAddress,
-  getBridgeQuoteForExactInput,
   addTimeoutToPromise,
   getLogger,
   addMarkupToAmount,
@@ -14,8 +12,6 @@ import {
 } from "../_utils";
 import {
   calculateAppFee,
-  getBridgeQuoteMessage,
-  getBridgeQuoteRecipient,
   getCrossSwapTypes,
   getPreferredBridgeTokens,
   getQuoteFetchStrategies,
@@ -49,6 +45,7 @@ import {
   CrossSwapQuotesRetrievalA2BResult,
   CrossSwapQuotesRetrievalB2AResult,
 } from "./types";
+import { BridgeStrategy } from "../_bridges/types";
 
 const QUOTE_BUFFER = 0.005; // 0.5%
 
@@ -58,10 +55,11 @@ const logger = getLogger();
 
 export async function getCrossSwapQuotes(
   crossSwap: CrossSwap,
-  strategies: QuoteFetchStrategies
+  strategies: QuoteFetchStrategies,
+  bridge: BridgeStrategy
 ): Promise<CrossSwapQuotes> {
   if (crossSwap.type === AMOUNT_TYPE.EXACT_INPUT) {
-    return getCrossSwapQuoteForAmountType(crossSwap, strategies, {
+    return getCrossSwapQuoteForAmountType(crossSwap, strategies, bridge, {
       [CROSS_SWAP_TYPE.BRIDGEABLE_TO_BRIDGEABLE]:
         getCrossSwapQuotesForExactInputB2B,
       [CROSS_SWAP_TYPE.BRIDGEABLE_TO_BRIDGEABLE_INDIRECT]:
@@ -76,7 +74,7 @@ export async function getCrossSwapQuotes(
     crossSwap.type === AMOUNT_TYPE.MIN_OUTPUT ||
     crossSwap.type === AMOUNT_TYPE.EXACT_OUTPUT
   ) {
-    return getCrossSwapQuoteForAmountType(crossSwap, strategies, {
+    return getCrossSwapQuoteForAmountType(crossSwap, strategies, bridge, {
       [CROSS_SWAP_TYPE.BRIDGEABLE_TO_BRIDGEABLE]:
         getCrossSwapQuotesForOutputB2B,
       [CROSS_SWAP_TYPE.BRIDGEABLE_TO_BRIDGEABLE_INDIRECT]:
@@ -95,11 +93,13 @@ export async function getCrossSwapQuotes(
 function getCrossSwapQuoteForAmountType(
   crossSwap: CrossSwap,
   strategies: QuoteFetchStrategies,
+  bridge: BridgeStrategy,
   typeToHandler: Record<
     (typeof CROSS_SWAP_TYPE)[keyof typeof CROSS_SWAP_TYPE],
     (
       crossSwap: CrossSwap,
-      strategies: QuoteFetchStrategies
+      strategies: QuoteFetchStrategies,
+      bridge: BridgeStrategy
     ) => Promise<CrossSwapQuotes>
   >
 ): Promise<CrossSwapQuotes> {
@@ -119,7 +119,7 @@ function getCrossSwapQuoteForAmountType(
         message: `Failed to fetch swap quote: invalid cross swap type '${crossSwapType}'`,
       });
     }
-    return handler(crossSwap, strategies);
+    return handler(crossSwap, strategies, bridge);
   });
 
   return selectBestCrossSwapQuote(crossSwaps, crossSwap);
@@ -127,19 +127,20 @@ function getCrossSwapQuoteForAmountType(
 
 export async function getCrossSwapQuotesForExactInputB2B(
   crossSwap: CrossSwap,
-  strategies: QuoteFetchStrategies
+  strategies: QuoteFetchStrategies,
+  bridge: BridgeStrategy
 ): Promise<CrossSwapQuotes> {
   const { originStrategy } = _prepCrossSwapQuotesRetrievalB2B(
     crossSwap,
     strategies
   );
 
-  const bridgeQuote = await getBridgeQuoteForExactInput({
+  const { bridgeQuote } = await bridge.getQuoteExactInput({
     inputToken: crossSwap.inputToken,
     outputToken: crossSwap.outputToken,
     exactInputAmount: crossSwap.amount,
-    recipient: getBridgeQuoteRecipient(crossSwap),
-    message: getBridgeQuoteMessage(crossSwap),
+    recipient: bridge.getBridgeQuoteRecipient(crossSwap),
+    message: bridge.getBridgeQuoteMessage(crossSwap),
   });
 
   if (bridgeQuote.outputAmount.lt(0)) {
@@ -156,7 +157,7 @@ export async function getCrossSwapQuotesForExactInputB2B(
     appFeeRecipient: crossSwap.appFeeRecipient,
     isNative: crossSwap.isOutputNative,
   });
-  bridgeQuote.message = getBridgeQuoteMessage(crossSwap, appFee);
+  bridgeQuote.message = bridge.getBridgeQuoteMessage(crossSwap, appFee);
 
   return {
     crossSwap,
@@ -174,7 +175,8 @@ export async function getCrossSwapQuotesForExactInputB2B(
 
 export async function getCrossSwapQuotesForOutputB2B(
   crossSwap: CrossSwap,
-  strategies: QuoteFetchStrategies
+  strategies: QuoteFetchStrategies,
+  bridge: BridgeStrategy
 ): Promise<CrossSwapQuotes> {
   const { originStrategy } = _prepCrossSwapQuotesRetrievalB2B(
     crossSwap,
@@ -185,12 +187,12 @@ export async function getCrossSwapQuotesForOutputB2B(
     ? addMarkupToAmount(crossSwap.amount, crossSwap.appFeePercent)
     : crossSwap.amount;
 
-  const bridgeQuote = await getBridgeQuoteForOutput({
+  const { bridgeQuote } = await bridge.getQuoteForOutput({
     inputToken: crossSwap.inputToken,
     outputToken: crossSwap.outputToken,
     minOutputAmount: outputAmountWithAppFee,
-    recipient: getBridgeQuoteRecipient(crossSwap),
-    message: getBridgeQuoteMessage(crossSwap),
+    recipient: bridge.getBridgeQuoteRecipient(crossSwap),
+    message: bridge.getBridgeQuoteMessage(crossSwap),
     forceExactOutput: crossSwap.type === AMOUNT_TYPE.EXACT_OUTPUT,
   });
 
@@ -208,7 +210,7 @@ export async function getCrossSwapQuotesForOutputB2B(
     crossSwap.type === AMOUNT_TYPE.MIN_OUTPUT ||
     (crossSwap.type === AMOUNT_TYPE.EXACT_OUTPUT && appFee.feeAmount.gt(0))
   ) {
-    bridgeQuote.message = getBridgeQuoteMessage(crossSwap, appFee);
+    bridgeQuote.message = bridge.getBridgeQuoteMessage(crossSwap, appFee);
   }
 
   return {
@@ -227,7 +229,8 @@ export async function getCrossSwapQuotesForOutputB2B(
 
 export async function getCrossSwapQuotesForExactInputB2BI(
   crossSwap: CrossSwap,
-  strategies: QuoteFetchStrategies
+  strategies: QuoteFetchStrategies,
+  bridge: BridgeStrategy
 ): Promise<CrossSwapQuotes> {
   const { originStrategy } = _prepCrossSwapQuotesRetrievalB2B(
     crossSwap,
@@ -257,7 +260,7 @@ export async function getCrossSwapQuotesForExactInputB2BI(
   )(crossSwap.amount);
 
   // 1. We fetch a quote from inputToken.chainId -> intermediaryOutputToken.chainId
-  const bridgeQuote = await getBridgeQuoteForExactInput({
+  const { bridgeQuote } = await bridge.getQuoteExactInput({
     inputToken: crossSwap.inputToken,
     outputToken: indirectDestinationRoute.intermediaryOutputToken,
     exactInputAmount: crossSwap.amount,
@@ -311,7 +314,8 @@ export async function getCrossSwapQuotesForExactInputB2BI(
 
 export async function getCrossSwapQuotesForOutputB2BI(
   crossSwap: CrossSwap,
-  strategies: QuoteFetchStrategies
+  strategies: QuoteFetchStrategies,
+  bridge: BridgeStrategy
 ): Promise<CrossSwapQuotes> {
   const { originStrategy } = _prepCrossSwapQuotesRetrievalB2B(
     crossSwap,
@@ -344,7 +348,7 @@ export async function getCrossSwapQuotesForOutputB2BI(
     indirectDestinationRoute.intermediaryOutputToken.decimals
   )(outputAmountWithAppFee);
 
-  const bridgeQuote = await getBridgeQuoteForOutput({
+  const { bridgeQuote } = await bridge.getQuoteForOutput({
     inputToken: crossSwap.inputToken,
     outputToken: indirectDestinationRoute.intermediaryOutputToken,
     minOutputAmount: bridgeableOutputAmount,
@@ -429,7 +433,8 @@ function _prepCrossSwapQuotesRetrievalB2B(
 
 export async function getCrossSwapQuotesForExactInputB2A(
   crossSwap: CrossSwap,
-  strategies: QuoteFetchStrategies
+  strategies: QuoteFetchStrategies,
+  bridge: BridgeStrategy
 ): Promise<CrossSwapQuotes> {
   const results = _prepCrossSwapQuotesRetrievalB2A(crossSwap, strategies);
 
@@ -484,7 +489,7 @@ export async function getCrossSwapQuotesForExactInputB2A(
   } = prioritizedStrategy.result;
 
   // 2. Get bridge quote for bridgeable input token -> any token with exact input amount.
-  const bridgeQuote = await getBridgeQuoteForExactInput({
+  const { bridgeQuote } = await bridge.getQuoteExactInput({
     inputToken: crossSwap.inputToken,
     outputToken: bridgeableOutputToken,
     exactInputAmount: crossSwap.amount,
@@ -546,7 +551,8 @@ export async function getCrossSwapQuotesForExactInputB2A(
 
 export async function getCrossSwapQuotesForOutputB2A(
   crossSwap: CrossSwap,
-  strategies: QuoteFetchStrategies
+  strategies: QuoteFetchStrategies,
+  bridge: BridgeStrategy
 ): Promise<CrossSwapQuotes> {
   // Add app fee percentage markup to cross swap amount
   const crossSwapWithAppFee = {
@@ -625,7 +631,7 @@ export async function getCrossSwapQuotesForOutputB2A(
 
   // 2, Fetch  bridge quote for bridgeable input token -> bridgeable output token based on
   //    destination swap quote.
-  const bridgeQuote = await getBridgeQuoteForOutput({
+  const { bridgeQuote } = await bridge.getQuoteForOutput({
     inputToken: crossSwapWithAppFee.inputToken,
     outputToken: bridgeableOutputToken,
     minOutputAmount: prioritizedStrategy.destinationSwapQuote.maximumAmountIn,
@@ -773,7 +779,8 @@ function _prepCrossSwapQuotesRetrievalB2A(
 
 export async function getCrossSwapQuotesForExactInputA2B(
   crossSwap: CrossSwap,
-  strategies: QuoteFetchStrategies
+  strategies: QuoteFetchStrategies,
+  bridge: BridgeStrategy
 ) {
   const results = _prepCrossSwapQuotesRetrievalA2B(crossSwap, strategies);
 
@@ -820,12 +827,12 @@ export async function getCrossSwapQuotesForExactInputA2B(
   } = prioritizedStrategy.result;
 
   // 2. Get bridge quote for bridgeable input token -> bridgeable output token
-  const bridgeQuote = await getBridgeQuoteForExactInput({
+  const { bridgeQuote } = await bridge.getQuoteExactInput({
     inputToken: bridgeableInputToken,
     outputToken: crossSwap.outputToken,
     exactInputAmount: prioritizedStrategy.originSwapQuote.minAmountOut,
-    recipient: getBridgeQuoteRecipient(crossSwap),
-    message: getBridgeQuoteMessage(crossSwap),
+    recipient: bridge.getBridgeQuoteRecipient(crossSwap),
+    message: bridge.getBridgeQuoteMessage(crossSwap),
   });
 
   if (bridgeQuote.outputAmount.lt(0)) {
@@ -842,7 +849,7 @@ export async function getCrossSwapQuotesForExactInputA2B(
     appFeeRecipient: crossSwap.appFeeRecipient,
     isNative: crossSwap.isInputNative,
   });
-  bridgeQuote.message = getBridgeQuoteMessage(crossSwap, appFee);
+  bridgeQuote.message = bridge.getBridgeQuoteMessage(crossSwap, appFee);
 
   return {
     crossSwap,
@@ -861,7 +868,8 @@ export async function getCrossSwapQuotesForExactInputA2B(
 
 export async function getCrossSwapQuotesForOutputA2B(
   crossSwap: CrossSwap,
-  strategies: QuoteFetchStrategies
+  strategies: QuoteFetchStrategies,
+  bridge: BridgeStrategy
 ) {
   const crossSwapWithAppFee = {
     ...crossSwap,
@@ -885,12 +893,12 @@ export async function getCrossSwapQuotesForOutputA2B(
   const { originSwapChainId, bridgeableInputToken } = results[0];
 
   // 1. Get bridge quote for bridgeable input token -> bridgeable output token
-  const bridgeQuote = await getBridgeQuoteForOutput({
+  const { bridgeQuote } = await bridge.getQuoteForOutput({
     inputToken: bridgeableInputToken,
     outputToken: crossSwapWithAppFee.outputToken,
     minOutputAmount: crossSwapWithAppFee.amount,
-    recipient: getBridgeQuoteRecipient(crossSwapWithAppFee),
-    message: getBridgeQuoteMessage(crossSwapWithAppFee),
+    recipient: bridge.getBridgeQuoteRecipient(crossSwapWithAppFee),
+    message: bridge.getBridgeQuoteMessage(crossSwapWithAppFee),
   });
 
   const strategyFetches = results.map((result) => {
@@ -946,7 +954,10 @@ export async function getCrossSwapQuotesForOutputA2B(
   });
 
   if (appFee.feeAmount.gt(0)) {
-    bridgeQuote.message = getBridgeQuoteMessage(crossSwapWithAppFee, appFee);
+    bridgeQuote.message = bridge.getBridgeQuoteMessage(
+      crossSwapWithAppFee,
+      appFee
+    );
   }
 
   return {
@@ -1045,7 +1056,8 @@ function _prepCrossSwapQuotesRetrievalA2B(
 
 export async function getCrossSwapQuotesA2A(
   crossSwap: CrossSwap,
-  strategies: QuoteFetchStrategies
+  strategies: QuoteFetchStrategies,
+  bridge: BridgeStrategy
 ) {
   const preferredBridgeTokens = getPreferredBridgeTokens(
     crossSwap.inputToken.chainId,
@@ -1102,7 +1114,7 @@ export async function getCrossSwapQuotesA2A(
 
     const crossSwapQuotesResults = await Promise.allSettled(
       bridgeRoutesToCompare.map((bridgeRoute) =>
-        fetchQuoteForRoute(crossSwap, bridgeRoute, strategies)
+        fetchQuoteForRoute(crossSwap, bridgeRoute, strategies, bridge)
       )
     );
 
@@ -1155,7 +1167,8 @@ export async function getCrossSwapQuotesForExactInputByRouteA2A(
     toTokenAddress: string;
     toChain: number;
   },
-  strategies: QuoteFetchStrategies
+  strategies: QuoteFetchStrategies,
+  bridge: BridgeStrategy
 ): Promise<CrossSwapQuotes> {
   const results = _prepCrossSwapQuotesRetrievalA2A({
     crossSwap,
@@ -1250,7 +1263,7 @@ export async function getCrossSwapQuotesForExactInputByRouteA2A(
   } = prioritizedOriginStrategy.result;
 
   // 3. Get bridge quote for bridgeable input token -> bridgeable output token
-  const bridgeQuote = await getBridgeQuoteForExactInput({
+  const { bridgeQuote } = await bridge.getQuoteExactInput({
     inputToken: bridgeableInputToken,
     outputToken: bridgeableOutputToken,
     exactInputAmount: prioritizedOriginStrategy.originSwapQuote.minAmountOut,
@@ -1328,7 +1341,8 @@ export async function getCrossSwapQuotesForOutputByRouteA2A(
     toTokenAddress: string;
     toChain: number;
   },
-  strategies: QuoteFetchStrategies
+  strategies: QuoteFetchStrategies,
+  bridge: BridgeStrategy
 ): Promise<CrossSwapQuotes> {
   // Add app fee percentage markup to cross swap amount
   const crossSwapWithAppFee = {
@@ -1430,7 +1444,7 @@ export async function getCrossSwapQuotesForOutputByRouteA2A(
   } = result;
 
   // 2. Get bridge quote for bridgeable input token -> bridgeable output token
-  const bridgeQuote = await getBridgeQuoteForOutput({
+  const { bridgeQuote } = await bridge.getQuoteForOutput({
     inputToken: bridgeableInputToken,
     outputToken: bridgeableOutputToken,
     minOutputAmount: destinationSwapQuote.maximumAmountIn,

--- a/api/swap/approval/_service.ts
+++ b/api/swap/approval/_service.ts
@@ -12,7 +12,6 @@ import {
   getTokenByAddress,
   getBalance,
 } from "../../_utils";
-import { buildCrossSwapTxForAllowanceHolder } from "./_utils";
 import {
   handleBaseSwapQueryParams,
   BaseSwapQueryParams,
@@ -25,6 +24,7 @@ import { getBalanceAndAllowance } from "../../_erc20";
 import { getCrossSwapQuotes } from "../../_dexes/cross-swap-service";
 import { inferCrossSwapType } from "../../_dexes/utils";
 import { quoteFetchStrategies } from "../_configs";
+import { getBridgeStrategy } from "../../_bridges";
 import { TypedVercelRequest } from "../../_types";
 import { AcrossErrorCode } from "../../_errors";
 
@@ -76,6 +76,12 @@ export async function handleApprovalSwap(
 
   const slippageTolerance = _slippageTolerance ?? slippage * 100;
 
+  // TODO: Extend the strategy selection based on more sophisticated logic when we start
+  // implementing burn/mint bridges.
+  const bridgeStrategy = getBridgeStrategy({
+    originChainId: inputToken.chainId,
+    destinationChainId: outputToken.chainId,
+  });
   const crossSwapQuotes = await getCrossSwapQuotes(
     {
       amount,
@@ -98,7 +104,8 @@ export async function handleApprovalSwap(
       isDestinationSvm,
       isOriginSvm,
     },
-    quoteFetchStrategies
+    quoteFetchStrategies,
+    bridgeStrategy
   );
   const crossSwapType = inferCrossSwapType(crossSwapQuotes);
   logger.debug({
@@ -109,10 +116,10 @@ export async function handleApprovalSwap(
     crossSwapQuotes,
   });
 
-  const crossSwapTx = await buildCrossSwapTxForAllowanceHolder(
-    crossSwapQuotes,
-    integratorId
-  );
+  const crossSwapTx = await bridgeStrategy.buildTxForAllowanceHolder({
+    quotes: crossSwapQuotes,
+    integratorId,
+  });
 
   const {
     originSwapQuote,


### PR DESCRIPTION
The goal of this refactor is to set the stage for implementing different bridging strategies (e.g. direct bridge HyperEVM -> HyperCore, OFT, CCTP, etc.). We employ a strategy pattern (similar to the one used for DEXes). Some things I want to add as a fast follow, but left out in this PR to keep the diff small:
- Move a bunch of helpers in `api/_dexes/utils.ts` to `api/_bridges/across` that are only relevant for Across-specific message building
- Move a bunch of helpers in `api/swap/approval/_utils.ts` to `api/_bridges/across` that are only relevant for Across-specific tx building
- Add more safeguards related to bridge capabilities in `api/_dexes/cross-swap-service.ts` (makes most sense probably when we add a new bridge strategy)