### PR TITLE
fix: relax message for svm

### DIFF
--- a/api/_balance.ts
+++ b/api/_balance.ts
@@ -9,22 +9,21 @@ import { toSolanaKitAddress } from "./_address";
 import { buildInternalCacheKey, makeCacheGetterAndSetter } from "./_cache";
 
 /**
- * Resolves the cached balance of a given ERC20 token at a provided address. If no token is provided, the balance of the
- * native currency will be returned.
- * @param chainId The blockchain Id to query against
- * @param account A valid Web3 wallet address
- * @param token The valid ERC20 token address on the given `chainId`.
+ * Resolves the cached balance of a given ERC20 token at a provided address.
+ * @param chainId The chain id to query against
+ * @param accountAddress A valid EVM or SVM wallet address
+ * @param tokenAddress A valid EVM or SVM token address on the given `chainId`.
  * @returns A promise that resolves to the BigNumber of the balance
  */
 export async function getCachedTokenBalance(
   chainId: string | number,
-  account: string,
-  token: string
+  accountAddress: string,
+  tokenAddress: string
 ): Promise<BigNumber> {
   const balance = await latestBalanceCache({
     chainId: Number(chainId),
-    tokenAddress: token,
-    address: account,
+    tokenAddress: tokenAddress,
+    address: accountAddress,
   }).get();
   return balance;
 }

