### PR TITLE
feat(e2e-api): Add axios instance to fix open handles

### DIFF
--- a/e2e-api/swap/fetch-approval.test.ts
+++ b/e2e-api/swap/fetch-approval.test.ts
@@ -1,8 +1,7 @@
-import axios from "axios";
 import { BigNumber, ethers } from "ethers";
 import { CHAIN_IDs, TOKEN_SYMBOLS_MAP } from "@across-protocol/constants";
 
-import { e2eConfig } from "../utils/config";
+import { e2eConfig, axiosInstance } from "../utils/config";
 
 const SWAP_API_BASE_URL = e2eConfig.swapApiBaseUrl;
 const SWAP_API_URL = `${SWAP_API_BASE_URL}/api/swap/approval`;
@@ -95,7 +94,7 @@ describe("GET /swap/approval", () => {
       } (${testCase.originChainId}) -> ${
         testCase.outputToken.symbol
       } (${testCase.destinationChainId})`, async () => {
-        const response = await axios.get(SWAP_API_URL, {
+        const response = await axiosInstance.get(SWAP_API_URL, {
           params: {
             amount: testCase.amount,
             tradeType,
@@ -117,7 +116,7 @@ describe("GET /swap/approval", () => {
   describe("Error handling", () => {
     it("should throw 400 for invalid parameters", async () => {
       try {
-        await axios.get(SWAP_API_URL, {
+        await axiosInstance.get(SWAP_API_URL, {
           params: {
             amount: "invalid",
             tradeType: "exactInput",

--- a/e2e-api/utils/config.ts
+++ b/e2e-api/utils/config.ts
@@ -2,8 +2,16 @@ import dotenv from "dotenv";
 import * as sdk from "@across-protocol/sdk";
 import { createMemoryClient, http, PREFUNDED_ACCOUNTS } from "tevm";
 import { optimism, base } from "tevm/common";
+import axios from "axios";
+import http from "http";
+import https from "https";
 
 dotenv.config({ path: [".env.e2e", ".env.local", ".env"] });
+
+export const axiosInstance = axios.create({
+  httpAgent: new http.Agent({ keepAlive: false }),
+  httpsAgent: new https.Agent({ keepAlive: false }),
+});
 
 export type SignerRole = "depositor" | "relayer";
 

--- a/jest.api.config.cjs
+++ b/jest.api.config.cjs
@@ -4,6 +4,7 @@ module.exports = {
   setupFiles: ["<rootDir>/setup.jest.ts"],
   preset: "ts-jest",
   testEnvironment: "node",
+  detectOpenHandles: true,
   moduleDirectories: ["node_modules", "<rootDir>"],
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
   transform: {


### PR DESCRIPTION
This PR addresses an issue where E2E API tests would hang and fail to exit gracefully, leading to a `TLSWRAP` open handle error in Jest. This was caused by `axios` keeping TCP connections alive after the tests had completed.

### The Fix

1.  **Enabled Open Handle Detection:** The `detectOpenHandles: true` option has been added to `jest.api.config.cjs`. This will help in diagnosing similar issues in the future by providing detailed information about any open handles that are preventing Jest from exiting.

2.  **Created a Custom Axios Instance:** A new, shared `axios` instance (`axiosInstance`) has been created in `e2e-api/utils/config.ts`. This instance is configured with `keepAlive: false` for both HTTP and HTTPS agents.

3.  **Updated Tests:** The `e2e-api/swap/fetch-approval.test.ts` file has been updated to use the new `axiosInstance` for all API requests.

### Why it Works

By default, `axios` uses the Node.js `http` and `https` agents with `keepAlive` enabled. This is a performance optimisation that keeps TCP connections open for reuse in subsequent requests. However, in a test environment, this can cause problems as the open connections prevent the Node.js event loop from emptying, which in turn prevents Jest from exiting.

By creating a custom `axios` instance with `keepAlive: false`, we ensure that a new TCP connection is established for each request and that it is closed immediately after the response is received. This allows the test process to terminate cleanly without any lingering open handles.