### PR TITLE
fix: weth incorrectly resolves to eth info

### DIFF
--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -562,6 +562,14 @@ export const getTokenByAddress = (
       }
     }
 
+    // Due to a misconfiguration in the constants file, the WETH address is sometimes associated with both the ETH and WETH symbols.
+    // This is problematic because the SDK will not be able to resolve the correct token if ETH is picked up first.
+    // To fix this, we will check if there is a WETH match and prioritize it over the ETH match.
+    const wethMatch = matches.find(([symbol]) => symbol === "WETH");
+    if (wethMatch) {
+      return wethMatch[1];
+    }
+
     return matches[0][1];
   } catch (error) {
     return undefined;

--- a/test/api/_utils.test.ts
+++ b/test/api/_utils.test.ts
@@ -111,18 +111,22 @@ describe("_utils", () => {
   });
 
   describe("#getTokenByAddress()", () => {
+    // Iterate over all chain IDs to test the token resolution for each chain.
     for (const chainId of Object.values(CHAIN_IDs)) {
       if (typeof chainId !== "number") continue;
 
       const weth = TOKEN_SYMBOLS_MAP.WETH.addresses[chainId];
       const eth = TOKEN_SYMBOLS_MAP.ETH.addresses[chainId];
 
+      // Test case where WETH and ETH have the same address.
+      // In this case, we want to ensure that WETH is always returned to avoid ambiguity.
       if (weth && eth && weth.toLowerCase() === eth.toLowerCase()) {
         test(`should return WETH for chain ${chainId} when both ETH and WETH have the same address`, () => {
           const token = getTokenByAddress(weth, chainId);
           expect(token?.symbol).toBe("WETH");
         });
       } else {
+        // Test case where WETH and ETH have different addresses.
         if (weth) {
           test(`should return WETH for chain ${chainId}`, () => {
             const token = getTokenByAddress(weth, chainId);

--- a/test/api/_utils.test.ts
+++ b/test/api/_utils.test.ts
@@ -7,6 +7,7 @@ import {
   validEvmAddress,
   validSvmAddress,
   validAddress,
+  getTokenByAddress,
 } from "../../api/_utils";
 import { is } from "superstruct";
 
@@ -107,6 +108,35 @@ describe("_utils", () => {
         },
       });
     });
+  });
+
+  describe("#getTokenByAddress()", () => {
+    for (const chainId of Object.values(CHAIN_IDs)) {
+      if (typeof chainId !== "number") continue;
+
+      const weth = TOKEN_SYMBOLS_MAP.WETH.addresses[chainId];
+      const eth = TOKEN_SYMBOLS_MAP.ETH.addresses[chainId];
+
+      if (weth && eth && weth.toLowerCase() === eth.toLowerCase()) {
+        test(`should return WETH for chain ${chainId} when both ETH and WETH have the same address`, () => {
+          const token = getTokenByAddress(weth, chainId);
+          expect(token?.symbol).toBe("WETH");
+        });
+      } else {
+        if (weth) {
+          test(`should return WETH for chain ${chainId}`, () => {
+            const token = getTokenByAddress(weth, chainId);
+            expect(token?.symbol).toBe("WETH");
+          });
+        }
+        if (eth) {
+          test(`should return ETH for chain ${chainId}`, () => {
+            const token = getTokenByAddress(eth, chainId);
+            expect(token?.symbol).toBe("ETH");
+          });
+        }
+      }
+    }
   });
 
   describe("#validateChainAndTokenParams()", () => {


### PR DESCRIPTION
# Fix WETH/ETH Symbol Resolution

**Linear:** [ACX-4369](https://linear.app/uma/issue/ACX-4369/incorrect-token-information-in-response-for-wetheth)

## :memo: Summary

This pull request addresses a bug where the `swap/approval` endpoint was incorrectly resolving the symbol for wrapped native tokens (like WETH) as the native token symbol (e.g., ETH). This was happening on chains like Base and Linea where the wrapped native token address is also present in the `TOKEN_SYMBOLS_MAP` under the `ETH` symbol.

## :wrench: Changes

- Modified the `getTokenByAddress` function in `api/_utils.ts` to correctly resolve the token symbol in cases of ambiguity between `ETH` and `WETH`.
- Added a comprehensive test suite for `getTokenByAddress` to ensure the correct symbol is returned for all supported chains.


## :thought_balloon: Rationale

The root cause of this issue lies in the `@across-protocol/constants` package, where some wrapped native token addresses are associated with both `ETH` and `WETH` symbols. The `getTokenByAddress` function was not deterministically picking the correct symbol, sometimes defaulting to `ETH` when it should have been `WETH`.

This pull request implements a solution that prioritizes `WETH` when a token address is associated with both symbols. This is a robust solution because it correctly handles the ambiguity in the constants file and ensures that the correct token symbol is used throughout the application.

The alternative of fixing the constants file is not feasible as it is an external dependency. This solution provides a local fix that is both effective and maintainable.
