### PR TITLE
fix: usdt-spot price lookup

### DIFF
--- a/api/coingecko.ts
+++ b/api/coingecko.ts
@@ -289,8 +289,8 @@ async function resolvePriceBySymbol(params: {
   }
 
   const symbol = String(
-    redirectedLookupSymbols[_symbol.toLowerCase()] ??
-      TOKEN_EQUIVALENCE_REMAPPING[_symbol.toLowerCase()] ??
+    redirectedLookupSymbols[_symbol.toUpperCase()] ??
+      TOKEN_EQUIVALENCE_REMAPPING[_symbol.toUpperCase()] ??
       _symbol
   ).toUpperCase();
 


### PR DESCRIPTION
[Example request](https://app-frontend-v3-git-fix-usdt-spot-price-lookup-uma.vercel.app/api/coingecko?symbol=USDT-SPOT&baseCurrency=usdt) that was previously failing