--- a/api/_message.ts
+++ b/api/_message.ts
@@ -1,7 +1,163 @@
+import * as sdk from "@across-protocol/sdk";
+import acrossDeployments from "@across-protocol/contracts/dist/deployments/deployments.json";
+import { BigNumber, ethers } from "ethers";
+
+import { InvalidParamError } from "./_errors";
+import { buildInternalCacheKey, makeCacheGetterAndSetter } from "./_cache";
+import { getProvider } from "./_providers";
+import { getCachedTokenBalance } from "./_balance";
+
 // Vercel imposes a 14KB URL length limit (https://vercel.com/docs/errors/URL_TOO_LONG)
 // We use a POST request to avoid this limit if message is too long.
 export const MAX_MESSAGE_LENGTH = 25_000; // ~14KB
 
 export function isMessageTooLong(message: string) {
   return message && message.length > MAX_MESSAGE_LENGTH;
+}
+
+export async function validateDepositMessage(params: {
+  recipient: string;
+  destinationChainId: number;
+  relayer: string;
+  outputTokenAddress: string;
+  amountInput: BigNumber;
+  message: string;
+}) {
+  const {
+    recipient,
+    destinationChainId,
+    relayer,
+    outputTokenAddress,
+    amountInput,
+    message,
+  } = params;
+
+  if (!sdk.utils.isMessageEmpty(message)) {
+    if (!ethers.utils.isHexString(message)) {
+      throw new InvalidParamError({
+        message: "Message must be a hex string",
+        param: "message",
+      });
+    }
+    if (message.length % 2 !== 0) {
+      // Our message encoding is a hex string, so we need to check that the length is even.
+      throw new InvalidParamError({
+        message: "Message must be an even hex string",
+        param: "message",
+      });
+    }
+
+    const isRecipientAContract =
+      getStaticIsContract(destinationChainId, recipient) ||
+      (await isContractCache(destinationChainId, recipient).get());
+
+    if (!isRecipientAContract) {
+      // If the message is a gas forwarding message to SVM, we allow it.
+      if (
+        sdk.utils.chainIsSvm(destinationChainId) &&
+        isGasForwardingMessageToSvm(message)
+      ) {
+        return;
+      }
+
+      throw new InvalidParamError({
+        message: "Recipient must be a contract when a message is provided",
+        param: "recipient",
+      });
+    } else {
+      // If we're in this case, it's likely that we're going to have to simulate the execution of
+      // a complex message handling from the specified relayer to the specified recipient by calling
+      // the arbitrary function call `handleAcrossMessage` at the recipient. So that we can discern
+      // the difference between an OUT_OF_FUNDS error in either the transfer or through the execution
+      // of the `handleAcrossMessage` we will check that the balance of the relayer is sufficient to
+      // support this deposit.
+      const balanceOfToken = await getCachedTokenBalance(
+        destinationChainId,
+        relayer,
+        outputTokenAddress
+      );
+      if (balanceOfToken.lt(amountInput)) {
+        throw new InvalidParamError({
+          message:
+            `Relayer Address (${relayer}) doesn't have enough funds to support this deposit;` +
+            ` for help, please reach out to https://discord.across.to`,
+          param: "relayer",
+        });
+      }
+    }
+  }
+}
+
+function isGasForwardingMessageToSvm(_message: string) {
+  const message = new Uint8Array(
+    Buffer.from(_message.startsWith("0x") ? _message.slice(2) : _message, "hex")
+  );
+  const decoder = sdk.arch.svm.getAcrossPlusMessageDecoder();
+  const decoded = decoder.decode(message);
+
+  // Heuristic to check if the message is a gas forwarding message to SVM:
+
+  // - Check that handler_message is empty (0x00000000)
+  const isEmptyHandlerMessage =
+    decoded.handler_message.length === 4 &&
+    Buffer.from(decoded.handler_message).toString("hex") === "00000000";
+
+  // - Check that there's exactly 1 account (the recipient of value_amount)
+  const hasSingleAccount = decoded.accounts.length === 1;
+
+  // - Check that valueAmount is greater than 0
+  const hasPositiveValue = decoded.value_amount > 0n;
+
+  return isEmptyHandlerMessage && hasSingleAccount && hasPositiveValue;
+}
+
+function getStaticIsContract(chainId: number, address: string) {
+  const addressType = sdk.utils.toAddressType(address, chainId);
+  let comparableAddress = address;
+
+  if (sdk.utils.chainIsSvm(chainId)) {
+    try {
+      comparableAddress = addressType.toBase58();
+    } catch (error) {
+      // noop
+    }
+  } else {
+    if (addressType.isEVM()) {
+      comparableAddress = addressType.toEvmAddress();
+    }
+  }
+
+  const deployedAcrossContract = Object.values(
+    (
+      acrossDeployments as {
+        [chainId: number]: {
+          [contractName: string]: {
+            address: string;
+          };
+        };
+      }
+    )[chainId]
+  ).find(
+    (contract) =>
+      contract.address.toLowerCase() === comparableAddress.toLowerCase()
+  );
+  return !!deployedAcrossContract;
+}
+
+function isContractCache(chainId: number, address: string) {
+  return makeCacheGetterAndSetter(
+    buildInternalCacheKey("isContract", chainId, address),
+    5 * 24 * 60 * 60, // 5 days - we can cache this for a long time
+    async () => {
+      if (sdk.utils.chainIsSvm(chainId)) {
+        return false;
+      }
+      const addressType = sdk.utils.toAddressType(address, chainId);
+      const isDeployed = await sdk.utils.isContractDeployedToAddress(
+        addressType.toEvmAddress(),
+        getProvider(chainId)
+      );
+      return isDeployed;
+    }
+  );
 }

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -308,7 +308,7 @@ export const validateDepositMessage = async (
     const isRecipientAContract =
       getStaticIsContract(destinationChainId, recipient) ||
       (await isContractCache(destinationChainId, recipient).get());
-    if (!isRecipientAContract) {
+    if (!isRecipientAContract && sdk.utils.chainIsEvm(destinationChainId)) {
       throw new InvalidParamError({
         message: "Recipient must be a contract when a message is provided",
         param: "recipient",

--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -3,7 +3,6 @@ import {
   ERC20__factory,
   HubPool__factory,
 } from "@across-protocol/contracts/dist/typechain";
-import acrossDeployments from "@across-protocol/contracts/dist/deployments/deployments.json";
 import * as sdk from "@across-protocol/sdk";
 import {
   BALANCER_NETWORK_CONFIG,
@@ -282,93 +281,6 @@ export const validateChainAndTokenParams = (
     allowUnmatchedDecimals,
   };
 };
-
-export const validateDepositMessage = async (
-  recipient: string,
-  destinationChainId: number,
-  relayer: string,
-  outputTokenAddress: string,
-  amountInput: BigNumber,
-  message: string
-) => {
-  if (!sdk.utils.isMessageEmpty(message)) {
-    if (!ethers.utils.isHexString(message)) {
-      throw new InvalidParamError({
-        message: "Message must be a hex string",
-        param: "message",
-      });
-    }
-    if (message.length % 2 !== 0) {
-      // Our message encoding is a hex string, so we need to check that the length is even.
-      throw new InvalidParamError({
-        message: "Message must be an even hex string",
-        param: "message",
-      });
-    }
-    const isRecipientAContract =
-      getStaticIsContract(destinationChainId, recipient) ||
-      (await isContractCache(destinationChainId, recipient).get());
-    if (!isRecipientAContract && sdk.utils.chainIsEvm(destinationChainId)) {
-      throw new InvalidParamError({
-        message: "Recipient must be a contract when a message is provided",
-        param: "recipient",
-      });
-    } else {
-      // If we're in this case, it's likely that we're going to have to simulate the execution of
-      // a complex message handling from the specified relayer to the specified recipient by calling
-      // the arbitrary function call `handleAcrossMessage` at the recipient. So that we can discern
-      // the difference between an OUT_OF_FUNDS error in either the transfer or through the execution
-      // of the `handleAcrossMessage` we will check that the balance of the relayer is sufficient to
-      // support this deposit.
-      const balanceOfToken = await getCachedTokenBalance(
-        destinationChainId,
-        relayer,
-        outputTokenAddress
-      );
-      if (balanceOfToken.lt(amountInput)) {
-        throw new InvalidParamError({
-          message:
-            `Relayer Address (${relayer}) doesn't have enough funds to support this deposit;` +
-            ` for help, please reach out to https://discord.across.to`,
-          param: "relayer",
-        });
-      }
-    }
-  }
-};
-
-function getStaticIsContract(chainId: number, address: string) {
-  const addressType = toAddressType(address, chainId);
-  let comparableAddress = address;
-
-  if (sdk.utils.chainIsSvm(chainId)) {
-    try {
-      comparableAddress = addressType.toBase58();
-    } catch (error) {
-      // noop
-    }
-  } else {
-    if (addressType.isEVM()) {
-      comparableAddress = addressType.toEvmAddress();
-    }
-  }
-
-  const deployedAcrossContract = Object.values(
-    (
-      acrossDeployments as {
-        [chainId: number]: {
-          [contractName: string]: {
-            address: string;
-          };
-        };
-      }
-    )[chainId]
-  ).find(
-    (contract) =>
-      contract.address.toLowerCase() === comparableAddress.toLowerCase()
-  );
-  return !!deployedAcrossContract;
-}
 
 export function getChainInfo(chainId: number) {
   const chainInfo = CHAINS[chainId];
@@ -1431,27 +1343,6 @@ export function getRoutesByChainIds(
       originChainId === fromChain && destinationChainId === toChain
   );
 }
-
-/**
- * Resolves the cached balance of a given ERC20 token at a provided address. If no token is provided, the balance of the
- * native currency will be returned.
- * @param chainId The blockchain Id to query against
- * @param account A valid Web3 wallet address
- * @param token The valid ERC20 token address on the given `chainId`.
- * @returns A promise that resolves to the BigNumber of the balance
- */
-export const getCachedTokenBalance = async (
-  chainId: string | number,
-  account: string,
-  token: string
-): Promise<BigNumber> => {
-  const balance = await latestBalanceCache({
-    chainId: Number(chainId),
-    tokenAddress: token,
-    address: account,
-  }).get();
-  return balance;
-};
 
 /**
  * Resolves the cached balance of a given ERC20 token at a provided address. If no token is provided, the balance of the

--- a/api/limits.ts
+++ b/api/limits.ts
@@ -11,7 +11,6 @@ import {
   HUB_POOL_CHAIN_ID,
   callViaMulticall3,
   ConvertDecimals,
-  getCachedTokenBalance,
   getCachedTokenPrice,
   getHubPool,
   getLimitsBufferMultiplier,
@@ -30,7 +29,6 @@ import {
   validateChainAndTokenParams,
   getCachedLatestBlock,
   parsableBigNumberString,
-  validateDepositMessage,
   latestGasPriceCache,
   getCachedNativeGasCost,
   getCachedOpStackL1DataFee,
@@ -47,6 +45,8 @@ import {
 import { getDefaultRecipientAddress } from "./_recipient-address";
 import { calcGasFeeDetails } from "./_gas";
 import { sendResponse } from "./_response_utils";
+import { getCachedTokenBalance } from "./_balance";
+import { validateDepositMessage } from "./_message";
 import { tracer } from "../instrumentation";
 
 const LimitsQueryParamsSchema = type({
@@ -142,14 +142,17 @@ const handler = async (
             param: "amount",
           });
         }
-        await validateDepositMessage(
-          recipient.toBytes32(),
+        await validateDepositMessage({
+          recipient: recipient.toBytes32(),
           destinationChainId,
-          relayer.toBytes32(),
-          outputToken.address,
-          ConvertDecimals(inputToken.decimals, outputToken.decimals)(amount),
-          message!
-        );
+          relayer: relayer.toBytes32(),
+          outputTokenAddress: outputToken.address,
+          amountInput: ConvertDecimals(
+            inputToken.decimals,
+            outputToken.decimals
+          )(amount),
+          message: message!,
+        });
       }
 
       let minDepositUsdForDestinationChainId = Number(

--- a/test/api/_message.test.ts
+++ b/test/api/_message.test.ts
@@ -82,8 +82,6 @@ describe("api/_message", () => {
           handlerMessage
         );
 
-        console.log("Valid gas forwarding message:", message);
-
         // Mock isContractCache to return false (not a contract)
         mockIsContractCacheGet.mockResolvedValue(false);
 
@@ -112,8 +110,6 @@ describe("api/_message", () => {
           accounts,
           handlerMessage
         );
-
-        console.log("Message with non-empty handler_message:", message);
 
         mockIsContractCacheGet.mockResolvedValue(false);
 
@@ -156,8 +152,6 @@ describe("api/_message", () => {
           handlerMessage
         );
 
-        console.log("Message with 0 accounts:", messageNoAccounts);
-
         mockIsContractCacheGet.mockResolvedValue(false);
 
         await expect(
@@ -182,8 +176,6 @@ describe("api/_message", () => {
           accountsTwo,
           handlerMessage
         );
-
-        console.log("Message with 2 accounts:", messageTwoAccounts);
 
         await expect(
           validateDepositMessage({
@@ -212,8 +204,6 @@ describe("api/_message", () => {
           accounts,
           handlerMessage
         );
-
-        console.log("Message with value_amount = 0:", message);
 
         mockIsContractCacheGet.mockResolvedValue(false);
 
@@ -244,8 +234,6 @@ describe("api/_message", () => {
           accounts,
           handlerMessage
         );
-
-        console.log("Message with 1 SOL value_amount:", message);
 
         mockIsContractCacheGet.mockResolvedValue(false);
 

--- a/test/api/_message.test.ts
+++ b/test/api/_message.test.ts
@@ -1,0 +1,312 @@
+import * as sdk from "@across-protocol/sdk";
+import { BigNumber } from "ethers";
+
+import { CHAIN_IDs, TOKEN_SYMBOLS_MAP } from "../../api/_constants";
+import { validateDepositMessage } from "../../api/_message";
+import { InvalidParamError } from "../../api/_errors";
+
+// Mock dependencies
+const mockIsContractCacheGet = jest.fn();
+
+jest.mock("../../api/_cache", () => ({
+  buildInternalCacheKey: jest.fn(),
+  makeCacheGetterAndSetter: jest.fn(() => ({
+    get: mockIsContractCacheGet,
+  })),
+}));
+
+jest.mock("../../api/_providers", () => ({
+  getProvider: jest.fn(),
+}));
+
+jest.mock("../../api/_balance", () => ({
+  getCachedTokenBalance: jest.fn(),
+}));
+
+// Helper to create an encoded AcrossPlusMessage
+function createEncodedMessage(
+  handler: string,
+  readOnlyLen: number,
+  valueAmount: bigint,
+  accounts: string[],
+  handlerMessage: Uint8Array
+): string {
+  // Create the message object
+  const message = {
+    handler: sdk.utils.SvmAddress.from(handler).toBase58(),
+    read_only_len: readOnlyLen,
+    value_amount: valueAmount,
+    accounts: accounts.map((addr) =>
+      sdk.utils.SvmAddress.from(addr).toBase58()
+    ),
+    handler_message: handlerMessage,
+  };
+
+  const encoder = sdk.arch.svm.getAcrossPlusMessageEncoder();
+  // @ts-expect-error - Type compatibility with @solana/kit Address type
+  const encoded = encoder.encode(message);
+  return "0x" + Buffer.from(encoded).toString("hex");
+}
+
+describe("api/_message", () => {
+  const SVM_CHAIN_ID = CHAIN_IDs.SOLANA;
+  const RECIPIENT_ADDRESS = "FmMK62wrtWVb5SVoTZftSCGw3nEDA79hDbZNTRnC1R6t";
+  const HANDLER_ADDRESS = sdk.utils.getDeployedAddress(
+    "MulticallHandler",
+    CHAIN_IDs.SOLANA,
+    true
+  ) as string;
+  const RELAYER_ADDRESS = sdk.constants.DEFAULT_SIMULATED_RELAYER_ADDRESS_SVM;
+  const TOKEN_ADDRESS = TOKEN_SYMBOLS_MAP.USDC.addresses[CHAIN_IDs.SOLANA];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("validateDepositMessage", () => {
+    describe("Gas forwarding messages to SVM", () => {
+      it("should accept a valid gas forwarding message to SVM", async () => {
+        // Create a valid gas forwarding message:
+        // - handler_message is empty (0x00000000)
+        // - accounts has exactly 1 account (the recipient)
+        // - value_amount > 0
+        const valueAmount = 5000000n; // 0.005 SOL in lamports
+        const handlerMessage = new Uint8Array(4).fill(0); // 0x00000000
+        const accounts = [RECIPIENT_ADDRESS];
+
+        const message = createEncodedMessage(
+          HANDLER_ADDRESS,
+          0,
+          valueAmount,
+          accounts,
+          handlerMessage
+        );
+
+        console.log("Valid gas forwarding message:", message);
+
+        // Mock isContractCache to return false (not a contract)
+        mockIsContractCacheGet.mockResolvedValue(false);
+
+        await expect(
+          validateDepositMessage({
+            recipient: RECIPIENT_ADDRESS,
+            destinationChainId: SVM_CHAIN_ID,
+            relayer: RELAYER_ADDRESS,
+            outputTokenAddress: TOKEN_ADDRESS,
+            amountInput: BigNumber.from(1000000),
+            message,
+          })
+        ).resolves.not.toThrow();
+      });
+
+      it("should reject if handler_message is not empty", async () => {
+        // Create a message with non-empty handler_message
+        const valueAmount = 5000000n;
+        const handlerMessage = new Uint8Array([0x01, 0x02, 0x03, 0x04]); // Not 0x00000000
+        const accounts = [RECIPIENT_ADDRESS];
+
+        const message = createEncodedMessage(
+          HANDLER_ADDRESS,
+          0,
+          valueAmount,
+          accounts,
+          handlerMessage
+        );
+
+        console.log("Message with non-empty handler_message:", message);
+
+        mockIsContractCacheGet.mockResolvedValue(false);
+
+        await expect(
+          validateDepositMessage({
+            recipient: RECIPIENT_ADDRESS,
+            destinationChainId: SVM_CHAIN_ID,
+            relayer: RELAYER_ADDRESS,
+            outputTokenAddress: TOKEN_ADDRESS,
+            amountInput: BigNumber.from(1000000),
+            message,
+          })
+        ).rejects.toThrow(InvalidParamError);
+
+        await expect(
+          validateDepositMessage({
+            recipient: RECIPIENT_ADDRESS,
+            destinationChainId: SVM_CHAIN_ID,
+            relayer: RELAYER_ADDRESS,
+            outputTokenAddress: TOKEN_ADDRESS,
+            amountInput: BigNumber.from(1000000),
+            message,
+          })
+        ).rejects.toThrow(
+          "Recipient must be a contract when a message is provided"
+        );
+      });
+
+      it("should reject if accounts.length !== 1", async () => {
+        // Create a message with 0 accounts
+        const valueAmount = 5000000n;
+        const handlerMessage = new Uint8Array(4).fill(0);
+        const accounts: string[] = [];
+
+        const messageNoAccounts = createEncodedMessage(
+          HANDLER_ADDRESS,
+          0,
+          valueAmount,
+          accounts,
+          handlerMessage
+        );
+
+        console.log("Message with 0 accounts:", messageNoAccounts);
+
+        mockIsContractCacheGet.mockResolvedValue(false);
+
+        await expect(
+          validateDepositMessage({
+            recipient: RECIPIENT_ADDRESS,
+            destinationChainId: SVM_CHAIN_ID,
+            relayer: RELAYER_ADDRESS,
+            outputTokenAddress: TOKEN_ADDRESS,
+            amountInput: BigNumber.from(1000000),
+            message: messageNoAccounts,
+          })
+        ).rejects.toThrow(
+          "Recipient must be a contract when a message is provided"
+        );
+
+        // Create a message with 2 accounts
+        const accountsTwo = [RECIPIENT_ADDRESS, HANDLER_ADDRESS];
+        const messageTwoAccounts = createEncodedMessage(
+          HANDLER_ADDRESS,
+          0,
+          valueAmount,
+          accountsTwo,
+          handlerMessage
+        );
+
+        console.log("Message with 2 accounts:", messageTwoAccounts);
+
+        await expect(
+          validateDepositMessage({
+            recipient: RECIPIENT_ADDRESS,
+            destinationChainId: SVM_CHAIN_ID,
+            relayer: RELAYER_ADDRESS,
+            outputTokenAddress: TOKEN_ADDRESS,
+            amountInput: BigNumber.from(1000000),
+            message: messageTwoAccounts,
+          })
+        ).rejects.toThrow(
+          "Recipient must be a contract when a message is provided"
+        );
+      });
+
+      it("should reject if value_amount is 0", async () => {
+        // Create a message with value_amount = 0
+        const valueAmount = 0n;
+        const handlerMessage = new Uint8Array(4).fill(0);
+        const accounts = [RECIPIENT_ADDRESS];
+
+        const message = createEncodedMessage(
+          HANDLER_ADDRESS,
+          0,
+          valueAmount,
+          accounts,
+          handlerMessage
+        );
+
+        console.log("Message with value_amount = 0:", message);
+
+        mockIsContractCacheGet.mockResolvedValue(false);
+
+        await expect(
+          validateDepositMessage({
+            recipient: RECIPIENT_ADDRESS,
+            destinationChainId: SVM_CHAIN_ID,
+            relayer: RELAYER_ADDRESS,
+            outputTokenAddress: TOKEN_ADDRESS,
+            amountInput: BigNumber.from(1000000),
+            message,
+          })
+        ).rejects.toThrow(
+          "Recipient must be a contract when a message is provided"
+        );
+      });
+
+      it("should accept message with larger value_amount", async () => {
+        // Create a message with a larger value_amount
+        const valueAmount = 1000000000n; // 1 SOL in lamports
+        const handlerMessage = new Uint8Array(4).fill(0);
+        const accounts = [RECIPIENT_ADDRESS];
+
+        const message = createEncodedMessage(
+          HANDLER_ADDRESS,
+          0,
+          valueAmount,
+          accounts,
+          handlerMessage
+        );
+
+        console.log("Message with 1 SOL value_amount:", message);
+
+        mockIsContractCacheGet.mockResolvedValue(false);
+
+        await expect(
+          validateDepositMessage({
+            recipient: RECIPIENT_ADDRESS,
+            destinationChainId: SVM_CHAIN_ID,
+            relayer: RELAYER_ADDRESS,
+            outputTokenAddress: TOKEN_ADDRESS,
+            amountInput: BigNumber.from(1000000),
+            message,
+          })
+        ).resolves.not.toThrow();
+      });
+    });
+
+    describe("Message validation", () => {
+      it("should reject non-hex string messages", async () => {
+        const message = "not a hex string";
+
+        await expect(
+          validateDepositMessage({
+            recipient: RECIPIENT_ADDRESS,
+            destinationChainId: SVM_CHAIN_ID,
+            relayer: RELAYER_ADDRESS,
+            outputTokenAddress: TOKEN_ADDRESS,
+            amountInput: BigNumber.from(1000000),
+            message,
+          })
+        ).rejects.toThrow("Message must be a hex string");
+      });
+
+      it("should reject odd-length hex strings", async () => {
+        const message = "0x123"; // Odd length
+
+        await expect(
+          validateDepositMessage({
+            recipient: RECIPIENT_ADDRESS,
+            destinationChainId: SVM_CHAIN_ID,
+            relayer: RELAYER_ADDRESS,
+            outputTokenAddress: TOKEN_ADDRESS,
+            amountInput: BigNumber.from(1000000),
+            message,
+          })
+        ).rejects.toThrow("Message must be an even hex string");
+      });
+
+      it("should accept empty messages", async () => {
+        const message = "0x";
+
+        await expect(
+          validateDepositMessage({
+            recipient: RECIPIENT_ADDRESS,
+            destinationChainId: SVM_CHAIN_ID,
+            relayer: RELAYER_ADDRESS,
+            outputTokenAddress: TOKEN_ADDRESS,
+            amountInput: BigNumber.from(1000000),
+            message,
+          })
+        ).resolves.not.toThrow();
+      });
+    });
+  });
+});


### PR DESCRIPTION
This adds a message validation relaxation for gas forwarding on Solana. 

[Here](https://app-frontend-v3-git-relax-recipient-contract-validat-09ba49-uma.vercel.app/api/suggested-fees?inputToken=0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48&outputToken=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v&destinationChainId=34268394551451&originChainId=1&recipient=GsiZqCTNRi4T3qZrixFdmhXVeA4CSUzS7c44EQ7Rw1Tw&amount=5000000&skipAmountLimit=true&allowUnmatchedDecimals=true&message=0xf649e2e88bc196def17b24eded08b15d76c77b50dc8973959f4705c4a1ee488900404b4c000000000001000000db6023a53f2cb1f57fc7a95176ad12f2080bc51f4bbb0e1aeeb722d53d779d850400000000000000) is an example request for USDC Mainnet -> Solana with an encoded gas forwarding message on Solana. 