### PR TITLE
feat: add token spans

### DIFF
--- a/api/_utils.ts
+++ b/api/_utils.ts
@@ -2624,7 +2624,7 @@ export function getLimitsSpanAttributes(
   inputToken: Token,
   tokenPriceUsd: number
 ) {
-  const attributes: Record<string, number> = {};
+  const attributes: Record<string, number | string> = {};
 
   for (const [key, value] of Object.entries(limits)) {
     const valueBn = BigNumber.from(value);
@@ -2639,11 +2639,14 @@ export function getLimitsSpanAttributes(
       ethers.utils.formatUnits(valueUsd, 18)
     );
   }
+  attributes["token.address"] = inputToken.address;
+  attributes["token.chainId"] = inputToken.chainId;
+  attributes["token.symbol"] = inputToken.symbol;
   return attributes;
 }
 
 export function setLimitsSpanAttributes(
-  limits: Record<string, number>,
+  limits: Record<string, number | string>,
   span: Span
 ) {
   for (const [key, value] of Object.entries(limits)) {


### PR DESCRIPTION
Adds token-specific info to the spans for the `suggested-fees` endpoint. 
These spans are necessary so we can group the USD value by the token address and chain Id in Datadog.